### PR TITLE
fix numerous warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+env:
+  global:
+    - RUSTFLAGS="-D warnings"
 matrix:
   fast_finish: true
   include:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ platform:
   - x64
 environment:
   RUST_INSTALL_DIR: C:\Rust
+  RUSTFLAGS: "-D warnings"
   matrix:
     - RUST_INSTALL_TRIPLE: x86_64-pc-windows-msvc
       RUST_VERSION: stable

--- a/lib/src/abstractinterp/bounded_addr_track.rs
+++ b/lib/src/abstractinterp/bounded_addr_track.rs
@@ -31,7 +31,6 @@
 //! operation would return join, the version is increased by one and `<register>,<version + 1> + 0`
 //! is returned instead. This delays reaching join and helps to get past edge cases like
 //! `and rsp, 0xffff0000`.
-#![allow(missing_docs)]
 
 use std::borrow::Cow;
 

--- a/lib/src/abstractinterp/bounded_addr_track.rs
+++ b/lib/src/abstractinterp/bounded_addr_track.rs
@@ -407,8 +407,7 @@ impl Avalue for BoundedAddrTrack {
 mod tests {
     use super::*;
     use lift;
-    use quickcheck::{Arbitrary,Gen,TestResult,Testable};
-    use quickcheck::QuickCheck;
+    use quickcheck::{Arbitrary,Gen,TestResult};
 
     impl Arbitrary for BoundedAddrTrack {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {

--- a/lib/src/abstractinterp/bounded_addr_track.rs
+++ b/lib/src/abstractinterp/bounded_addr_track.rs
@@ -52,9 +52,24 @@ pub const VERSION_LIMIT: usize = 10;
 /// represented by None.
 #[derive(Debug,PartialEq,Eq,Clone,Hash,RustcDecodable,RustcEncodable)]
 pub enum BoundedAddrTrack {
+    /// Lattice top
     Join,
-    Region{ region: Option<(Cow<'static,str>,usize)> },
-    Offset{ region: Option<(Cow<'static,str>,usize)>, offset: u64, offset_size: usize },
+    /// Pointer pointing somewhere into `region`
+    Region{
+        /// Name of pointed to region and pointer version. None stands for the global region.
+        region: Option<(Cow<'static,str>,usize)>
+    },
+    /// Pointer pointing to `offset` inside `region`. `offset_size` is the size of the **pointer**
+    /// in bits.
+    Offset{
+        /// Name of pointed to region and pointer version. None stands for the global region.
+        region: Option<(Cow<'static,str>,usize)>,
+        /// Offset into region.
+        offset: u64,
+        /// Size of the pointer in bits. Not the value pointed to.
+        offset_size: usize
+    },
+    /// Lattice bottom
     Meet,
 }
 

--- a/lib/src/abstractinterp/kset.rs
+++ b/lib/src/abstractinterp/kset.rs
@@ -278,7 +278,7 @@ mod tests {
         ControlFlowTarget,Function,ControlFlowGraph,
         Guard,
         Lvalue,Rvalue,
-        Bound,Mnemonic,
+        Mnemonic,
         ssa_convertion,
         BasicBlock,
         approximate,
@@ -368,7 +368,7 @@ mod tests {
         func.cflow_graph = cfg;
         func.entry_point = Some(v0);
 
-        ssa_convertion(&mut func);
+        assert!(ssa_convertion(&mut func).is_ok());
 
         let vals = approximate::<Kset>(&func).ok().unwrap();
         let res = results::<Kset>(&func,&vals);
@@ -412,7 +412,7 @@ mod tests {
         func.cflow_graph = cfg;
         func.entry_point = Some(v0);
 
-        ssa_convertion(&mut func);
+        assert!(ssa_convertion(&mut func).is_ok());
 
         let vals = approximate::<Kset>(&func).ok().unwrap();
 

--- a/lib/src/abstractinterp/kset.rs
+++ b/lib/src/abstractinterp/kset.rs
@@ -20,10 +20,8 @@
 //!
 //! TODO
 
-use std::borrow::Cow;
-use std::collections::{HashSet,HashMap};
+use std::collections::{HashSet};
 use std::iter::FromIterator;
-use std::ops::Range;
 
 use {
     Rvalue,
@@ -32,7 +30,6 @@ use {
     ProgramPoint,
     Operation,
     execute,
-    Region,
 };
 
 /// Largest Kset cardinality before Join.

--- a/lib/src/abstractinterp/mod.rs
+++ b/lib/src/abstractinterp/mod.rs
@@ -54,7 +54,7 @@ use graph_algos::order::{
 
 use {
     Lvalue,Rvalue,
-    Statement,Operation,execute,
+    Statement,Operation,
     ControlFlowTarget,
     ControlFlowRef,
     ControlFlowGraph,

--- a/lib/src/abstractinterp/mod.rs
+++ b/lib/src/abstractinterp/mod.rs
@@ -628,7 +628,7 @@ mod tests {
             }
         }
 
-        fn extract(&self,size: usize,offset: usize) -> Self {
+        fn extract(&self,_: usize,_: usize) -> Self {
             match self {
                 &Sign::Join => Sign::Join,
                 &Sign::Meet => Sign::Meet,
@@ -684,7 +684,7 @@ mod tests {
         func.cflow_graph = cfg;
         func.entry_point = Some(v0);
 
-        ssa_convertion(&mut func);
+        assert!(ssa_convertion(&mut func).is_ok());
 
         let vals = approximate::<Sign>(&func).ok().unwrap();
         let res = results::<Sign>(&func,&vals);
@@ -744,7 +744,7 @@ mod tests {
         func.cflow_graph = cfg;
         func.entry_point = Some(v0);
 
-        ssa_convertion(&mut func);
+        assert!(ssa_convertion(&mut func).is_ok());
 
         let vals = approximate::<Sign>(&func).ok().unwrap();
         let res = results::<Sign>(&func,&vals);

--- a/lib/src/amd64/semantic.rs
+++ b/lib/src/amd64/semantic.rs
@@ -378,7 +378,7 @@ fn write_reg(reg: &Rvalue, val: &Rvalue, _sz: usize) -> Result<Vec<Statement>> {
         let mut hi = *offset + *size;
         let mut lo = *offset;
         // this warning seems totally spurious, wtf...
-        let mut stmts = vec![];
+        let mut stmts;
 
         if let Some((reg8l,reg8h,reg16,reg32,reg64)) = reg_variants(name) {
             if *reg == reg8h.clone().into() {

--- a/lib/src/avr/mod.rs
+++ b/lib/src/avr/mod.rs
@@ -543,7 +543,8 @@ mod tests {
     use Rvalue;
     use std::borrow::Cow;
 
-    use std::hash::{Hash,Hasher,SipHasher};
+    use std::hash::{Hash,Hasher};
+    use std::collections::hash_map::DefaultHasher;
 
     use graph_algos::{
         GraphTrait,
@@ -563,7 +564,7 @@ mod tests {
             0x21,0x2c, // 6:8 mov
         ));
         let fun = Function::disassemble::<Avr>(None,Mcu::atmega8(),&reg,0);
-        let _cg = &fun.cflow_graph;
+        let cg = &fun.cflow_graph;
 
         for x in cg.vertices() {
             match cg.vertex_label(x) {
@@ -784,8 +785,8 @@ mod tests {
             Some(&ControlFlowTarget::Resolved(ref bb)) => Some(format!("\"bb{}\"",bb.area.start)),
             Some(&ControlFlowTarget::Unresolved(Rvalue::Constant{ ref value,.. })) => Some(format!("\"v{}\"",*value)),
             Some(&ControlFlowTarget::Unresolved(ref c)) => {
-                let ref mut h = SipHasher::new();
-                c.hash::<SipHasher>(h);
+                let ref mut h = DefaultHasher::new();
+                c.hash::<DefaultHasher>(h);
                 Some(format!("\"c{}\"",h.finish()))
             },
             _ => None,

--- a/lib/src/avr/mod.rs
+++ b/lib/src/avr/mod.rs
@@ -24,15 +24,12 @@
 
 use std::convert::Into;
 use std::borrow::Cow;
-use std::sync::Arc;
 
 use {
     Lvalue,Rvalue,
     Guard,
     Result,
-    LayerIter,
     Region,
-    Disassembler,
     State,
     Match,
     Statement,
@@ -260,7 +257,7 @@ pub fn resolv(r: u64) -> Lvalue {
 pub fn optional_skip(next: Rvalue, st: &mut State<Avr>) {
     if st.configuration.skip.is_some() {
         let (g,o) = st.configuration.skip.as_ref().unwrap().clone();
-        st.jump_from(o,next,g);
+        st.jump_from(o,next,g).unwrap();
     }
 }
 
@@ -278,21 +275,21 @@ pub fn skip(n: &'static str, expect: bool) -> Box<Fn(&mut State<Avr>) -> bool> {
         } else {
             let a = Rvalue::Constant{ value: st.get_group("sA"), size: 6 };
 
-            st.mnemonic(0,"__io_reg","",vec![],&|cg: &mut Mcu| {
+            st.mnemonic(0,"__io_reg","",vec![],&|_cg: &mut Mcu| {
                 rreil!{
                     load/io ioreg:8, (a);
                 }
-            });
+            }).unwrap();
 
             (Rvalue::Variable{ name: Cow::Borrowed("ioreg"), size: 1, offset: bit as usize, subscript: None },a)
         };
 
-        st.mnemonic(2,n,"{u}, {u}",vec![_rr.clone().into(),b.clone()],&|cg: &mut Mcu| {
+        st.mnemonic(2,n,"{u}, {u}",vec![_rr.clone().into(),b.clone()],&|_cg: &mut Mcu| {
             let rr = rr.clone();
             rreil!{
                 mov skip_flag:1, (rr);
             }
-        });
+        }).unwrap();
 
         let fallthru = st.configuration.wrap(st.address + 2);
         let skip = st.configuration.wrap(st.address + 4);
@@ -302,12 +299,12 @@ pub fn skip(n: &'static str, expect: bool) -> Box<Fn(&mut State<Avr>) -> bool> {
         };
 
         if st.tokens.len() == 1 {
-            st.jump(skip,g.clone());
+            st.jump(skip,g.clone()).unwrap();
         } else {
             st.configuration.skip = Some((g.clone(),st.address));
         }
 
-        st.jump(fallthru,g.negation());
+        st.jump(fallthru,g.negation()).unwrap();
         true
     })
 }
@@ -328,11 +325,11 @@ pub fn binary(n: &'static str,sem: fn(Lvalue,Rvalue,&mut Mcu) -> Result<Vec<Stat
         };
         let next = st.configuration.wrap(st.address + st.tokens.len() as u64 * 2);
 
-        st.mnemonic(2,n,"{u}, {u}",vec!(rd.clone().into(),rr.clone()),&|cg: &mut Mcu| {
-            sem(rd.clone(),rr.clone(),cg)
-        });
+        st.mnemonic(2,n,"{u}, {u}",vec!(rd.clone().into(),rr.clone()),&|_cg: &mut Mcu| {
+            sem(rd.clone(),rr.clone(),_cg)
+        }).unwrap();
         optional_skip(next.clone(),st);
-        st.jump(next,Guard::always());
+        st.jump(next,Guard::always()).unwrap();
         true
     })
 }
@@ -346,11 +343,11 @@ pub fn binary_imm(n: &'static str,sem: fn(Lvalue,u64,&mut Mcu) -> Result<Vec<Sta
         } else {
             let a = Rvalue::Constant{ value: st.get_group("A"), size: 6 };
 
-            st.mnemonic(0,"__io_reg","",vec![],&|cg: &mut Mcu| {
+            st.mnemonic(0,"__io_reg","",vec![],&|_cg: &mut Mcu| {
                 rreil!{
                     load/io ioreg:8, (a);
                 }
-            });
+            }).unwrap();
 
             (Lvalue::Variable{ name: Cow::Borrowed("ioreg"), size: 8, subscript: None },Some(a))
         };
@@ -362,11 +359,11 @@ pub fn binary_imm(n: &'static str,sem: fn(Lvalue,u64,&mut Mcu) -> Result<Vec<Sta
         let next = st.configuration.wrap(st.address + st.tokens.len() as u64 * 2);
         let len = st.tokens.len() * 2;
 
-        st.mnemonic(len,n,"{u}, {u}",vec![rd_rv.unwrap_or(rd.clone().into()),kc.clone()],&|cg: &mut Mcu| {
-            sem(rd.clone(),k,cg)
-        });
+        st.mnemonic(len,n,"{u}, {u}",vec![rd_rv.unwrap_or(rd.clone().into()),kc.clone()],&|_cg: &mut Mcu| {
+            sem(rd.clone(),k,_cg)
+        }).unwrap();
         optional_skip(next.clone(),st);
-        st.jump(next,Guard::always());
+        st.jump(next,Guard::always()).unwrap();
         true
     })
 }
@@ -404,7 +401,7 @@ pub fn binary_ptr(n: &'static str,sem: fn(Lvalue,Lvalue,&mut Mcu) -> Result<Vec<
         };
         let next = st.configuration.wrap(st.address + st.tokens.len() as u64 * 2);
 
-        st.mnemonic(0,"__addr_reg","",vec![],&|cg: &mut Mcu| {
+        st.mnemonic(0,"__addr_reg","",vec![],&|_cg: &mut Mcu| {
             let (r1,r2) = match ar {
                 AddressRegister::X => (rreil_lvalue!{ R26:8 },rreil_lvalue!{ R27:8 }),
                 AddressRegister::Y => (rreil_lvalue!{ R28:8 },rreil_lvalue!{ R29:8 }),
@@ -415,7 +412,7 @@ pub fn binary_ptr(n: &'static str,sem: fn(Lvalue,Lvalue,&mut Mcu) -> Result<Vec<
                 zext/16 (addr_reg), (r1);
                 sel/8 (addr_reg), (r2);
             }
-        });
+        }).unwrap();
 
         let (fmt,rd,rr) = if ptr_first {
             ("{p:ram}, {u}",addr_reg.clone().into(),reg.clone().into())
@@ -423,7 +420,7 @@ pub fn binary_ptr(n: &'static str,sem: fn(Lvalue,Lvalue,&mut Mcu) -> Result<Vec<
             ("{u}, {p:ram}",reg.clone().into(),addr_reg.clone().into())
         };
 
-        st.mnemonic(2,n,fmt,vec!(rd,rr),&|cg: &mut Mcu| {
+        st.mnemonic(2,n,fmt,vec!(rd,rr),&|_cg: &mut Mcu| {
             let mut stmts = vec![];
 
             if off == AddressOffset::Predecrement {
@@ -432,7 +429,7 @@ pub fn binary_ptr(n: &'static str,sem: fn(Lvalue,Lvalue,&mut Mcu) -> Result<Vec<
                 }));
             }
 
-            stmts.append(&mut try!(sem(addr_reg.clone(),reg.clone(),cg)));
+            stmts.append(&mut try!(sem(addr_reg.clone(),reg.clone(),_cg)));
 
             if off == AddressOffset::Postincrement {
                 stmts.append(&mut try!(rreil!{
@@ -456,10 +453,10 @@ pub fn binary_ptr(n: &'static str,sem: fn(Lvalue,Lvalue,&mut Mcu) -> Result<Vec<
             }));
 
             Ok(stmts)
-        });
+        }).unwrap();
 
         optional_skip(next.clone(),st);
-        st.jump(next,Guard::always());
+        st.jump(next,Guard::always()).unwrap();
         true
     })
 }
@@ -468,9 +465,9 @@ pub fn nonary(n: &'static str,sem: fn(&mut Mcu) -> Result<Vec<Statement>>) -> Bo
     Box::new(move |st: &mut State<Avr>| {
         let next = st.configuration.wrap(st.address + st.tokens.len() as u64 * 2);
 
-        st.mnemonic(2,n,"",vec![],&sem);
+        st.mnemonic(2,n,"",vec![],&sem).unwrap();
         optional_skip(next.clone(),st);
-        st.jump(next,Guard::always());
+        st.jump(next,Guard::always()).unwrap();
         true
     })
 }
@@ -480,11 +477,11 @@ pub fn unary(n: &'static str,sem: fn(Lvalue,&mut Mcu) -> Result<Vec<Statement>>)
         let rd = if st.has_group("D") { reg(st,"D") } else { resolv(st.get_group("d") + 16) };
         let next = st.configuration.wrap(st.address + st.tokens.len() as u64 * 2);
 
-        st.mnemonic(2,n,"{u}",vec!(rd.clone().into()),&|cg: &mut Mcu| -> Result<Vec<Statement>> {
-            sem(rd.clone(),cg)
-        });
+        st.mnemonic(2,n,"{u}",vec!(rd.clone().into()),&|_cg: &mut Mcu| -> Result<Vec<Statement>> {
+            sem(rd.clone(),_cg)
+        }).unwrap();
         optional_skip(next.clone(),st);
-        st.jump(next,Guard::always());
+        st.jump(next,Guard::always()).unwrap();
         true
     })
 }
@@ -494,15 +491,15 @@ pub fn flag(n: &'static str,_f: &Lvalue,val: bool) -> Box<Fn(&mut State<Avr>) ->
     Box::new(move |st: &mut State<Avr>| -> bool {
         let next = st.configuration.wrap(st.address + st.tokens.len() as u64 * 2);
 
-        st.mnemonic(2,n,"",vec!(),&|cg: &mut Mcu| {
+        st.mnemonic(2,n,"",vec!(),&|_cg: &mut Mcu| {
             let bit = if val { 1 } else { 0 };
 
             rreil!{
                 mov (f.clone()), [bit]:1;
             }
-        });
+        }).unwrap();
         optional_skip(next.clone(),st);
-        st.jump(next,Guard::always());
+        st.jump(next,Guard::always()).unwrap();
         true
     })
 }
@@ -515,23 +512,23 @@ pub fn branch(n: &'static str,_f: &Lvalue,val: bool) -> Box<Fn(&mut State<Avr>) 
         let jump = st.configuration.wrap((st.address as i64 + st.tokens.len() as i64 * 2 + k) as u64);
         let fallthru = st.configuration.wrap(st.address + st.tokens.len() as u64 * 2);
 
-        st.mnemonic(2,n,"{c:flash}",vec!(jump.clone().into()),&|cg: &mut Mcu| -> Result<Vec<Statement>> {
+        st.mnemonic(2,n,"{c:flash}",vec!(jump.clone().into()),&|_cg: &mut Mcu| -> Result<Vec<Statement>> {
             let bit = if val { 1 } else { 0 };
 
             rreil!{
                 mov (f), [bit]:1;
             }
-        });
+        }).unwrap();
 
         optional_skip(fallthru.clone(),st);
         let g = Guard::from_flag(&f.clone().into()).ok().unwrap();
 
         if val {
-            st.jump(fallthru,g.negation());
-            st.jump(jump,g);
+            st.jump(fallthru,g.negation()).unwrap();
+            st.jump(jump,g).unwrap();
         } else {
-            st.jump(jump,g.negation());
-            st.jump(fallthru,g);
+            st.jump(jump,g.negation()).unwrap();
+            st.jump(fallthru,g).unwrap();
         }
         true
     })
@@ -566,7 +563,7 @@ mod tests {
             0x21,0x2c, // 6:8 mov
         ));
         let fun = Function::disassemble::<Avr>(None,Mcu::atmega8(),&reg,0);
-        let cg = &fun.cflow_graph;
+        let _cg = &fun.cflow_graph;
 
         for x in cg.vertices() {
             match cg.vertex_label(x) {

--- a/lib/src/avr/semantic.rs
+++ b/lib/src/avr/semantic.rs
@@ -17,25 +17,25 @@ pub fn cpse(st: &mut State<Avr>) -> bool {
     let skip = st.configuration.wrap(st.address + 4);
     let g = Guard::from_flag(&rreil_rvalue!{ skip_flag:1 }).ok().unwrap();
 
-    st.mnemonic(2,"cpse","{u}, {u}",vec!(rd.clone().into(),rr.clone().into()),&|cg: &mut Mcu| {
+    st.mnemonic(2,"cpse","{u}, {u}",vec!(rd.clone().into(),rr.clone().into()),&|_cg: &mut Mcu| {
         rreil!{
             cmpeq skip_flag:1, (rr.clone()), (rd.clone());
         }
-    });
+    }).unwrap();
 
     optional_skip(fallthru.clone(),st);
 
     if st.tokens.len() == 1 {
-        st.jump(skip,g.clone());
+        st.jump(skip,g.clone()).unwrap();
     } else {
         st.configuration.skip = Some((g.clone(),st.address));
     }
 
-    st.jump(fallthru,g.negation());
+    st.jump(fallthru,g.negation()).unwrap();
     true
 }
 
-pub fn adc(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn adc(rd: Lvalue, rr: Rvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     let half_rd = if let &Lvalue::Variable{ ref name, size: 8,.. } = &rd {
         Lvalue::Variable{
             name: name.clone(),
@@ -93,7 +93,7 @@ pub fn adc(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
     }
 }
 
-pub fn add(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn add(rd: Lvalue, rr: Rvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     let half_rd = rd.extract(4,0).ok().unwrap();
 
     rreil!{
@@ -140,14 +140,14 @@ pub fn adiw(st: &mut State<Avr>) -> bool {
     let rd2 = resolv(st.get_group("d") * 2 + 25);
     let k = Rvalue::new_u8(st.get_group("K") as u8);
 
-    st.mnemonic(0,"__wide_reg","",vec![],&|cg: &mut Mcu| {
+    st.mnemonic(0,"__wide_reg","",vec![],&|_cg: &mut Mcu| {
         rreil!{
             zext/16 reg:16, (rd1);
             sel/8 reg:16, (rd2);
         }
-    });
+    }).unwrap();
 
-    st.mnemonic(2,"adiw","{u:8}, {u:8}",vec!(rd1.clone().into(),k.clone()),&|cg: &mut Mcu| {
+    st.mnemonic(2,"adiw","{u:8}, {u:8}",vec!(rd1.clone().into(),k.clone()),&|_cg: &mut Mcu| {
         rreil!{
             zext/16 imm:16, (k);
             add res:16, reg:16, imm:16;
@@ -181,16 +181,16 @@ pub fn adiw(st: &mut State<Avr>) -> bool {
             mov (rd1), res:8;
             mov (rd2), res:8/8;
         }
-    });
+    }).unwrap();
 
     let next = st.configuration.wrap(st.address + st.tokens.len() as u64 * 2);
 
     optional_skip(next.clone(),st);
-    st.jump(next,Guard::always());
+    st.jump(next,Guard::always()).unwrap();
     true
 }
 
-pub fn and(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn and(rd: Lvalue, rr: Rvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         and res:8, (rd), (rr);
 
@@ -201,7 +201,7 @@ pub fn and(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
     }
 }
 
-pub fn asr(rd: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn asr(rd: Lvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         mov lsb:1, C:1;
         cmpltu C:1, [0x7f]:8, (rd);
@@ -217,13 +217,13 @@ pub fn asr(rd: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
 
 pub fn _break(_: &mut Mcu) -> Result<Vec<Statement>> { Ok(vec![]) }
 
-pub fn bld(rd: Lvalue, b: u64, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn bld(rd: Lvalue, b: u64, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         sel/b (rd), T:1;
     }
 }
 
-pub fn bst(rd: Lvalue, b: u64, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn bst(rd: Lvalue, b: u64, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     let r: Rvalue = rd.extract(1,b as usize).ok().unwrap();
 
     rreil!{
@@ -235,24 +235,24 @@ pub fn call(st: &mut State<Avr>) -> bool {
     let k = st.configuration.wrap(st.get_group("k") * 2);
     let next = st.configuration.wrap(st.address + st.tokens.len() as u64 * 2);
 
-    st.mnemonic(4,"call","{c:flash}",vec![k.clone()],&|cg: &mut Mcu| {
+    st.mnemonic(4,"call","{c:flash}",vec![k.clone()],&|_cg: &mut Mcu| {
         rreil!{
             call ?, (k);
         }
-    });
+    }).unwrap();
 
     optional_skip(next.clone(),st);
-    st.jump(next,Guard::always());
+    st.jump(next,Guard::always()).unwrap();
     true
 }
 
-pub fn cbx(rd: Lvalue, b: u64, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn cbx(rd: Lvalue, b: u64, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         sel/b (rd), [0]:1;
     }
 }
 
-pub fn com(rd: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn com(rd: Lvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         sub res:8, [0xff]:8, (rd);
         mov C:1, [0]:1;
@@ -263,7 +263,7 @@ pub fn com(rd: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
     }
 }
 
-pub fn cp(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn cp(rd: Lvalue, rr: Rvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     let half_rd: Rvalue = rd.extract(4,0).ok().unwrap();
 
     rreil!{
@@ -298,7 +298,7 @@ pub fn cp(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
     }
 }
 
-pub fn cpc(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn cpc(rd: Lvalue, rr: Rvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     let half_rd: Rvalue = rd.extract(4,0).ok().unwrap();
 
     rreil!{
@@ -341,7 +341,7 @@ pub fn cpc(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
     }
 }
 
-pub fn dec(rd: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn dec(rd: Lvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         cmpeq V:1, (rd), [0x80]:8;
         sub (rd), (rd), [1]:8;
@@ -353,7 +353,7 @@ pub fn dec(rd: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
 
 pub fn des(st: &mut State<Avr>) -> bool {
     let k = Rvalue::new_u8(st.get_group("K") as u8);
-    st.mnemonic(2,"des","{u}",vec![k],&|cg: &mut Mcu| {
+    st.mnemonic(2,"des","{u}",vec![k],&|_cg: &mut Mcu| {
     rreil!{
         mov R0:8, ?;
         mov R1:8, ?;
@@ -372,15 +372,15 @@ pub fn des(st: &mut State<Avr>) -> bool {
         mov R14:8, ?;
         mov R15:8, ?;
     }
-    });
-let next = st.configuration.wrap(st.address + st.tokens.len() as u64 * 2);
+    }).unwrap();
+    let next = st.configuration.wrap(st.address + st.tokens.len() as u64 * 2);
 
     optional_skip(next.clone(),st);
-    st.jump(next,Guard::always());
+    st.jump(next,Guard::always()).unwrap();
     true
 }
 
-pub fn eicall(cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn eicall(_cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         zext/22 p:22, R30:8;
         sel/8 p:22, R31:8;
@@ -391,14 +391,14 @@ pub fn eicall(cg: &mut Mcu) -> Result<Vec<Statement>> {
 }
 
 pub fn eijmp(st: &mut State<Avr>) -> bool {
-    st.mnemonic(2,"eijmp","",vec![],&|cg: &mut Mcu| {
+    st.mnemonic(2,"eijmp","",vec![],&|_cg: &mut Mcu| {
         rreil!{
             zext/22 p:22, R30:8;
             sel/8 p:22, R31:8;
             sel/16 p:22, EIND:6;
             load/sram q:22, p:22;
         }
-    });
+    }).unwrap();
 
     let next = Rvalue::Variable{
         name: Cow::Borrowed("q"),
@@ -408,7 +408,7 @@ pub fn eijmp(st: &mut State<Avr>) -> bool {
     };
 
     optional_skip(next.clone(),st);
-    st.jump(next,Guard::always());
+    st.jump(next,Guard::always()).unwrap();
     true
 }
 
@@ -419,16 +419,16 @@ pub fn elpm(rd: Lvalue, off: usize, st: &mut State<Avr>) -> bool {
         subscript: None,
     };
 
-    st.mnemonic(0,"__wide_reg","",vec![],&|cg: &mut Mcu| {
+    st.mnemonic(0,"__wide_reg","",vec![],&|_cg: &mut Mcu| {
         rreil!{
             zext/24 (zreg), R30:8;
             sel/8 (zreg), R31:8;
             sel/16 (zreg), RAMPZ:8;
         }
-    });
+    }).unwrap();
 
     let arg = if rd == rreil_lvalue!{ R0:8 } { vec![] } else { vec![zreg.clone().into()] };
-    st.mnemonic(2,"elpm","{p:sram}",arg,&|cg: &mut Mcu| {
+    st.mnemonic(2,"elpm","{p:sram}",arg,&|_cg: &mut Mcu| {
         let mut stmts = try!(rreil!{
             load/sram ptr:24, (zreg);
             load/flash (rd), ptr:24;
@@ -444,11 +444,11 @@ pub fn elpm(rd: Lvalue, off: usize, st: &mut State<Avr>) -> bool {
         }
 
         Ok(stmts)
-    });
+    }).unwrap();
 
     let next = st.configuration.wrap(st.address + st.tokens.len() as u64 * 2);
     optional_skip(next.clone(),st);
-    st.jump(next,Guard::always());
+    st.jump(next,Guard::always()).unwrap();
     true
 }
 
@@ -464,7 +464,7 @@ pub fn elpm3(st: &mut State<Avr>) -> bool {
     elpm(reg(st,"D"),1,st)
 }
 
-pub fn eor(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn eor(rd: Lvalue, rr: Rvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         xor res:8, (rd), (rr);
 
@@ -475,7 +475,7 @@ pub fn eor(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
     }
 }
 
-pub fn fmul(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn fmul(rd: Lvalue, rr: Rvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         zext/16 rd:16, (rd);
         zext/16 rr:16, (rr);
@@ -492,7 +492,7 @@ pub fn fmul(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
     }
 }
 
-pub fn fmuls(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn fmuls(rd: Lvalue, rr: Rvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         sext/16 rd:16, (rd);
         sext/16 rr:16, (rr);
@@ -509,7 +509,7 @@ pub fn fmuls(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
     }
 }
 
-pub fn fmulsu(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn fmulsu(rd: Lvalue, rr: Rvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         sext/16 rd:16, (rd);
         zext/16 rr:16, (rr);
@@ -533,23 +533,23 @@ pub fn icall(st: &mut State<Avr>) -> bool {
         subscript: None,
     };
 
-    st.mnemonic(0,"__wide_reg","",vec![],&|cg: &mut Mcu| {
+    st.mnemonic(0,"__wide_reg","",vec![],&|_cg: &mut Mcu| {
         rreil!{
             zext/16 (zreg), R30:8;
             sel/8 (zreg), R31:8;
         }
-    });
+    }).unwrap();
 
-    st.mnemonic(2,"icall","{p:sram}",vec![],&|cg: &mut Mcu| {
+    st.mnemonic(2,"icall","{p:sram}",vec![],&|_cg: &mut Mcu| {
         rreil!{
             load/sram ptr:24, (zreg);
             call ?, ptr:24;
         }
-    });
+    }).unwrap();
 
     let next = st.configuration.wrap(st.address + st.tokens.len() as u64 * 2);
     optional_skip(next.clone(),st);
-    st.jump(next,Guard::always());
+    st.jump(next,Guard::always()).unwrap();
     true
 }
 
@@ -559,17 +559,17 @@ pub fn ijmp(st: &mut State<Avr>) -> bool {
         size: 22,
         subscript: None,
     };
-    st.mnemonic(2,"ijmp","",vec![],&|cg: &mut Mcu| {
+    st.mnemonic(2,"ijmp","",vec![],&|_cg: &mut Mcu| {
         rreil!{
             zext/22 p:22, R30:8;
             sel/8 p:22, R31:8;
             sel/16 p:22, [0]:6;
             mov (next), p:22;
         }
-    });
+    }).unwrap();
 
     optional_skip(next.clone().into(),st);
-    st.jump(next.into(),Guard::always());
+    st.jump(next.into(),Guard::always()).unwrap();
     true
 }
 
@@ -577,19 +577,19 @@ pub fn _in(st: &mut State<Avr>) -> bool {
     let rd = reg(st,"D");
     let rr = Rvalue::Constant{ value: st.get_group("A"), size: 6 };
 
-    st.mnemonic(2,"in","{u}, {u}",vec!(rd.clone().into(),rr.clone().into()),&|cg: &mut Mcu| {
+    st.mnemonic(2,"in","{u}, {u}",vec!(rd.clone().into(),rr.clone().into()),&|_cg: &mut Mcu| {
         rreil!{
             load/io (rd), (rr);
         }
-    });
+    }).unwrap();
 
     let next = st.configuration.wrap(st.address + st.tokens.len() as u64 * 2);
     optional_skip(next.clone(),st);
-    st.jump(next,Guard::always());
+    st.jump(next,Guard::always()).unwrap();
     true
 }
 
-pub fn inc(rd: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn inc(rd: Lvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         cmpeq V:1, (rd), [0x80]:8;
         add (rd), (rd), [1]:8;
@@ -604,13 +604,13 @@ pub fn jmp(st: &mut State<Avr>) -> bool {
     let _k = (st.get_group("k") * 2) % pc_mod;
     let k = Rvalue::Constant{ value: _k, size: st.configuration.pc_bits as usize };
 
-    st.mnemonic(4,"jmp","{c:flash}",vec!(k.clone()),&|_: &mut Mcu| { Ok(vec![]) });
+    st.mnemonic(4,"jmp","{c:flash}",vec!(k.clone()),&|_: &mut Mcu| { Ok(vec![]) }).unwrap();
     optional_skip(st.configuration.wrap(st.address + st.tokens.len() as u64 * 2),st);
-    st.jump(k,Guard::always());
+    st.jump(k,Guard::always()).unwrap();
     true
 }
 
-pub fn lac(ptr: Lvalue, reg: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn lac(ptr: Lvalue, reg: Lvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         load/sram zcont:8, (ptr);
         xor nreg:8, (reg), [0xff]:8;
@@ -619,7 +619,7 @@ pub fn lac(ptr: Lvalue, reg: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
     }
 }
 
-pub fn las(ptr: Lvalue, reg: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn las(ptr: Lvalue, reg: Lvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         load/sram zcont:8, (ptr);
         or (reg), (reg), zcont:8;
@@ -627,7 +627,7 @@ pub fn las(ptr: Lvalue, reg: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
     }
 }
 
-pub fn lat(ptr: Lvalue, reg: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn lat(ptr: Lvalue, reg: Lvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         load/sram zcont:8, (ptr);
         xor (reg), (reg), zcont:8;
@@ -635,13 +635,13 @@ pub fn lat(ptr: Lvalue, reg: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
     }
 }
 
-pub fn ld(ptr: Lvalue, reg: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn ld(ptr: Lvalue, reg: Lvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         load/sram (reg), (ptr);
     }
 }
 
-pub fn ldi(rd: Lvalue, k: u64, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn ldi(rd: Lvalue, k: u64, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         mov (rd), [k]:8;
     }
@@ -651,16 +651,16 @@ pub fn lds1(st: &mut State<Avr>) -> bool {
     let rd = reg(st,"D");
     let k = Rvalue::new_u16(st.get_group("k") as u16);
 
-    st.mnemonic(4,"lds","{p:sram}, {u}",vec![rd.clone().into(),k.clone().into()],&|cg: &mut Mcu| {
+    st.mnemonic(4,"lds","{p:sram}, {u}",vec![rd.clone().into(),k.clone().into()],&|_cg: &mut Mcu| {
         rreil!{
             load/sram (rd), (k);
         }
-    });
+    }).unwrap();
 
     let next = st.configuration.wrap(st.address + st.tokens.len() as u64 * 2);
 
     optional_skip(next.clone(),st);
-    st.jump(next,Guard::always());
+    st.jump(next,Guard::always()).unwrap();
     true
 }
 
@@ -669,16 +669,16 @@ pub fn lds2(st: &mut State<Avr>) -> bool {
     let _k = st.get_group("k") as u16;
     let k = Rvalue::new_u16(if _k <= 0x1F { _k + 0x20 } else { _k });
 
-    st.mnemonic(2,"lds","{u}, {p:sram}",vec![rd.clone().into(),k.clone().into()],&|cg: &mut Mcu| {
+    st.mnemonic(2,"lds","{u}, {p:sram}",vec![rd.clone().into(),k.clone().into()],&|_cg: &mut Mcu| {
         rreil!{
             load/sram (rd), (k);
         }
-    });
+    }).unwrap();
 
     let next = st.configuration.wrap(st.address + st.tokens.len() as u64 * 2);
 
     optional_skip(next.clone(),st);
-    st.jump(next,Guard::always());
+    st.jump(next,Guard::always()).unwrap();
     true
 }
 
@@ -689,15 +689,15 @@ pub fn lpm(rd: Lvalue, off: usize, st: &mut State<Avr>) -> bool {
         subscript: None,
     };
 
-    st.mnemonic(0,"__wide_reg","",vec![],&|cg: &mut Mcu| {
+    st.mnemonic(0,"__wide_reg","",vec![],&|_cg: &mut Mcu| {
         rreil!{
             zext/16 (zreg), R30:8;
             sel/8 (zreg), R31:8;
         }
-    });
+    }).unwrap();
 
     let arg = if rd == rreil_lvalue!{ R0:8 } { vec![] } else { vec![zreg.clone().into()] };
-    st.mnemonic(2,"lpm","{p:sram}",arg,&|cg: &mut Mcu| {
+    st.mnemonic(2,"lpm","{p:sram}",arg,&|_cg: &mut Mcu| {
         let mut stmts = try!(rreil!{
             load/sram ptr:16, (zreg);
             load/flash (rd), ptr:16;
@@ -712,12 +712,12 @@ pub fn lpm(rd: Lvalue, off: usize, st: &mut State<Avr>) -> bool {
         }
 
         Ok(stmts)
-    });
+    }).unwrap();
 
     let next = st.configuration.wrap(st.address + st.tokens.len() as u64 * 2);
 
     optional_skip(next.clone(),st);
-    st.jump(next,Guard::always());
+    st.jump(next,Guard::always()).unwrap();
     true
 }
 
@@ -733,7 +733,7 @@ pub fn lpm3(st: &mut State<Avr>) -> bool {
     lpm(reg(st,"D"),1,st)
 }
 
-pub fn lsr(rd: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn lsr(rd: Lvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         mov C:1, (rd.extract(1,0).ok().unwrap());
         shr (rd), (rd), [1]:8;
@@ -744,7 +744,7 @@ pub fn lsr(rd: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
     }
 }
 
-pub fn mov(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn mov(rd: Lvalue, rr: Rvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         mov (rd), (rr);
     }
@@ -757,19 +757,19 @@ pub fn movw(st: &mut State<Avr>) -> bool {
     let rr2 = resolv(st.get_group("r") * 2 + 1);
     let next = st.configuration.wrap(st.address + st.tokens.len() as u64 * 2);
 
-    st.mnemonic(2,"movw","{u}, {u}",vec!(rd1.clone().into(),rr1.clone().into()),&|cg: &mut Mcu| {
+    st.mnemonic(2,"movw","{u}, {u}",vec!(rd1.clone().into(),rr1.clone().into()),&|_cg: &mut Mcu| {
         rreil!{
             mov (rd1), (rr1);
             mov (rd2), (rr2);
         }
-    });
+    }).unwrap();
 
     optional_skip(next.clone(),st);
-    st.jump(next,Guard::always());
+    st.jump(next,Guard::always()).unwrap();
     true
 }
 
-pub fn mul(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn mul(rd: Lvalue, rr: Rvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         zext/16 rd:16, (rd);
         zext/16 rr:16, (rr);
@@ -784,7 +784,7 @@ pub fn mul(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
     }
 }
 
-pub fn muls(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn muls(rd: Lvalue, rr: Rvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         sext/16 rd:16, (rd);
         sext/16 rr:16, (rr);
@@ -800,7 +800,7 @@ pub fn muls(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
     }
 }
 
-pub fn mulsu(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn mulsu(rd: Lvalue, rr: Rvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         sext/16 rd:16, (rd);
         zext/16 rr:16, (rr);
@@ -816,7 +816,7 @@ pub fn mulsu(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
     }
 }
 
-pub fn neg(rd: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn neg(rd: Lvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         sub res:8, [0]:8, (rd);
 
@@ -832,7 +832,7 @@ pub fn neg(rd: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
 
 pub fn nop(_: &mut Mcu) -> Result<Vec<Statement>> { Ok(vec![]) }
 
-pub fn or(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn or(rd: Lvalue, rr: Rvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         or res:8, (rd), (rr);
 
@@ -851,17 +851,17 @@ pub fn out(st: &mut State<Avr>) -> bool {
     let rr = reg(st,"R");
     let next = st.configuration.wrap(st.address + st.tokens.len() as u64 * 2);
 
-    st.mnemonic(2,"out","{u}, {u}",vec!(rd.clone().into(),rr.clone().into()),&|cg: &mut Mcu| {
+    st.mnemonic(2,"out","{u}, {u}",vec!(rd.clone().into(),rr.clone().into()),&|_cg: &mut Mcu| {
         rreil!{
             store/io (rr), (rd);
         }
-    });
+    }).unwrap();
     optional_skip(next.clone(),st);
-    st.jump(next,Guard::always());
+    st.jump(next,Guard::always()).unwrap();
     true
 }
 
-pub fn pop(rd: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn pop(rd: Lvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         zext/16 stack:16, spl:8;
         sel/8 stack:16, sph:8;
@@ -872,7 +872,7 @@ pub fn pop(rd: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
     }
 }
 
-pub fn push(rd: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn push(rd: Lvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         zext/16 stack:16, spl:8;
         sel/8 stack:16, sph:8;
@@ -889,14 +889,14 @@ pub fn rcall(st: &mut State<Avr>) -> bool {
     let k = Rvalue::Constant{ value: _k, size: st.configuration.pc_bits };
     let next = st.configuration.wrap(st.address + st.tokens.len() as u64 * 2);
 
-    st.mnemonic(2,"rcall","{c:flash}",vec![k.clone()],&|cg: &mut Mcu| {
+    st.mnemonic(2,"rcall","{c:flash}",vec![k.clone()],&|_cg: &mut Mcu| {
     rreil!{
         call ?, (k);
     }
-    });
+    }).unwrap();
 
     optional_skip(next.clone(),st);
-    st.jump(next,Guard::always());
+    st.jump(next,Guard::always()).unwrap();
     true
 }
 
@@ -907,13 +907,13 @@ pub fn rjmp(st: &mut State<Avr>) -> bool {
     let _k = (st.address + st.get_group("k") * 2 + 2) % pc_mod;
     let k = Rvalue::Constant{ value: _k, size: st.configuration.pc_bits };
 
-    st.mnemonic(2,"rjmp","{c:flash}",vec!(k.clone()),&|_: &mut Mcu| { Ok(vec![]) });
+    st.mnemonic(2,"rjmp","{c:flash}",vec!(k.clone()),&|_: &mut Mcu| { Ok(vec![]) }).unwrap();
     optional_skip(st.configuration.wrap(st.address + st.tokens.len() as u64 * 2),st);
-    st.jump(k,Guard::always());
+    st.jump(k,Guard::always()).unwrap();
     true
 }
 
-pub fn ror(rd: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn ror(rd: Lvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
  rreil!{
         mov nc:1, (rd.extract(1,7).ok().unwrap());
         shr (rd), (rd), [1]:8;
@@ -926,7 +926,7 @@ pub fn ror(rd: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
     }
 }
 
-pub fn sbc(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn sbc(rd: Lvalue, rr: Rvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         zext/8 carry:8, C:1;
         sub res:8, (rd), (rr);
@@ -955,7 +955,7 @@ pub fn sbc(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
     }
 }
 
-pub fn sbci(rd: Lvalue, k: u64, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn sbci(rd: Lvalue, k: u64, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         mov k:8, [k]:8;
         zext/8 carry:8, C:1;
@@ -985,7 +985,7 @@ pub fn sbci(rd: Lvalue, k: u64, cg: &mut Mcu) -> Result<Vec<Statement>> {
     }
 }
 
-pub fn sbi(rd: Lvalue, b: u64, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn sbi(rd: Lvalue, b: u64, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         sel/b (rd), [1]:1;
     }
@@ -996,14 +996,14 @@ pub fn sbiw(st: &mut State<Avr>) -> bool {
     let rd2 = resolv(st.get_group("d") * 2 + 25);
     let k = Rvalue::new_u8(st.get_group("K") as u8);
 
-    st.mnemonic(0,"__wide_reg","",vec![],&|cg: &mut Mcu| {
+    st.mnemonic(0,"__wide_reg","",vec![],&|_cg: &mut Mcu| {
         rreil!{
             zext/16 reg:16, (rd1);
             sel/8 reg:16, (rd2);
         }
-    });
+    }).unwrap();
 
-    st.mnemonic(2,"sbiw","{u:8}, {u:8}",vec!(rd1.clone().into(),k.clone()),&|cg: &mut Mcu| {
+    st.mnemonic(2,"sbiw","{u:8}, {u:8}",vec!(rd1.clone().into(),k.clone()),&|_cg: &mut Mcu| {
         rreil!{
             zext/16 reg:16, (rd1);
             sel/8 reg:16, (rd2);
@@ -1029,12 +1029,12 @@ pub fn sbiw(st: &mut State<Avr>) -> bool {
             mov (rd1), res:8;
             mov (rd2), res:8/8;
         }
-    });
+    }).unwrap();
 
     let next = st.configuration.wrap(st.address + st.tokens.len() as u64 * 2);
 
     optional_skip(next.clone(),st);
-    st.jump(next,Guard::always());
+    st.jump(next,Guard::always()).unwrap();
     true
 }
 
@@ -1048,15 +1048,15 @@ pub fn spm(rd: Lvalue, off: usize, st: &mut State<Avr>) -> bool {
     };
     let len = st.tokens.len() * 2;
 
-    st.mnemonic(0,"__wide_reg","",vec![],&|cg: &mut Mcu| {
+    st.mnemonic(0,"__wide_reg","",vec![],&|_cg: &mut Mcu| {
         rreil!{
             zext/16 (zreg), R30:8;
             sel/8 (zreg), R31:8;
         }
-    });
+    }).unwrap();
 
     let arg = if off == 0 { vec![] } else { vec![zreg.clone().into()] };
-    st.mnemonic(len,"spm","{p:sram}",arg,&|cg: &mut Mcu| {
+    st.mnemonic(len,"spm","{p:sram}",arg,&|_cg: &mut Mcu| {
         let mut stmts = try!(rreil!{
             load/sram ptr:16, (zreg);
             load/flash ptr:16, (rd);
@@ -1071,12 +1071,12 @@ pub fn spm(rd: Lvalue, off: usize, st: &mut State<Avr>) -> bool {
         }
 
         Ok(stmts)
-    });
+    }).unwrap();
 
     let next = st.configuration.wrap(st.address + st.tokens.len() as u64 * 2);
 
     optional_skip(next.clone(),st);
-    st.jump(next,Guard::always());
+    st.jump(next,Guard::always()).unwrap();
     true
 }
 
@@ -1092,7 +1092,7 @@ pub fn spm3(st: &mut State<Avr>) -> bool {
     spm(reg(st,"D"),1,st)
 }
 
-pub fn st(ptr: Lvalue, reg: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn st(ptr: Lvalue, reg: Lvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         load/sram (ptr), (reg);
     }
@@ -1102,16 +1102,16 @@ pub fn sts1(st: &mut State<Avr>) -> bool {
     let rd = reg(st,"R");
     let k = Rvalue::new_u16(st.get_group("k") as u16);
 
-    st.mnemonic(4,"sts","{p:sram}, {u}",vec![k.clone().into(),rd.clone().into()],&|cg: &mut Mcu| {
+    st.mnemonic(4,"sts","{p:sram}, {u}",vec![k.clone().into(),rd.clone().into()],&|_cg: &mut Mcu| {
         rreil!{
             store/sram (rd), (k);
         }
-    });
+    }).unwrap();
 
     let next = st.configuration.wrap(st.address + st.tokens.len() as u64 * 2);
 
     optional_skip(next.clone(),st);
-    st.jump(next,Guard::always());
+    st.jump(next,Guard::always()).unwrap();
     true
 }
 
@@ -1120,20 +1120,20 @@ pub fn sts2(st: &mut State<Avr>) -> bool {
     let _k = st.get_group("k") as u16;
     let k = Rvalue::new_u16(if _k <= 0x1F { _k + 0x20 } else { _k });
 
-    st.mnemonic(2,"sts","{p:sram}, {u}",vec![k.clone().into(),rd.clone().into()],&|cg: &mut Mcu| {
+    st.mnemonic(2,"sts","{p:sram}, {u}",vec![k.clone().into(),rd.clone().into()],&|_cg: &mut Mcu| {
         rreil!{
             store/sram (rd), (k);
         }
-    });
+    }).unwrap();
 
     let next = st.configuration.wrap(st.address + st.tokens.len() as u64 * 2);
 
     optional_skip(next.clone(),st);
-    st.jump(next,Guard::always());
+    st.jump(next,Guard::always()).unwrap();
     true
 }
 
-pub fn sub(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn sub(rd: Lvalue, rr: Rvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         sub res:8, (rd), (rr);
 
@@ -1157,7 +1157,7 @@ pub fn sub(rd: Lvalue, rr: Rvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
     }
 }
 
-pub fn subi(rd: Lvalue, k: u64, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn subi(rd: Lvalue, k: u64, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         sub res:8, (rd), [k]:8;
 
@@ -1181,7 +1181,7 @@ pub fn subi(rd: Lvalue, k: u64, cg: &mut Mcu) -> Result<Vec<Statement>> {
     }
 }
 
-pub fn swap(rd: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn swap(rd: Lvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         mov tmp:4, (rd.extract(4,0).ok().unwrap());
         sel/0 (rd), (rd.extract(4,4).ok().unwrap());
@@ -1191,7 +1191,7 @@ pub fn swap(rd: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
 
 pub fn wdr(_: &mut Mcu) -> Result<Vec<Statement>> { Ok(vec![]) }
 
-pub fn xch(ptr: Lvalue, reg: Lvalue, cg: &mut Mcu) -> Result<Vec<Statement>> {
+pub fn xch(ptr: Lvalue, reg: Lvalue, _cg: &mut Mcu) -> Result<Vec<Statement>> {
     rreil!{
         load/sram zcont:8, (ptr);
         store/sram (ptr), (reg);

--- a/lib/src/dataflow.rs
+++ b/lib/src/dataflow.rs
@@ -669,7 +669,7 @@ mod tests {
         func.cflow_graph = cfg;
         func.entry_point = Some(v0);
 
-        phi_functions(&mut func);
+        assert!(phi_functions(&mut func).is_ok());
 
         let a0 = Lvalue::Variable{ name: Cow::Borrowed("a"), size: 32, subscript: None };
         let b0 = Lvalue::Variable{ name: Cow::Borrowed("b"), size: 32, subscript: None };
@@ -880,8 +880,8 @@ mod tests {
         func.cflow_graph = cfg;
         func.entry_point = Some(v0);
 
-        phi_functions(&mut func);
-        rename_variables(&mut func);
+        assert!(phi_functions(&mut func).is_ok());
+        assert!(rename_variables(&mut func).is_ok());
 
         for v in func.cflow_graph.vertices() {
             if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cflow_graph.vertex_label(v) {

--- a/lib/src/disassembler.rs
+++ b/lib/src/disassembler.rs
@@ -109,7 +109,6 @@ use {
     Mnemonic,
     Guard,
     Region,
-    LayerIter,
     Result,
     Statement,
 };
@@ -266,7 +265,7 @@ impl<A: Architecture> State<A> {
         }
 
         let o = self.jump_origin;
-        self.jump_from(o,v,g);
+        self.jump_from(o,v,g)?;
 
         Ok(())
     }
@@ -310,6 +309,7 @@ impl<A: Architecture> PartialEq for Rule<A> {
 #[derive(PartialEq,Hash,Eq,Debug)]
 enum Symbol {
 	Sparse,
+    // another broken warning; this variant is directly accessed in a private function, which is used by a public facing function, hence its bunk
 	Dense(Vec<AdjacencyListVertexDescriptor>),
 }
 
@@ -338,8 +338,8 @@ impl<A: Architecture> Disassembler<A> {
             default: None,
         }
     }
-
-    fn to_dot(&self) {
+    /// Converts to a dot file; useful for debugging
+    pub fn to_dot(&self) {
         println!("digraph G {{");
         for v in self.graph.vertices() {
             let lb = self.graph.vertex_label(v).unwrap();

--- a/lib/src/function.rs
+++ b/lib/src/function.rs
@@ -28,7 +28,6 @@
 //! on the front-end.
 
 use std::collections::{HashMap,BTreeMap,HashSet};
-use std::sync::Arc;
 use std::borrow::Cow;
 use std::fmt::Debug;
 
@@ -38,7 +37,6 @@ use graph_algos::{
     MutableGraphTrait,
     VertexListGraphTrait,
     EdgeListGraphTrait,
-    BidirectionalGraphTrait,
 };
 use graph_algos::adjacency_list::{
     AdjacencyListVertexDescriptor,
@@ -54,9 +52,7 @@ use {
     BasicBlock,
     Guard,
     Region,
-    Disassembler,
     Architecture,
-    LayerIter,
     Rvalue,
     Mnemonic,
     Statement,

--- a/lib/src/function.rs
+++ b/lib/src/function.rs
@@ -523,7 +523,6 @@ mod tests {
     use super::*;
     use std::borrow::Cow;
     use std::sync::Arc;
-    use std::fmt;
     use graph_algos::{VertexListGraphTrait,EdgeListGraphTrait,AdjacencyMatrixGraphTrait};
     use graph_algos::{GraphTrait,MutableGraphTrait};
     use {
@@ -535,7 +534,6 @@ mod tests {
         Match,
         Rvalue,
         OpaqueLayer,
-        LayerIter,
         Result,
         State,
         Architecture,
@@ -708,7 +706,7 @@ mod tests {
     fn add_single() {
         let main = new_disassembler!(TestArchShort =>
             [ 0 ] = |st: &mut State<TestArchShort>| {
-                st.mnemonic(1,"A","",vec!(),&|_| { Ok(vec![]) });
+                st.mnemonic(1,"A","",vec!(),&|_| { Ok(vec![]) }).unwrap();
                 true
             }
 		);
@@ -741,38 +739,38 @@ mod tests {
         let main = new_disassembler!(TestArchShort =>
             [ 0 ] = |st: &mut State<TestArchShort>| {
                 let next = st.address;
-                st.mnemonic(1,"test0","",vec!(),&|_| { Ok(vec![]) });
-                st.jump(Rvalue::new_u64(next + 1),Guard::always());
+                st.mnemonic(1,"test0","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u64(next + 1),Guard::always()).unwrap();
                 true
             },
             [ 1 ] = |st: &mut State<TestArchShort>| {
                 let next = st.address;
-                st.mnemonic(1,"test1","",vec!(),&|_| { Ok(vec![]) });
-                st.jump(Rvalue::new_u64(next + 1),Guard::always());
+                st.mnemonic(1,"test1","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u64(next + 1),Guard::always()).unwrap();
                 true
             },
             [ 2 ] = |st: &mut State<TestArchShort>| {
                 let next = st.address;
-                st.mnemonic(1,"test2","",vec!(),&|_| { Ok(vec![]) });
-                st.jump(Rvalue::new_u64(next + 1),Guard::always());
+                st.mnemonic(1,"test2","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u64(next + 1),Guard::always()).unwrap();
                 true
             },
             [ 3 ] = |st: &mut State<TestArchShort>| {
                 let next = st.address;
-                st.mnemonic(1,"test3","",vec!(),&|_| { Ok(vec![]) });
-                st.jump(Rvalue::new_u64(next + 1),Guard::always());
+                st.mnemonic(1,"test3","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u64(next + 1),Guard::always()).unwrap();
                 true
             },
             [ 4 ] = |st: &mut State<TestArchShort>| {
                 let next = st.address;
-                st.mnemonic(1,"test4","",vec!(),&|_| { Ok(vec![]) });
-                st.jump(Rvalue::new_u64(next + 1),Guard::always());
+                st.mnemonic(1,"test4","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u64(next + 1),Guard::always()).unwrap();
                 true
             },
             [ 5 ] = |st: &mut State<TestArchShort>| {
                 let next = st.address;
-                st.mnemonic(1,"test5","",vec!(),&|_| { Ok(vec![]) });
-                st.jump(Rvalue::new_u64(next + 1),Guard::always());
+                st.mnemonic(1,"test5","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u64(next + 1),Guard::always()).unwrap();
                 true
             }
         );
@@ -822,19 +820,19 @@ mod tests {
     fn branch() {
         let main = new_disassembler!(TestArchShort =>
             [ 0 ] = |st: &mut State<TestArchShort>| {
-                st.mnemonic(1,"test0","",vec!(),&|_| { Ok(vec![]) });
-                st.jump(Rvalue::new_u32(1),Guard::always());
-                st.jump(Rvalue::new_u32(2),Guard::always());
+                st.mnemonic(1,"test0","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(1),Guard::always()).unwrap();
+                st.jump(Rvalue::new_u32(2),Guard::always()).unwrap();
                 true
             },
             [ 1 ] = |st: &mut State<TestArchShort>| {
-                st.mnemonic(1,"test1","",vec!(),&|_| { Ok(vec![]) });
-                st.jump(Rvalue::new_u32(3),Guard::always());
+                st.mnemonic(1,"test1","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(3),Guard::always()).unwrap();
                 true
             },
             [ 2 ] = |st: &mut State<TestArchShort>| {
-                st.mnemonic(1,"test2","",vec!(),&|_| { Ok(vec![]) });
-                st.jump(Rvalue::new_u32(1),Guard::always());
+                st.mnemonic(1,"test2","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(1),Guard::always()).unwrap();
                 true
             }
         );
@@ -895,18 +893,18 @@ mod tests {
     fn function_loop() {
       let main = new_disassembler!(TestArchShort =>
             [ 0 ] = |st: &mut State<TestArchShort>| {
-                st.mnemonic(1,"test0","",vec!(),&|_| { Ok(vec![]) });
-                st.jump(Rvalue::new_u32(1),Guard::always());
+                st.mnemonic(1,"test0","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(1),Guard::always()).unwrap();
                 true
             },
             [ 1 ] = |st: &mut State<TestArchShort>| {
-                st.mnemonic(1,"test1","",vec!(),&|_| { Ok(vec![]) });
-                st.jump(Rvalue::new_u32(2),Guard::always());
+                st.mnemonic(1,"test1","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(2),Guard::always()).unwrap();
                 true
             },
             [ 2 ] = |st: &mut State<TestArchShort>| {
-                st.mnemonic(1,"test2","",vec!(),&|_| { Ok(vec![]) });
-                st.jump(Rvalue::new_u32(0),Guard::always());
+                st.mnemonic(1,"test2","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(0),Guard::always()).unwrap();
                 true
             }
         );
@@ -943,18 +941,18 @@ mod tests {
     fn empty() {
         let main = new_disassembler!(TestArchShort =>
             [ 0 ] = |st: &mut State<TestArchShort>| {
-                st.mnemonic(1,"test0","",vec!(),&|_| { Ok(vec![]) });
-                st.jump(Rvalue::new_u32(1),Guard::always());
+                st.mnemonic(1,"test0","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(1),Guard::always()).unwrap();
                 true
             },
             [ 1 ] = |st: &mut State<TestArchShort>| {
-                st.mnemonic(1,"test1","",vec!(),&|_| { Ok(vec![]) });
-                st.jump(Rvalue::new_u32(2),Guard::always());
+                st.mnemonic(1,"test1","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(2),Guard::always()).unwrap();
                 true
             },
             [ 2 ] = |st: &mut State<TestArchShort>| {
-                st.mnemonic(1,"test2","",vec!(),&|_| { Ok(vec![]) });
-                st.jump(Rvalue::new_u32(0),Guard::always());
+                st.mnemonic(1,"test2","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(0),Guard::always()).unwrap();
                 true
             }
         );
@@ -986,18 +984,18 @@ mod tests {
 
         let main = new_disassembler!(TestArchShort =>
             [ 0 ] = |st: &mut State<TestArchShort>| {
-                st.mnemonic(1,"test0","",vec!(),&|_| { Ok(vec![]) });
-                st.jump(Rvalue::new_u32(1),Guard::always());
+                st.mnemonic(1,"test0","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(1),Guard::always()).unwrap();
                 true
             },
             [ 1 ] = |st: &mut State<TestArchShort>| {
-                st.mnemonic(1,"test1","",vec!(),&|_| { Ok(vec![]) });
-                st.jump(Rvalue::new_u32(2),Guard::always());
+                st.mnemonic(1,"test1","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(2),Guard::always()).unwrap();
                 true
             },
             [ 2 ] = |st: &mut State<TestArchShort>| {
-                st.mnemonic(1,"test2","",vec!(),&|_| { Ok(vec![]) });
-                st.jump(Rvalue::new_u32(1),Guard::always());
+                st.mnemonic(1,"test2","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(1),Guard::always()).unwrap();
                 true
             }
         );
@@ -1057,23 +1055,23 @@ mod tests {
             [0x2211] = |s: &mut State<TestArchWide>|
             {
                 let a = s.address;
-                s.mnemonic(2,"A","",vec!(),&|_| { Ok(vec![]) });
-                s.jump(Rvalue::new_u64(a + 2),Guard::always());
+                s.mnemonic(2,"A","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                s.jump(Rvalue::new_u64(a + 2),Guard::always()).unwrap();
                 true
             },
 
             [0x4433] = |s: &mut State<TestArchWide>|
             {
                 let a = s.address;
-                s.mnemonic(2,"B","",vec!(),&|_| { Ok(vec![]) });
-                s.jump(Rvalue::new_u64(a + 2),Guard::always());
-                s.jump(Rvalue::new_u64(a + 4),Guard::always());
+                s.mnemonic(2,"B","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                s.jump(Rvalue::new_u64(a + 2),Guard::always()).unwrap();
+                s.jump(Rvalue::new_u64(a + 4),Guard::always()).unwrap();
                 true
             },
 
             [0x4455] = |s: &mut State<TestArchWide>|
             {
-                s.mnemonic(2, "C","",vec!(),&|_| { Ok(vec![]) });
+                s.mnemonic(2, "C","",vec!(),&|_| { Ok(vec![]) }).unwrap();
                 true
             }
         );
@@ -1114,18 +1112,18 @@ mod tests {
     fn issue_51_treat_entry_point_as_incoming_edge() {
         let main = new_disassembler!(TestArchShort =>
             [ 0 ] = |st: &mut State<TestArchShort>| {
-                st.mnemonic(1,"test0","",vec!(),&|_| { Ok(vec![]) });
-                st.jump(Rvalue::new_u32(1),Guard::always());
+                st.mnemonic(1,"test0","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(1),Guard::always()).unwrap();
                 true
             },
             [ 1 ] = |st: &mut State<TestArchShort>| {
-                st.mnemonic(1,"test1","",vec!(),&|_| { Ok(vec![]) });
-                st.jump(Rvalue::new_u32(2),Guard::always());
+                st.mnemonic(1,"test1","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(2),Guard::always()).unwrap();
                 true
             },
             [ 2 ] = |st: &mut State<TestArchShort>| {
-                st.mnemonic(1,"test2","",vec!(),&|_| { Ok(vec![]) });
-                st.jump(Rvalue::new_u32(0),Guard::always());
+                st.mnemonic(1,"test2","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(0),Guard::always()).unwrap();
                 true
             }
         );
@@ -1168,18 +1166,18 @@ mod tests {
     fn issue_232_overlap_with_entry_point() {
         let main = new_disassembler!(TestArchShort =>
             [ 0, 1 ] = |st: &mut State<TestArchShort>| {
-                st.mnemonic(2,"test01","",vec!(),&|_| { Ok(vec![]) });
-                st.jump(Rvalue::new_u32(2),Guard::always());
+                st.mnemonic(2,"test01","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(2),Guard::always()).unwrap();
                 true
             },
             [ 1 ] = |st: &mut State<TestArchShort>| {
-                st.mnemonic(1,"test1","",vec!(),&|_| { Ok(vec![]) });
-                st.jump(Rvalue::new_u32(2),Guard::always());
+                st.mnemonic(1,"test1","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(2),Guard::always()).unwrap();
                 true
             },
             [ 2 ] = |st: &mut State<TestArchShort>| {
-                st.mnemonic(1,"test2","",vec!(),&|_| { Ok(vec![]) });
-                st.jump(Rvalue::new_u32(0),Guard::always());
+                st.mnemonic(1,"test2","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(0),Guard::always()).unwrap();
                 true
             }
         );

--- a/lib/src/layer.rs
+++ b/lib/src/layer.rs
@@ -244,7 +244,8 @@ impl OpaqueLayer {
     /// `path`. The `Layer` will have the size of the file.
     pub fn open(p: &Path) -> Result<OpaqueLayer> {
         let mut buf: Vec<u8> = Vec::new();
-        try!(File::open(p).map(|ref mut f| f.read_to_end(&mut buf)));
+        let mut fd = File::open(p)?;
+        fd.read_to_end(&mut buf)?;
         Ok(Self::wrap(buf))
     }
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -92,6 +92,7 @@ extern crate lazy_static;
 extern crate byteorder;
 extern crate goblin;
 
+#[cfg(test)]
 #[macro_use]
 extern crate quickcheck;
 

--- a/qt/src/controller.rs
+++ b/qt/src/controller.rs
@@ -22,9 +22,8 @@ use std::sync::{
 use std::collections::BTreeMap;
 use std::path::{PathBuf,Path};
 use std::iter::FromIterator;
-use std::fs::{remove_file,DirBuilder};
+use std::fs::{remove_file};
 use std::error::Error;
-use std::borrow::Cow;
 use std::convert::Into;
 
 use libc::c_int;
@@ -32,7 +31,6 @@ use qmlrs::{ffi,MetaObject,Variant,Object,ToQVariant,unpack_varlist};
 use rustc_serialize::{json,Encodable};
 use tempdir::TempDir;
 
-use panopticon::result;
 use panopticon::{
     Project,
     Result,
@@ -285,7 +283,7 @@ impl Controller {
         }
     }
 
-    pub fn instantiate_singleton(_: MetaObject, mut s: Object) -> Result<()> {
+    pub fn instantiate_singleton(_: MetaObject, s: Object) -> Result<()> {
         {
             let mut guard = try!(CONTROLLER.write());
 
@@ -311,7 +309,7 @@ impl Controller {
                 },
             }
             Ok(())
-        }.and_then(|t| {
+        }.and_then(|_t| {
             Controller::update_state()
         })
     }

--- a/qt/src/function.rs
+++ b/qt/src/function.rs
@@ -27,7 +27,8 @@ use panopticon::{
     Kset,
 };
 
-use std::hash::{Hash,Hasher,SipHasher};
+use std::hash::{Hash,Hasher};
+use std::collections::hash_map::DefaultHasher;
 use std::thread;
 use std::fs;
 use std::path::{PathBuf};
@@ -738,8 +739,8 @@ fn to_ident(t: &ControlFlowTarget) -> String {
         &ControlFlowTarget::Resolved(ref bb) =>
             format!("bb{}",bb.area.start),
         &ControlFlowTarget::Unresolved(ref c) => {
-            let ref mut h = SipHasher::new();
-            c.hash::<SipHasher>(h);
+            let ref mut h = DefaultHasher::new();
+            c.hash::<DefaultHasher>(h);
             format!("c{}",h.finish())
         }
         &ControlFlowTarget::Failed(ref pos,_) =>
@@ -1002,7 +1003,6 @@ struct SessionInfo {
 }
 
 pub fn sessions() -> Variant {
-    use std::time::SystemTime;
     use chrono;
     use chrono_humanize::HumanTime;
     use paths::session_directory;

--- a/qt/src/main.rs
+++ b/qt/src/main.rs
@@ -117,7 +117,7 @@ fn main() {
             let request = format!("{{\"kind\": \"{}\", \"path\": \"{}\"}}",
                 fileformat.to_string(),
                 input_file_path);
-            Controller::set_request(&request);
+            Controller::set_request(&request).unwrap();
             let mut engine = qmlrs::Engine::new("Panopticon");
             engine.load_local_file(&format!("{}",window.display()));
             engine.exec();

--- a/qt/src/paths.rs
+++ b/qt/src/paths.rs
@@ -20,7 +20,7 @@ use panopticon::result;
 use panopticon::result::Result;
 
 use std::env;
-use std::fs::{File,DirBuilder};
+use std::fs::{DirBuilder};
 use std::path::{PathBuf,Path};
 use std::borrow::Cow;
 use std::error::Error;
@@ -93,7 +93,6 @@ pub fn find_data_file(p: &Path) -> Result<Option<PathBuf>> {
 
 #[cfg(all(unix,not(target_os = "macos")))]
 fn find_data_file_impl(p: &Path) -> Result<Option<PathBuf>> {
-    use std::env;
     match BaseDirectories::with_prefix("panopticon") {
         Ok(dirs) => Ok(dirs.find_data_file(p)),
         Err(e) => Err(result::Error(Cow::Owned(e.description().to_string()))),

--- a/qt/src/paths.rs
+++ b/qt/src/paths.rs
@@ -25,11 +25,9 @@ use std::path::{PathBuf,Path};
 use std::borrow::Cow;
 use std::error::Error;
 
-#[cfg(unix)]
-use xdg::BaseDirectories;
-
 #[cfg(all(unix,not(target_os = "macos")))]
 pub fn session_directory() -> Result<PathBuf> {
+    use xdg::BaseDirectories;
     match BaseDirectories::with_prefix("panopticon") {
         Ok(dirs) => {
             let ret = dirs.get_data_home().join("sessions");
@@ -93,6 +91,7 @@ pub fn find_data_file(p: &Path) -> Result<Option<PathBuf>> {
 
 #[cfg(all(unix,not(target_os = "macos")))]
 fn find_data_file_impl(p: &Path) -> Result<Option<PathBuf>> {
+    use xdg::BaseDirectories;
     match BaseDirectories::with_prefix("panopticon") {
         Ok(dirs) => Ok(dirs.find_data_file(p)),
         Err(e) => Err(result::Error(Cow::Owned(e.description().to_string()))),

--- a/qt/src/project.rs
+++ b/qt/src/project.rs
@@ -30,7 +30,6 @@ use panopticon::{
     Layer,
     Region,
     Bound,
-    World,
     approximate,
     Kset,
 };
@@ -42,7 +41,6 @@ use panopticon::loader;
 use std::path::Path;
 use std::thread;
 use std::collections::{
-    HashMap,
     HashSet,
 };
 use std::fmt::Debug;
@@ -198,8 +196,6 @@ pub fn set_request(_req: &Variant) -> Variant {
 
 /// Starts disassembly
 pub fn spawn_disassembler<A: 'static + Architecture + Debug>(_cfg: A::Configuration) where A::Configuration: Debug + Sync, A::Token: Sync + Send {
-    use std::sync::Mutex;
-
     thread::spawn(move || -> Result<()> {
         let maybe_prog_uuid = try!(Controller::read(|proj| {
             proj.code.first().map(|x| x.uuid)
@@ -280,7 +276,7 @@ pub fn spawn_disassembler<A: 'static + Architecture + Debug>(_cfg: A::Configurat
 
                             while !fixpoint {
                                 fixpoint = true;
-                                ssa_convertion(&mut func);
+                                ssa_convertion(&mut func).unwrap();
 
                                 let vals = try!(approximate::<Kset>(&func));
                                 let vxs = { func.cflow_graph.vertices().collect::<Vec<_>>() };

--- a/tests/amd64.rs
+++ b/tests/amd64.rs
@@ -668,8 +668,8 @@ macro_rules! rappel_xcheck {
                     let a = ops.get(0).cloned().unwrap().unwrap();
                     let b = ops.get(1).cloned().unwrap().unwrap();
 
-                    discard |= (stringify!($mne) == "movsx" && size(&a) <= size(&b));
-                    discard |= (stringify!($mne) == "movzx" && size(&a) <= size(&b));
+                    discard |= stringify!($mne) == "movsx" && size(&a) <= size(&b);
+                    discard |= stringify!($mne) == "movzx" && size(&a) <= size(&b);
 
                     if !discard {
                         let ret = rappel_xcheck(stringify!($mne),semantic::$sem,a,b,ctx);

--- a/tests/amd64.rs
+++ b/tests/amd64.rs
@@ -21,8 +21,6 @@ extern crate panopticon;
 
 extern crate env_logger;
 extern crate regex;
-
-#[macro_use]
 extern crate quickcheck;
 
 use panopticon::{

--- a/tests/avr.rs
+++ b/tests/avr.rs
@@ -21,7 +21,6 @@ extern crate graph_algos;
 
 use panopticon::region::Region;
 use panopticon::avr::{Mcu,Avr};
-use panopticon::avr::syntax::disassembler;
 use panopticon::function::{ControlFlowTarget,Function};
 use panopticon::loader;
 


### PR DESCRIPTION
**Please review**:

There are two warnings left; I don't know how to fix them, they seem spurious to me.

1. adds unwraps to mos/avr semantics
2. removes unused imports
3. removes unused mutations
4. adds some minor docs
5. adds allow empty docs to `abstractinterp` because i don't know how to doc it
6. other misc changes

I don't want to do this again; we need to make buildbox fail on warnings after above two warnings fixed.

Also if you want to change something, please just update the PR with the commits that change it how you want; e.g., I suspect the unwraps are undesirable, but this would require larger refactor of changing function type and I didn't feel like messing with it cause I don't know that code