### PR TITLE
use old style target spec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,14 @@ git = "https://github.com/flanfly/qmlrs"
 [dependencies.graph_algos]
 git = "https://github.com/flanfly/rust-graph-algos.git"
 
-[target.'cfg(unix)'.dependencies]
+[target.i686-unknown-linux-gnu.dependencies]
+xdg = "^2.0"
+
+[target.x86_64-unknown-linux-gnu.dependencies]
+xdg = "^2.0"
+
+[target.x86_64-apple-darwin.dependencies]
+xdg = "^2.0"
+
+[target.i686-apple-darwin.dependencies]
 xdg = "^2.0"


### PR DESCRIPTION
Ubuntu 16.04 is at 1.7.0 and it's not likely to change. The only reason we need 1.8.0 is because of the `cfg` syntax added with cargo 0.9.

This PR replaces this with the (rather verbose) alternative of spelling out all target triples that are considered *nix.

See #153 