### PR TITLE
add CLI component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,6 @@ dependencies = [
 name = "panopticon-cli"
 version = "0.16.0"
 dependencies = [
- "clap 2.24.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -439,6 +438,8 @@ dependencies = [
  "panopticon-avr 0.16.0",
  "panopticon-core 0.16.0",
  "panopticon-graph-algos 0.11.0",
+ "structopt 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -668,6 +669,23 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "structopt"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "clap 2.24.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "syn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +874,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum smallvec 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2e40af10aafe98b4d8294ae8388d8a5cd0707c65d364872efe72d063ec44bee0"
 "checksum stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15132e0e364248108c5e2c02e3ab539be8d6f5d52a01ca9bbf27ed657316f02b"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
+"checksum structopt 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "79f07532bff6d657b904f2e6258f7b51aa62ba95ac623bed728decbaf29ca499"
+"checksum structopt-derive 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "294512063cbbe2eaf048f2daaa861da940315cc210cfa85d0117002352aa68dd"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "hamt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,10 +354,12 @@ dependencies = [
  "error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hamt 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "multimap 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "panopticon-abstract-interp 0.16.0",
  "panopticon-amd64 0.16.0",
  "panopticon-analysis 0.16.0",
@@ -421,6 +428,18 @@ dependencies = [
 [[package]]
 name = "panopticon-cli"
 version = "0.16.0"
+dependencies = [
+ "clap 2.24.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "panopticon-amd64 0.16.0",
+ "panopticon-analysis 0.16.0",
+ "panopticon-avr 0.16.0",
+ "panopticon-core 0.16.0",
+ "panopticon-graph-algos 0.11.0",
+]
 
 [[package]]
 name = "panopticon-core"
@@ -796,6 +815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum futures-cpupool 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a283c84501e92cade5ea673a2a7ca44f71f209ccdd302a3e0896f50083d2c5ff"
 "checksum gcc 0.3.50 (registry+https://github.com/rust-lang/crates.io-index)" = "5f837c392f2ea61cb1576eac188653df828c861b7137d74ea4a5caa89621f9e6"
 "checksum goblin 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "4023288fcdb49f38f7b15887078b922bb9e96b9d9b33dbb17eb61cb7b2578ba2"
+"checksum hamt 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a348cf9404ba4aeff9fe6f5e9f5d12eaf236b5e51f129f876e8666af7e21cb50"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"

--- a/analysis/src/pipeline.rs
+++ b/analysis/src/pipeline.rs
@@ -25,11 +25,12 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::iter::FromIterator;
 use std::thread;
+use std::sync::Arc;
 
 /// Starts disassembling insructions in `region` and puts them into `program`. Returns a stream of
 /// of newly discovered functions.
 pub fn pipeline<A: Architecture + Debug + 'static>(
-    program: Program,
+    program: Arc<Program>,
     region: Region,
     config: A::Configuration,
 ) -> Box<Stream<Item = Function, Error = ()> + Send>

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,3 +7,13 @@ authors = ["seu <seu@panopticon.re>"]
 name = "panop"
 
 [dependencies]
+clap = "2.24"
+error-chain = "0.8"
+futures = "0.1"
+panopticon-core = { path = "../core" }
+panopticon-analysis = { path = "../analysis" }
+panopticon-amd64 = { path = "../amd64" }
+panopticon-avr = { path = "../avr" }
+panopticon-graph-algos = { path = "../graph-algos" }
+log = "0.3"
+env_logger = "0.3"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,7 +7,8 @@ authors = ["seu <seu@panopticon.re>"]
 name = "panop"
 
 [dependencies]
-clap = "2.24"
+structopt = "0.0.5"
+structopt-derive = "0.0.5"
 error-chain = "0.8"
 futures = "0.1"
 panopticon-core = { path = "../core" }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,87 @@
+#[macro_use]
+extern crate clap;
+#[macro_use]
+extern crate error_chain;
+extern crate panopticon_core;
+extern crate panopticon_amd64;
+extern crate panopticon_avr;
+extern crate panopticon_analysis;
+extern crate panopticon_graph_algos;
+extern crate futures;
+#[macro_use]
+extern crate log;
+extern crate env_logger;
+
+use std::result;
+use std::path::Path;
+use panopticon_core::{Machine, loader};
+use panopticon_amd64 as amd64;
+use panopticon_avr as avr;
+use panopticon_analysis::pipeline;
+use panopticon_graph_algos::{GraphTrait};
+use futures::Stream;
+
+mod errors {
+    error_chain! {
+        foreign_links {
+            Panopticon(::panopticon_core::Error);
+        }
+    }
+}
+use errors::*;
+
 fn main() {
-    println!("Hello, world!");
+    env_logger::init().unwrap();
+
+    let matches = clap_app!(Panopticon =>
+        (version: "0.1")
+        (about: "A libre cross-platform disassembler.")
+        (@arg INPUT: +required ... {exists_path_val} "Files to disassemble")
+    ).get_matches();
+
+    if let Some(vals) = matches.values_of("INPUT") {
+        for p in vals.map(str::to_string) {
+            info!("{}",p);
+
+            match disassemble(&p) {
+                Ok(()) => {}
+                Err(s) => {
+                    error!("Error: {}",s);
+                    return;
+                }
+            }
+        }
+    }
+}
+
+fn exists_path_val(filepath: String) -> result::Result<(), String> {
+    match Path::new(&filepath).is_file() {
+        true => Ok(()),
+        false => Err(format!("'{}': no such file", filepath)),
+    }
+}
+
+fn disassemble(p: &String) -> Result<()> {
+    let (mut proj, machine) = loader::load(Path::new(p))?;
+    let maybe_prog = proj.code.pop();
+    let reg = proj.data.dependencies.vertex_label(proj.data.root).unwrap().clone();
+
+    if let Some(prog) = maybe_prog {
+        let pipe = match machine {
+            Machine::Avr => pipeline::<avr::Avr>(prog, reg.clone(), avr::Mcu::atmega103()),
+            Machine::Ia32 => pipeline::<amd64::Amd64>(prog, reg.clone(), amd64::Mode::Protected),
+            Machine::Amd64 => pipeline::<amd64::Amd64>(prog, reg.clone(), amd64::Mode::Long),
+        };
+
+        info!("disassembly thread started");
+        for i in pipe.wait() {
+            if let Ok(func) = i {
+                info!("{}",func.uuid);
+            }
+        }
+        info!("disassembly thread finished");
+
+    }
+
+    Ok(())
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,6 @@
+extern crate structopt;
 #[macro_use]
-extern crate clap;
+extern crate structopt_derive;
 #[macro_use]
 extern crate error_chain;
 extern crate panopticon_core;
@@ -20,6 +21,7 @@ use panopticon_avr as avr;
 use panopticon_analysis::pipeline;
 use panopticon_graph_algos::{GraphTrait};
 use futures::Stream;
+use structopt::StructOpt;
 
 mod errors {
     error_chain! {
@@ -30,39 +32,26 @@ mod errors {
 }
 use errors::*;
 
-fn main() {
-    env_logger::init().unwrap();
-
-    let matches = clap_app!(Panopticon =>
-        (version: "0.1")
-        (about: "A libre cross-platform disassembler.")
-        (@arg INPUT: +required ... {exists_path_val} "Files to disassemble")
-    ).get_matches();
-
-    if let Some(vals) = matches.values_of("INPUT") {
-        for p in vals.map(str::to_string) {
-            info!("{}",p);
-
-            match disassemble(&p) {
-                Ok(()) => {}
-                Err(s) => {
-                    error!("Error: {}",s);
-                    return;
-                }
-            }
-        }
-    }
+#[derive(StructOpt, Debug)]
+#[structopt(name = "panop", about = "A libre cross-platform disassembler.")]
+struct Args {
+    /// The specific function to disassemble
+    #[structopt(short = "f", long = "function", help = "Disassemble the given function")]
+    function: Option<String>,
+    /// The binary to disassemble
+    #[structopt(help = "The binary to disassemble")]
+    binary: String,
 }
 
-fn exists_path_val(filepath: String) -> result::Result<(), String> {
-    match Path::new(&filepath).is_file() {
+fn exists_path_val(filepath: &str) -> result::Result<(), String> {
+    match Path::new(filepath).is_file() {
         true => Ok(()),
         false => Err(format!("'{}': no such file", filepath)),
     }
 }
 
-fn disassemble(p: &String) -> Result<()> {
-    let (mut proj, machine) = loader::load(Path::new(p))?;
+fn disassemble(binary: &str, filter: &Option<String>) -> Result<()> {
+    let (mut proj, machine) = loader::load(Path::new(binary))?;
     let maybe_prog = proj.code.pop();
     let reg = proj.data.dependencies.vertex_label(proj.data.root).unwrap().clone();
 
@@ -77,11 +66,32 @@ fn disassemble(p: &String) -> Result<()> {
         for i in pipe.wait() {
             if let Ok(func) = i {
                 info!("{}",func.uuid);
+                if let &Some(ref filter) = filter {
+                    if func.name.as_str() == filter {
+                        info!("Filter matches {} - {:?}", func.name, func.cflow_graph);
+                    }
+                }
             }
         }
         info!("disassembly thread finished");
-
     }
 
     Ok(())
+}
+
+fn run(args: Args) -> Result<()> {
+    exists_path_val(&args.binary)?;
+    disassemble(&args.binary, &args.function)?;
+    Ok(())
+}
+
+fn main() {
+    env_logger::init().unwrap();
+    match run(Args::from_args()) {
+        Ok(()) => {}
+        Err(s) => {
+            error!("Error: {}",s);
+            ::std::process::exit(1);
+        }
+    }
 }

--- a/core/src/basic_block.rs
+++ b/core/src/basic_block.rs
@@ -22,7 +22,7 @@
 //! Basic blocks always occupy a continuous byte range.
 
 
-use {Bound, Mnemonic, Statement};
+use {Bound, Mnemonic, Statement, Program};
 use std::cmp::{max, min};
 
 /// A basic block: a continiuous sequence of mnemonics without any branches in between.
@@ -90,6 +90,20 @@ impl BasicBlock {
                 f(i);
             }
         }
+    }
+    /// Displays the basic block in disassembly order, in human readable form, and looks up any functions calls in `program`
+    pub fn display_with(&self, program: &Program) -> String {
+        let seed = String::new();
+        let display = self.mnemonics.iter().filter_map(|x| {
+            if x.opcode.starts_with("__") {
+                None
+            } else {
+                Some(x)
+            }
+        }).collect::<Vec<_>>();
+        display.iter().fold(seed, |acc, ref m| -> String {
+            format!("{}\n{}", acc, m.display_with(program))
+        })
     }
 }
 

--- a/core/src/function.rs
+++ b/core/src/function.rs
@@ -28,7 +28,7 @@
 //! on the front-end.
 
 
-use {Architecture, BasicBlock, Guard, Mnemonic, Operation, Region, Rvalue, Statement};
+use {Architecture, BasicBlock, Guard, Mnemonic, Operation, Region, Rvalue, Statement, Program};
 
 use panopticon_graph_algos::{AdjacencyList, EdgeListGraphTrait, GraphTrait, MutableGraphTrait, VertexListGraphTrait};
 use panopticon_graph_algos::adjacency_list::{AdjacencyListEdgeDescriptor, AdjacencyListVertexDescriptor};
@@ -568,6 +568,28 @@ impl Function {
         }
 
         format!("{}\n}}", ret)
+    }
+
+    /// Displays the function in a human readable format, using `program`
+    pub fn display_with(&self, program: &Program) -> String {
+        let mut bbs = self.cflow_graph.vertices().filter_map(|v| {
+            match self.cflow_graph.vertex_label(v) {
+                Some(&ControlFlowTarget::Resolved(ref bb)) => {
+                    Some (bb)
+                },
+                _ => None
+            }
+        }).collect::<Vec<&BasicBlock>>();
+        bbs.sort_by(|bb1, bb2| bb1.area.start.cmp(&bb2.area.start));
+        let mut fmt = if let Some(bb) = bbs.first() {
+            format!("{:0>8x} <{}>:", bb.area.start, self.name)
+        } else {
+            format!("{}", self.name)
+        };
+        for bb in bbs {
+            fmt = format!("{}{}", fmt, bb.display_with(program));
+        }
+        fmt
     }
 }
 

--- a/qt/src/singleton.rs
+++ b/qt/src/singleton.rs
@@ -158,6 +158,7 @@ impl Panopticon {
             let reg = proj.data.dependencies.vertex_label(proj.data.root).unwrap().clone();
 
             if let Some(prog) = maybe_prog {
+                let prog = ::std::sync::Arc::new(prog);
                 let pipe = match machine {
                     Machine::Avr => pipeline::<avr::Avr>(prog, reg.clone(), avr::Mcu::atmega103()),
                     Machine::Ia32 => pipeline::<amd64::Amd64>(prog, reg.clone(), amd64::Mode::Protected),


### PR DESCRIPTION
I made several changes based on your branch:

1. switched to [structopt](https://docs.rs/structopt), which is easier and better to use for adding more command line functionality, and very easy to read imho.
2. switched to a main/run setup, and exit on error
3. unfortunately, I don't see any display logic for printing a disassembled function. I hope I just missed it, but I thought the point of adding a middle layer was to reuse assembly printers, etc., otherwise it's very tedious and repetitive.

For assembly printing, I implemented a `display_with` function on an older branch that took the program as an argument and printed it very nicely, but it needed the display structs and display logic that was originally in the qt/qml portion; I think we should move those display structs into pipeline and have them be reusable, otherwise the cli will fork on important issues, and will make maintenance harder IMHO

@flanfly what do you think?


--- META ---
Also, so I made this a branch on panopticon, can remove if you like, but I think we should consider this for development model; if your branch hadn't been from your own repo, I could in principle push commits to it directly (very nice for basic fixes, etc.), or make a PR merging commits into your branch; to do that against your own branch in your own repo is much harder, and not sure what the gain is.

_anyway_ if you don't like having branch on panopticon, I can delete this and push to my master, but again, i strongly urge to consider other development model.