### PR TITLE
goblin 0.0.5 with unified binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,16 @@ matrix:
   include:
     # CI targets
     - os: osx
-      rust: 1.10.0
+      rust: 1.12.0
       env: TARGET=x86_64-apple-darwin
     - os: linux
       dist: trusty
-      rust: 1.10.0
+      rust: 1.12.0
       env: TARGET=x86_64-unknown-linux-gnu
     # rustdoc
     - os: linux
       dist: trusty
-      rust: 1.10.0
+      rust: 1.12.0
       env:
         - TARGET=x86_64-unknown-linux-gnu
         - PACKAGE=doc
@@ -20,7 +20,7 @@ matrix:
     # nightly builds
     - os: linux
       dist: trusty
-      rust: 1.10.0
+      rust: 1.12.0
       env:
         - TARGET=x86_64-unknown-linux-gnu
         - PACKAGE=ubuntu
@@ -30,7 +30,7 @@ matrix:
           - master
     - os: linux
       dist: trusty
-      rust: 1.10.0
+      rust: 1.12.0
       env:
         - TARGET=x86_64-unknown-linux-gnu
         - PACKAGE=debian
@@ -39,7 +39,7 @@ matrix:
         only:
           - master
     - os: osx
-      rust: 1.10.0
+      rust: 1.12.0
       env:
         - TARGET=x86_64-apple-darwin
         - PACKAGE=osx

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ dependencies = [
  "chrono-humanize 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "goblin 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "goblin 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph_algos 0.10.2 (git+https://github.com/flanfly/rust-graph-algos.git)",
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -100,7 +100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "goblin"
-version = "0.0.4"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -359,7 +359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "3eeb481e957304178d2e782f2da1257f1434dfecbae883bafb61ada2a9fea3bb"
 "checksum gcc 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)" = "41337e9dc80ebadf36b4f252bf7440f61bcf34f99caa170e50dcd0f9a0cdb5d8"
-"checksum goblin 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "196a8fcf12cb1a74acdfbb15dd096899278b53f1e385abb78cf0fcd49b1046b6"
+"checksum goblin 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c930d9f8abb2e85d2824c6fb849718967ba921602d444947f5d63d9d21d27d3"
 "checksum graph_algos 0.10.2 (git+https://github.com/flanfly/rust-graph-algos.git)" = "<none>"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ dependencies = [
  "chrono-humanize 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "goblin 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "goblin 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph_algos 0.10.2 (git+https://github.com/flanfly/rust-graph-algos.git)",
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -100,7 +100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "goblin"
-version = "0.0.2"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -359,7 +359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "3eeb481e957304178d2e782f2da1257f1434dfecbae883bafb61ada2a9fea3bb"
 "checksum gcc 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)" = "41337e9dc80ebadf36b4f252bf7440f61bcf34f99caa170e50dcd0f9a0cdb5d8"
-"checksum goblin 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "836737747be93a839b487c56f9b081972f46e4716e44a1efdec9c23ca2fafbc0"
+"checksum goblin 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "196a8fcf12cb1a74acdfbb15dd096899278b53f1e385abb78cf0fcd49b1046b6"
 "checksum graph_algos 0.10.2 (git+https://github.com/flanfly/rust-graph-algos.git)" = "<none>"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rmp-serialize = "0.7.0"
 byteorder = "0.5.1"
 chrono = "0.2"
 chrono-humanize = "0.0.6"
-goblin = "0.0.3"
+goblin = "0.0.4"
 
 [dependencies.qmlrs]
 git = "https://github.com/flanfly/qmlrs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rmp-serialize = "0.7.0"
 byteorder = "0.5.1"
 chrono = "0.2"
 chrono-humanize = "0.0.6"
-goblin = "0.0.4"
+goblin = "0.0.5"
 
 [dependencies.qmlrs]
 git = "https://github.com/flanfly/qmlrs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rmp-serialize = "0.7.0"
 byteorder = "0.5.1"
 chrono = "0.2"
 chrono-humanize = "0.0.6"
-goblin = "0.0.2"
+goblin = "0.0.3"
 
 [dependencies.qmlrs]
 git = "https://github.com/flanfly/qmlrs"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,9 @@ environment:
   RUST_INSTALL_DIR: C:\Rust
   matrix:
     - RUST_INSTALL_TRIPLE: x86_64-pc-windows-msvc
-      RUST_VERSION: 1.10.0
+      RUST_VERSION: 1.12.0
     - RUST_INSTALL_TRIPLE: x86_64-pc-windows-msvc
-      RUST_VERSION: 1.10.0
+      RUST_VERSION: 1.12.0
       PACKAGE: win
       FTP_PASSWD:
         secure: DBE4nt5J/zQUXTGe8QTOJg==

--- a/qt/src/function.rs
+++ b/qt/src/function.rs
@@ -59,6 +59,7 @@ use controller::{
 };
 
 use sugiyama;
+use goblin;
 
 #[derive(RustcEncodable)]
 struct Metainfo {
@@ -513,11 +514,12 @@ pub fn file_details(arg: &Variant) -> Variant {
             } else {
                 let ro = meta.permissions().readonly();
 
-                if let Ok(id) = elf::Ident::read(&mut fd) {
+                if let Ok((class, is_lsb)) = goblin::elf::header::peek(&mut fd) {
+                    let endianness = if is_lsb { "LittleEndian" } else { "BigEndian" };
                     Ok(FileDetails{
                         state: if ro { "readable" } else { "writable" }.to_string(),
                         format: Some("elf".to_string()),
-                        info: vec![format!("{:?}, {:?}",id.class,id.data)],
+                        info: vec![format!("{:?}, {:?}",goblin::elf::header::class_to_str(class),endianness)],
                     })
                 } else {
                     let mut buf = [0u8;2];

--- a/qt/src/main.rs
+++ b/qt/src/main.rs
@@ -31,6 +31,7 @@ extern crate tempdir;
 extern crate byteorder;
 extern crate chrono;
 extern crate chrono_humanize;
+extern crate goblin;
 
 #[cfg(unix)]
 extern crate xdg;

--- a/qt/src/project.rs
+++ b/qt/src/project.rs
@@ -158,7 +158,7 @@ pub fn create_elf_project(_path: &Variant) -> Variant {
 
                 return_json(Controller::replace(proj,None))
             },
-            Err(_) => return_json::<()>(Err("Failed to read ELF file".into())),
+            Err(err) => return_json::<()>(Err(format!("Failed to read ELF file: {:?}", err).into())),
         }
     } else {
         return_json::<()>(Err("1st argument is not a string".into()))


### PR DESCRIPTION
* unified 32/64 binary parser, with single struct/API courtesy of goblin 0.0.5
* removes unused code, etc.
* fixes the Qt directory display for elf binaries
* loads the non-import function information, if any, from the dynamic symbols, and adds them to call graph with their respective function names
* other minor fixes

The ELF machine stuff can also probably be transferred out of the `elf.rs` module, or even used from goblin, but that's a matter of preference/future refactor.

Feel free to squash the commits, etc.  Also I made this really fast so could get you the unified binary api asap; I still think there's a lot to be done in the post ELF parsing phase for obtaining call-graph information, etc., but don't have the time just as yet, as I'll need to play around with it.

I think there's also some room for some other refactors, but again, no time for it right now.

Another PR soon!