### PR TITLE
simple command line interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "hamt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,10 +354,12 @@ dependencies = [
  "error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hamt 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "multimap 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "panopticon-abstract-interp 0.16.0",
  "panopticon-amd64 0.16.0",
  "panopticon-analysis 0.16.0",
@@ -421,6 +428,18 @@ dependencies = [
 [[package]]
 name = "panopticon-cli"
 version = "0.16.0"
+dependencies = [
+ "clap 2.24.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "panopticon-amd64 0.16.0",
+ "panopticon-analysis 0.16.0",
+ "panopticon-avr 0.16.0",
+ "panopticon-core 0.16.0",
+ "panopticon-graph-algos 0.11.0",
+]
 
 [[package]]
 name = "panopticon-core"
@@ -796,6 +815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum futures-cpupool 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a283c84501e92cade5ea673a2a7ca44f71f209ccdd302a3e0896f50083d2c5ff"
 "checksum gcc 0.3.50 (registry+https://github.com/rust-lang/crates.io-index)" = "5f837c392f2ea61cb1576eac188653df828c861b7137d74ea4a5caa89621f9e6"
 "checksum goblin 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "4023288fcdb49f38f7b15887078b922bb9e96b9d9b33dbb17eb61cb7b2578ba2"
+"checksum hamt 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a348cf9404ba4aeff9fe6f5e9f5d12eaf236b5e51f129f876e8666af7e21cb50"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,3 +7,13 @@ authors = ["seu <seu@panopticon.re>"]
 name = "panop"
 
 [dependencies]
+clap = "2.24"
+error-chain = "0.8"
+futures = "0.1"
+panopticon-core = { path = "../core" }
+panopticon-analysis = { path = "../analysis" }
+panopticon-amd64 = { path = "../amd64" }
+panopticon-avr = { path = "../avr" }
+panopticon-graph-algos = { path = "../graph-algos" }
+log = "0.3"
+env_logger = "0.3"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,87 @@
+#[macro_use]
+extern crate clap;
+#[macro_use]
+extern crate error_chain;
+extern crate panopticon_core;
+extern crate panopticon_amd64;
+extern crate panopticon_avr;
+extern crate panopticon_analysis;
+extern crate panopticon_graph_algos;
+extern crate futures;
+#[macro_use]
+extern crate log;
+extern crate env_logger;
+
+use std::result;
+use std::path::Path;
+use panopticon_core::{Machine, loader};
+use panopticon_amd64 as amd64;
+use panopticon_avr as avr;
+use panopticon_analysis::pipeline;
+use panopticon_graph_algos::{GraphTrait};
+use futures::Stream;
+
+mod errors {
+    error_chain! {
+        foreign_links {
+            Panopticon(::panopticon_core::Error);
+        }
+    }
+}
+use errors::*;
+
 fn main() {
-    println!("Hello, world!");
+    env_logger::init().unwrap();
+
+    let matches = clap_app!(Panopticon =>
+        (version: "0.1")
+        (about: "A libre cross-platform disassembler.")
+        (@arg INPUT: +required ... {exists_path_val} "Files to disassemble")
+    ).get_matches();
+
+    if let Some(vals) = matches.values_of("INPUT") {
+        for p in vals.map(str::to_string) {
+            info!("{}",p);
+
+            match disassemble(&p) {
+                Ok(()) => {}
+                Err(s) => {
+                    error!("Error: {}",s);
+                    return;
+                }
+            }
+        }
+    }
+}
+
+fn exists_path_val(filepath: String) -> result::Result<(), String> {
+    match Path::new(&filepath).is_file() {
+        true => Ok(()),
+        false => Err(format!("'{}': no such file", filepath)),
+    }
+}
+
+fn disassemble(p: &String) -> Result<()> {
+    let (mut proj, machine) = loader::load(Path::new(p))?;
+    let maybe_prog = proj.code.pop();
+    let reg = proj.data.dependencies.vertex_label(proj.data.root).unwrap().clone();
+
+    if let Some(prog) = maybe_prog {
+        let pipe = match machine {
+            Machine::Avr => pipeline::<avr::Avr>(prog, reg.clone(), avr::Mcu::atmega103()),
+            Machine::Ia32 => pipeline::<amd64::Amd64>(prog, reg.clone(), amd64::Mode::Protected),
+            Machine::Amd64 => pipeline::<amd64::Amd64>(prog, reg.clone(), amd64::Mode::Long),
+        };
+
+        info!("disassembly thread started");
+        for i in pipe.wait() {
+            if let Ok(func) = i {
+                info!("{}",func.uuid);
+            }
+        }
+        info!("disassembly thread finished");
+
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
The cli is back! Now that we can use multiple crates I added a simple command line interface that disassembles a file. I agree that's better for experimentation than using the GUI.

Start with `cargo run -p panopticon-cli`. Use RUST_LOG=info for more useless output.