### PR TITLE
rust 1.10.0 is not supported anymore, use 1.12.0 instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you simply want to use Panopticon follow the
 
 ## Building
 Panopticon builds with Rust stable. The only dependencies aside from
-a working Rust 1.12.0 toolchain and Cargo you need is Qt 5.4 or higher.
+a working Rust 1.13.0 toolchain and Cargo you need is Qt 5.4 or higher.
 
 **Ubuntu 15.10 and 16.04**
 ```bash
@@ -55,7 +55,7 @@ cargo build --release
 **Windows**
 
 Install the [Qt 5.4 SDK](http://download.qt.io/official_releases/online_installers/qt-unified-windows-x86-online.exe),
-the [Rust toolchain](https://static.rust-lang.org/dist/rust-1.12.0-x86_64-pc-windows-gnu.msi)
+the [Rust toolchain](https://static.rust-lang.org/dist/rust-1.13.0-x86_64-pc-windows-gnu.msi)
 and [CMake](https://cmake.org/files/v3.6/cmake-3.6.1-win64-x64.msi).
 Panopticon can be build using ``cargo build --release``.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you simply want to use Panopticon follow the
 
 ## Building
 Panopticon builds with Rust stable. The only dependencies aside from
-a working Rust 1.10.0 toolchain and Cargo you need is Qt 5.4 or higher.
+a working Rust 1.12.0 toolchain and Cargo you need is Qt 5.4 or higher.
 
 **Ubuntu 15.10 and 16.04**
 ```bash
@@ -55,7 +55,7 @@ cargo build --release
 **Windows**
 
 Install the [Qt 5.4 SDK](http://download.qt.io/official_releases/online_installers/qt-unified-windows-x86-online.exe),
-the [Rust toolchain](https://static.rust-lang.org/dist/rust-1.10.0-x86_64-pc-windows-gnu.msi)
+the [Rust toolchain](https://static.rust-lang.org/dist/rust-1.12.0-x86_64-pc-windows-gnu.msi)
 and [CMake](https://cmake.org/files/v3.6/cmake-3.6.1-win64-x64.msi).
 Panopticon can be build using ``cargo build --release``.
 


### PR DESCRIPTION
Error with rust 1.11.0

https://hub.docker.com/r/think/panopticon/builds/bnmmevcpnsbzrbmhqjjbp6v/
```
/root/.cargo/registry/src/github.com-1ecc6299db9ec823/goblin-0.0.5/src/elf/mod.rs:261         pub header: Header,
                                                                                                          ^~~~~~
/root/.cargo/registry/src/github.com-1ecc6299db9ec823/goblin-0.0.5/src/elf/mod.rs:261:21: 261:27 help: run `rustc --explain E0446` to see a detailed explanation
Could not compile `goblin`.
```