### PR TITLE
cli: print function now colors cross platform.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,14 +166,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "colored"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "conv"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,7 +498,7 @@ dependencies = [
 name = "panopticon-cli"
 version = "0.16.0"
 dependencies = [
- "colored 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -518,6 +510,7 @@ dependencies = [
  "panopticon-graph-algos 0.11.0",
  "structopt 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt-derive 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -842,6 +835,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wincolor 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +934,15 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "wincolor"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "xdg"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,7 +968,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2267a8fdd4dce6956ba6649e130f62fb279026e5e84b92aa939ac8f85ce3f9f0"
 "checksum cmake 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ebbb35d3dc9cd09497168f33de1acb79b265d350ab0ac34133b98f8509af1f"
 "checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
-"checksum colored 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9d95596bdc53fde0e14c7dca1113a7784fcb2a9247676fb7415ee889b20de38a"
 "checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
 "checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
@@ -1025,6 +1034,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
 "checksum term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b6b55df3198cc93372e85dd2ed817f0e38ce8cc0f22eb32391bfad9c4bf209"
+"checksum termcolor 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9a5193a56b8d82014662c4b933dea6bec851daf018a2b01722e007daaf5f9dca"
 "checksum textwrap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f728584ea33b0ad19318e20557cb0a39097751dbb07171419673502f848c7af6"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread-id 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2af4d6289a69a35c4d3aea737add39685f2784122c28119a7713165a63d68c9d"
@@ -1038,4 +1048,5 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+"checksum wincolor 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a39ee4464208f6430992ff20154216ab2357772ac871d994c51628d60e58b8b0"
 "checksum xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a66b7c2281ebde13cf4391d70d4c7e5946c3c25e72a7b859ca8f677dcd0b0c61"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,4 +18,5 @@ panopticon-avr = { path = "../avr" }
 panopticon-graph-algos = { path = "../graph-algos" }
 log = "0.3"
 env_logger = "0.3"
-colored = "1.5"
+termcolor = "0.3.2"
+atty = "0.2.2"

--- a/cli/src/display.rs
+++ b/cli/src/display.rs
@@ -9,7 +9,7 @@ macro_rules! color_bold {
     ($fmt:ident, $color:ident, $str:expr) => ({
     $fmt.set_color(ColorSpec::new().set_bold(true).set_fg(Some($color)))?;
     write!($fmt, "{}", $str)?;
-    $fmt.reset()?;
+    $fmt.reset()
     })
 }
 
@@ -17,7 +17,7 @@ macro_rules! color {
     ($fmt:ident, $color:ident, $str:expr) => ({
         $fmt.set_color(ColorSpec::new().set_fg(Some($color)))?;
         write!($fmt, "{}", $str)?;
-        $fmt.reset()?;
+        $fmt.reset()
     })
 }
 
@@ -29,7 +29,7 @@ pub fn print_function(function: &Function, program: &Program, always_color: bool
     let mut bbs = function.basic_blocks().collect::<Vec<&BasicBlock>>();
     bbs.sort_by(|bb1, bb2| bb1.area.start.cmp(&bb2.area.start));
     write!(fmt, "{:0>8x} <", function.start())?;
-    color_bold!(fmt, Yellow, function.name);
+    color_bold!(fmt, Yellow, function.name)?;
     writeln!(fmt, ">:")?;
     for bb in bbs {
         display_basic_block(&mut fmt, &bb, program)?;
@@ -52,12 +52,12 @@ pub fn display_basic_block<W: Write + WriteColor>(fmt: &mut W, basic_block: &Bas
 pub fn display_mnemonic<W: Write + WriteColor>(fmt: &mut W, mnemonic: &Mnemonic, program: &Program) -> Result<()> {
     let mut ops = mnemonic.operands.iter();
     write!(fmt, "{:8x}: ", mnemonic.area.start)?;
-    color_bold!(fmt, Blue, mnemonic.opcode);
+    color_bold!(fmt, Blue, mnemonic.opcode)?;
     write!(fmt, " ")?;
     for token in &mnemonic.format_string {
         match token {
             &MnemonicFormatToken::Literal(ref s) => {
-                color_bold!(fmt, Green, s);
+                color_bold!(fmt, Green, s)?;
             },
             &MnemonicFormatToken::Variable{ ref has_sign } => {
                 match ops.next() {
@@ -69,16 +69,16 @@ pub fn display_mnemonic<W: Write + WriteColor>(fmt: &mut W, mnemonic: &Mnemonic,
                             } else { c };
                         let sign_bit = if s < 64 { 1u64 << (s - 1) } else { 0x8000000000000000 };
                         if !has_sign || val & sign_bit == 0 {
-                            color!(fmt, Red, format!("{:x}", val));
+                            color!(fmt, Red, format!("{:x}", val))?;
                         } else {
-                            color!(fmt, White, format!("{:x}", (val as i64).wrapping_neg()));
+                            color!(fmt, White, format!("{:x}", (val as i64).wrapping_neg()))?;
                         }
                     },
                     Some(&Rvalue::Variable{ ref name, subscript: Some(ref _subscript),.. }) => {
-                        color_bold!(fmt, White, &name.to_lowercase());
+                        color_bold!(fmt, White, &name.to_lowercase())?;
                     },
                     _ => {
-                        color!(fmt, Black, "?");
+                        color!(fmt, Black, "?")?;
                     }
                 }
             },
@@ -92,28 +92,28 @@ pub fn display_mnemonic<W: Write + WriteColor>(fmt: &mut W, mnemonic: &Mnemonic,
                             } else { c };
                         if is_code {
                             if let Some(function) = program.find_function_by(|f| { f.start() == val }) {
-                                color!(fmt, Red, format!("{:x}",val));
+                                color!(fmt, Red, format!("{:x}",val))?;
                                 write!(fmt, " <", )?;
-                                color_bold!(fmt, Yellow, function.name);
+                                color_bold!(fmt, Yellow, function.name)?;
                                 write!(fmt, ">")?;
                             } else {
-                                color_bold!(fmt, Magenta, format!("{:x}",val));
+                                color_bold!(fmt, Magenta, format!("{:x}",val))?;
                             }
                         } else {
                             write!(fmt, "{}", format!("{:#x}",val))?;
                         }
                     },
                     Some(&Rvalue::Variable{ ref name, subscript: Some(_),.. }) => {
-                        color!(fmt, Yellow, name.to_lowercase());
+                        color!(fmt, Yellow, name.to_lowercase())?;
                     },
                     Some(&Rvalue::Variable{ ref name, .. }) => {
-                        color!(fmt, Yellow, name.to_lowercase());
+                        color!(fmt, Yellow, name.to_lowercase())?;
                     },
                     Some(&Rvalue::Undefined) => {
-                        color_bold!(fmt, Red, "undefined");
+                        color_bold!(fmt, Red, "undefined")?;
                     },
                     None => {
-                        color!(fmt, Black, "?");
+                        color!(fmt, Black, "?")?;
                     }
                 }
             }

--- a/cli/src/display.rs
+++ b/cli/src/display.rs
@@ -21,9 +21,9 @@ macro_rules! color {
     })
 }
 
-/// Displays the function in a human readable format, using `program`
+/// Prints the function in a human readable format, using `program`, with colors. If `always_color` is set, it will force printing, even to non ttys.
 pub fn print_function(function: &Function, program: &Program, always_color: bool) -> Result<()> {
-    let cc = if always_color || atty::is(atty::Stream::Stdout) { ColorChoice::Auto }else { ColorChoice::Never };
+    let cc = if always_color || atty::is(atty::Stream::Stdout) { ColorChoice::Auto } else { ColorChoice::Never };
     let writer = BufferWriter::stdout(cc);
     let mut fmt = writer.buffer();
     let mut bbs = function.basic_blocks().collect::<Vec<&BasicBlock>>();
@@ -38,7 +38,7 @@ pub fn print_function(function: &Function, program: &Program, always_color: bool
     Ok(())
 }
 
-/// Displays the basic block in disassembly order, in human readable form, and looks up any functions calls in `program`
+/// Prints the basic block into `fmt`, in disassembly order, in human readable form, and looks up any functions calls in `program`
 pub fn display_basic_block<W: Write + WriteColor>(fmt: &mut W, basic_block: &BasicBlock, program: &Program) -> Result<()> {
     for x in basic_block.mnemonics.iter() {
         if !x.opcode.starts_with("__") {
@@ -48,7 +48,7 @@ pub fn display_basic_block<W: Write + WriteColor>(fmt: &mut W, basic_block: &Bas
     Ok(())
 }
 
-/// Displays the mnemonic in human readable form, and looks up any functions calls in `program`
+/// Prints the mnemonic into `fmt`, in human readable form, and looks up any functions calls in `program`
 pub fn display_mnemonic<W: Write + WriteColor>(fmt: &mut W, mnemonic: &Mnemonic, program: &Program) -> Result<()> {
     let mut ops = mnemonic.operands.iter();
     write!(fmt, "{:8x}: ", mnemonic.area.start)?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -72,7 +72,7 @@ impl Filter {
     }
     pub fn is_match(&self, func: &Function) -> bool {
         if let Some(ref name) = self.name {
-            if name == &func.name { return true }
+            if name == &func.name || func.aliases().contains(name){ return true }
         }
         if let Some(ref addr) = self.addr {
             return *addr == func.start()

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -38,13 +38,13 @@ use errors::*;
 #[derive(StructOpt, Debug)]
 #[structopt(name = "panop", about = "A libre cross-platform disassembler.")]
 struct Args {
-    #[structopt(long = "color", help = "Always color")]
+    #[structopt(long = "color", help = "Forces coloring, even when piping to a file, etc.")]
     color: bool,
     /// Print every function the function calls
     #[structopt(short = "c", long = "calls", help = "Print every address of every function this function calls")]
     calls: bool,
     /// The specific function to disassemble
-    #[structopt(short = "f", long = "function", help = "Disassemble the given function")]
+    #[structopt(short = "f", long = "function", help = "Disassemble the given function, or any of its aliases")]
     function_filter: Option<String>,
     /// The specific function address to disassemble
     #[structopt(short = "a", long = "address", help = "Disassemble the function at the given address")]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -12,7 +12,8 @@ extern crate futures;
 #[macro_use]
 extern crate log;
 extern crate env_logger;
-extern crate colored;
+extern crate termcolor;
+extern crate atty;
 
 use panopticon_amd64 as amd64;
 use panopticon_analysis::analyze;
@@ -37,6 +38,8 @@ use errors::*;
 #[derive(StructOpt, Debug)]
 #[structopt(name = "panop", about = "A libre cross-platform disassembler.")]
 struct Args {
+    #[structopt(long = "color", help = "Always color")]
+    color: bool,
     /// Print every function the function calls
     #[structopt(short = "c", long = "calls", help = "Print every address of every function this function calls")]
     calls: bool,
@@ -102,7 +105,7 @@ fn disassemble(args: Args) -> Result<()> {
     });
 
     for function in functions {
-        println!("{}", display::display_function(&function, &program));
+        display::print_function(&function, &program, args.color)?;
         if args.calls {
             let calls = function.collect_call_addresses();
             println!("Calls ({}):", calls.len());


### PR DESCRIPTION
adds `--color` flag to force color printing (e.g., useful if piped into `less -r`, or whatever)
