### PR TITLE
Update README to reflect current qt dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ Fedora 20:
 sudo yum install qt5-qtdeclarative-devel qt5-qtquickcontrols glpk-devel
 ```
 
+```
+
+Fedora 23:
+```bash
+sudo dnf install qt5-qtdeclarative-devel qt5-qtquickcontrols qt5-qtgraphicaleffects glpk-devel
+```
+
+```
+
 After that clone the repository onto disk and use cargo to build
 everything.
 


### PR DESCRIPTION
I am on a fresh fedora VM -- I found that although panopticon built with the specified dependencies, Qt borked on `cargo run` without this additional dependency.