### PR TITLE
Wrong twitter handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,4 +81,4 @@ Contact
 =======
 
 IRC: #panopticon on Freenode.
-Twitter: @_cibo_
+Twitter: ```@_cibo_```


### PR DESCRIPTION
Your twitter handle has preceding and following underscores which Markdown interprets. The effect is: @cibo instead of ```@_cibo_```

Kind regards,