### PR TITLE
print symbolic targets correctly for amd64

### DIFF
--- a/lib/src/amd64/mod.rs
+++ b/lib/src/amd64/mod.rs
@@ -2294,10 +2294,19 @@ pub fn read(mode: Mode, buf: &[u8], addr: u64) -> Result<(u64,Mnemonic,Vec<(Rval
                 };
                 stmts.append(&mut op_stmts);
 
+                let fmt =
+                    match s {
+                        "call" => "{c:text}",
+                        "jmp" => "{c:text}",
+                        "je" => "{c:text}",
+                        "jne" => "{c:text}",
+                        _ => "{u}",
+                    };
+
                 let len = tail.fd.position() + i as u64 + 1;
                 let mne = try!(match ops.len() {
                     0 => Mnemonic::new((addr..addr+len),format!("{}",s),"".to_string(),ops.iter(),stmts.iter()),
-                    1 => Mnemonic::new((addr..addr+len),format!("{}",s),"{u}".to_string(),ops.iter(),stmts.iter()),
+                    1 => Mnemonic::new((addr..addr+len),format!("{}",s),fmt.to_string(),ops.iter(),stmts.iter()),
                     2 => Mnemonic::new((addr..addr+len),format!("{}",s),"{u}, {u}".to_string(),ops.iter(),stmts.iter()),
                     3 => Mnemonic::new((addr..addr+len),format!("{}",s),"{u}, {u}, {u}".to_string(),ops.iter(),stmts.iter()),
                     4 => Mnemonic::new((addr..addr+len),format!("{}",s),"{u}, {u}, {u}, {u}".to_string(),ops.iter(),stmts.iter()),


### PR DESCRIPTION
Currently, qt disassembly printing for call/jmp targets doesn't work as intended, and prints the address instead of the function name (if found and available), because the call target operand is always set to constant instead of pointer in the `MnemonicFormatToken`.

E.g., it now will correctly print the `memcpy` call target:

![screenshot from 2017-02-11 21-02-29](https://cloud.githubusercontent.com/assets/1920204/22859726/7cb5813c-f09b-11e6-9b16-04e3bba90f6b.png)

This is a a hack to solve the problem for a couple of common x86 instructions, but:

1. I don't know if this is the right approach
2. I don't know if the `:text` format is correct
3. I feel like there has to be a better way than pattern matching on the instruction name?

I don't necessarily recommend merging this, but feedback on correct and robust solution in `amd64/mod.rs` is probably better, and then can update from there.