### PR TITLE
fix wrong precedence bug

### DIFF
--- a/lib/src/abstractinterp.rs
+++ b/lib/src/abstractinterp.rs
@@ -541,7 +541,7 @@ impl Avalue for Kset {
             &Kset::Meet => Kset::Meet,
             &Kset::Set(ref v) =>
                 Kset::Set(v.iter().map(|&(v,sz)| {
-                    ((v >> offset) % 1 << (size - 1),size)
+                    ((v >> offset) % (1 << (size - 1)),size)
                 }).collect::<Vec<_>>()),
         }
     }


### PR DESCRIPTION
I've got little time, but I ran clippy over panopticon and I'd like to fix this one thing for now – `%` binds stronger than `<<`, so you have `((v >> offset) % 1)` which is zero in all cases and shift that left by `size - 1` which doesn't do anything.

Clippy suggested a lot more improvements, so expect another PR in the future.  