### PR TITLE
initial prototype sample usage for goblin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ dependencies = [
  "chrono 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono-humanize 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "goblin 0.0.1 (git+https://github.com/m4b/goblin)",
  "graph_algos 0.10.2 (git+https://github.com/flanfly/rust-graph-algos.git)",
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -78,6 +79,14 @@ dependencies = [
 name = "gcc"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "goblin"
+version = "0.0.1"
+source = "git+https://github.com/m4b/goblin#7d6f51ca4b1593847702107170e9338ad6ebdc92"
+dependencies = [
+ "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "graph_algos"
@@ -273,3 +282,39 @@ name = "xdg"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[metadata]
+"checksum bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9bf6104718e80d7b26a68fdbacff3481cfc05df670821affc7e9cbc1884400c"
+"checksum bit-vec 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5b97c2c8e8bbb4251754f559df8af22fb264853c7d009084a576cdf12565089d"
+"checksum byteorder 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "29b2aa490a8f546381308d68fc79e6bd753cd3ad839f7a7172897f1feedfa175"
+"checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
+"checksum cassowary 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "934c4515ec7266e7f1c0206d9e1f9efb92b321cc180073c4ad4ad7691fe524e6"
+"checksum chrono 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)" = "a714b6792cb4bb07643c35d2a051d92988d4e296322a60825549dd0764bcd396"
+"checksum chrono-humanize 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92afb1436280b0e4ed573c747ad30a1469cd945c201265b4d01e72cfa598da4f"
+"checksum flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "3eeb481e957304178d2e782f2da1257f1434dfecbae883bafb61ada2a9fea3bb"
+"checksum gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)" = "3da3a2cbaeb01363c8e3704fd9fd0eb2ceb17c6f27abd4c1ef040fb57d20dc79"
+"checksum goblin 0.0.1 (git+https://github.com/m4b/goblin)" = "<none>"
+"checksum graph_algos 0.10.2 (git+https://github.com/flanfly/rust-graph-algos.git)" = "<none>"
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
+"checksum libc 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "97def9dc7ce1d8e153e693e3a33020bc69972181adb2f871e87e888876feae49"
+"checksum log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ab83497bf8bf4ed2a74259c1c802351fcd67a65baa86394b6ba73c36f4838054"
+"checksum miniz-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d1f4d337a01c32e1f2122510fed46393d53ca35a7f429cb0450abaedfa3ed54"
+"checksum num 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "c04bd954dbf96f76bab6e5bd6cef6f1ce1262d15268ce4f926d2b5b778fa7af2"
+"checksum num-bigint 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "41655c8d667be847a0b72fe0888857a7b3f052f691cf40852be5fcf87b274a65"
+"checksum num-complex 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "ccac67baf893ac97474f8d70eff7761dabb1f6c66e71f8f1c67a6859218db810"
+"checksum num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "fb24d9bfb3f222010df27995441ded1e954f8f69cd35021f6bef02ca9552fb92"
+"checksum num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "287a1c9969a847055e1122ec0ea7a5c5d6f72aad97934e131c83d5c08ab4e45c"
+"checksum num-rational 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "48cdcc9ff4ae2a8296805ac15af88b3d88ce62128ded0cb74ffb63a587502a84"
+"checksum num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "51eab148f171aefad295f8cece636fc488b9b392ef544da31ea4b8ef6b9e9c39"
+"checksum pkg-config 0.3.8 (git+https://github.com/alexcrichton/pkg-config-rs)" = "<none>"
+"checksum qmlrs 0.2.1 (git+https://github.com/flanfly/qmlrs)" = "<none>"
+"checksum rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2791d88c6defac799c3f20d74f094ca33b9332612d9aef9078519c82e4fe04a5"
+"checksum rmp 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d627734813936c08e50ba10cfc30dd9c68b02b00a10843cc748272a5dcc970d9"
+"checksum rmp-serialize 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29b83c3c7aad4c9a8273f7aa108aeedf50f88b5330ac3b99cf5f40ba2bb323fa"
+"checksum rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "6159e4e6e559c81bd706afe9c8fd68f547d3e851ce12e76b1de7914bab61691b"
+"checksum tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0b62933a3f96cd559700662c34f8bab881d9e3540289fb4f368419c7f13a5aa9"
+"checksum time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "3c7ec6d62a20df54e07ab3b78b9a3932972f4b7981de295563686849eb3989af"
+"checksum uuid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a5efe91619a89528042b9b513ee41dc1ed06b35dc77b1e7a945a1caf580b863"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+"checksum xdg 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "77b831a5ba77110f438f0ac5583aafeb087f70432998ba6b7dcb1d32185db453"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ byteorder = "0.5.1"
 chrono = "0.2"
 chrono-humanize = "0.0.6"
 
+[dependencies.goblin]
+git = "https://github.com/m4b/goblin"
+
 [dependencies.qmlrs]
 git = "https://github.com/flanfly/qmlrs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,7 @@ rmp-serialize = "0.7.0"
 byteorder = "0.5.1"
 chrono = "0.2"
 chrono-humanize = "0.0.6"
-
-[dependencies.goblin]
-git = "https://github.com/m4b/goblin"
+goblin = "0.0.2"
 
 [dependencies.qmlrs]
 git = "https://github.com/flanfly/qmlrs"

--- a/lib/src/elf/load.rs
+++ b/lib/src/elf/load.rs
@@ -16,12 +16,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+extern crate goblin;
+
 use std::io::{Seek,SeekFrom,Read};
 use std::fs::File;
 use std::path::Path;
 
 use graph_algos::MutableGraphTrait;
 use uuid::Uuid;
+use goblin::elf::Binary;
 
 use {
     Program,
@@ -35,53 +38,32 @@ use {
 };
 use elf::{
     Machine,
-    Ehdr,
-    Type,
-    SegmentType,
 };
 
 pub fn load(p: &Path) -> Result<(Project,Machine)> {
+    let mut entry = 0x0;
+    let mut interp = None;
     let mut fd = File::open(p).ok().unwrap();
-    let ehdr = try!(Ehdr::read(&mut fd));
     let mut reg = Region::undefined("base".to_string(), 0x1000000000000);
-
-    match ehdr.file_type {
-        Type::Core | Type::Executable | Type::Shared => {
-            for ph in ehdr.progam_headers.iter() {
-                match ph.seg_type {
-                    SegmentType::Load => {
-                        println!("load segment of {} bytes from {:x} to {:x}",ph.filesz,ph.offset,ph.vaddr);
-                        if fd.seek(SeekFrom::Start(ph.offset)).ok() == Some(ph.offset) {
-                            let mut buf = vec![0u8; ph.filesz as usize];
-                            if let Err(_) = fd.read(&mut buf) {
-                                return Err("Failed to read segment".into());
-                            }
-
-                            reg.cover(Bound::new(ph.vaddr,ph.vaddr + ph.filesz),Layer::wrap(buf));
-                        } else {
-                            return Err("Failed to read segment".into());
-                        }
-                    },
-                    SegmentType::Interp => {
-                        if fd.seek(SeekFrom::Start(ph.offset)).ok() == Some(ph.offset) {
-                            let mut interp = vec![0u8; ph.filesz as usize];
-                            if let Err(_) = fd.read(&mut interp) {
-                                return Err("Failed to read interpreter path".into());
-                            }
-
-                            match String::from_utf8(interp) {
-                                Ok(s) => println!("load interpreter {}",s),
-                                Err(_) => println!("load intepreter (encoding error)"),
-                            }
-                        } else {
-                            return Err("Failed to read interpreter path".into());
-                        }
-                    },
-                    _ => {},
+    match goblin::elf::from_fd(&mut fd) {
+        Ok(Binary::Elf64(elf)) => {
+            entry = elf.entry;
+            interp = elf.interpreter;
+            println!("Soname: {:?} with interpreter: {:?}", elf.soname, interp);
+            for ph in elf.program_headers {
+                let mut buf = vec![0u8; ph.p_filesz as usize];
+                if fd.seek(SeekFrom::Start(ph.p_offset)).ok() == Some(ph.p_offset) {
+                    reg.cover(Bound::new(ph.p_vaddr, ph.p_vaddr + ph.p_filesz), Layer::wrap(buf));
+                }
+                else {
+                    return Err("Failed to read segment".into())
                 }
             }
         },
-        _ => {}
+        Ok(Binary::Elf32(_elf)) => {
+            unimplemented!();
+        },
+        _ => {} // error out here
     }
 
     let name = p.file_name()
@@ -91,9 +73,13 @@ pub fn load(p: &Path) -> Result<(Project,Machine)> {
     let mut prog = Program::new("prog0");
     let mut proj = Project::new(name.clone(),reg);
 
-    prog.call_graph.add_vertex(CallTarget::Todo(Rvalue::new_u64(ehdr.entry),Some(name),Uuid::new_v4()));
-    proj.comments.insert(("base".to_string(),ehdr.entry),"main".to_string());
+    prog.call_graph.add_vertex(CallTarget::Todo(Rvalue::new_u64(entry as u64),Some(name),Uuid::new_v4()));
+    proj.comments.insert(("base".to_string(),entry as u64),"main".to_string());
     proj.code.push(prog);
 
-    Ok((proj,ehdr.machine))
+    // TODO: add proper ELF machine -> Enum translation here
+    // my guess is you'll want to pull out the Machine::* value
+    // from the appropriate ELF datastructure and add it to generic project data
+    // since machine type is independent of binary format and could be used for mach, pe, etc.
+    Ok((proj,Machine::X86_64))
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -118,6 +118,8 @@ extern crate tempdir;
 extern crate uuid;
 extern crate rmp_serialize;
 
+extern crate goblin;
+
 #[macro_use]
 extern crate lazy_static;
 


### PR DESCRIPTION
I wouldn't merge this as is necessarily, just sample PR showing how goblin could be used.

There's several different routes to take to reduce the ELF64/ELF32 boilerplate.  A simple way would be to convert ELF32s -> ELF64, which would just take the u32s -> u64, and then the tool would deal with just ELF64 binaries.  This is probably an all around bad idea, but would be the simplest.

Or macros to pun on the field names which are the same (which is probably the approach I'll end up taking for all of the impure `from_fd` stuff in the lib itself)

Note, ELF32 doesn't have `from_fd` methods implemented yet, and I'm not sure if I'll have time to write them right now (though it really just is copy/pasting or better, just writing macros like I said above).

Anyway, PR just a suggestion on way to go about it/demonstrate simple usage.  Also the API for `goblin::elf` isn't quite finalized (but hoping to do so soon for a 1.0 release, still need to think about some things/work on things, etc.), so be aware that I might break upstream every now and then.

Nevertheless, the `goblin::elf::Binary::Elf64` object is pretty complete for most needs I think, and will be basically exactly the same for Elf32.

But yea, this is how you might start to use it, if you're interested :P