### PR TITLE
Add specific install instructions for Ubuntu 16.04.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ sudo apt-get install qt5-default qtdeclarative5-dev libqt5qml-quickcontrols \
                      libglpk-dev git build-essential cmake
 ```
 
+Ubuntu 16.04:
+```bash
+sudo apt install qt5-default qtdeclarative5-dev \
+                 qml-module-qtquick-controls qml-module-qtquick-dialogs \
+                 qtbase5-private-dev pkg-config \
+                 libglpk-dev git build-essential cmake
+```
+
 Fedora 20:
 ```bash
 sudo yum install qt5-qtdeclarative-devel qt5-qtquickcontrols glpk-devel


### PR DESCRIPTION
The Ubuntu 14.04 instructions doesn't works on 16.04 because libqt5qml-quickcontrols
doesn't exists.