### PR TITLE
generic function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "ordermap"
-version = "0.2.13"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -445,7 +445,7 @@ dependencies = [
  "panopticon-graph-algos 0.11.0",
  "panopticon-mos6502 0.16.0",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quickcheck 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -474,7 +474,7 @@ dependencies = [
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "panopticon-core 0.16.0",
- "quickcheck 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -550,7 +550,7 @@ dependencies = [
  "num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "panopticon-avr 0.16.0",
  "panopticon-graph-algos 0.11.0",
- "petgraph 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.10 (git+https://github.com/m4b/petgraph?branch=dominance_frontiers)",
  "quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -570,7 +570,7 @@ dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "panopticon-core 0.16.0",
  "panopticon-graph-algos 0.11.0",
- "petgraph 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.10 (git+https://github.com/m4b/petgraph?branch=dominance_frontiers)",
  "smallvec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -631,11 +631,13 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.4.10"
+source = "git+https://github.com/m4b/petgraph?branch=dominance_frontiers#6ea8c947b679780ee156e445ea0edfa01676dcdc"
 dependencies = [
  "fixedbitset 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordermap 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -647,16 +649,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "plain"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "quickcheck"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "quickcheck"
@@ -1061,16 +1053,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-rational 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "288629c76fac4b33556f4b7ab57ba21ae202da65ba8b77466e6d598e31990790"
 "checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
 "checksum num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "514f0d73e64be53ff320680ca671b64fe3fb91da01e1ae2ddc99eb51d453b20d"
-"checksum ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b81cf3b8cb96aa0e73bbedfcdc9708d09fec2854ba8d474be4e6f666d7379e8b"
+"checksum ordermap 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8c7790b1bc9bf27776cd5cdeaae1263758c2c597d4ae02b58aa63c320f94d778"
 "checksum owning_ref 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9d52571ddcb42e9c900c901a18d8d67e393df723fcd51dd59c5b1a85d0acb6cc"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum parking_lot 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "fa12d706797d42551663426a45e2db2e0364bd1dbf6aeada87e89c5f981f43e9"
 "checksum parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "149d8f5b97f3c1133e3cfcd8886449959e856b557ff281e292b733d7c69e005e"
 "checksum parking_lot_core 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4f610cb9664da38e417ea3225f23051f589851999535290e077939838ab7a595"
-"checksum petgraph 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "2c960f99a9b3962c6a942e0e8f1f47fe72c82202dae8539ded32d3bb8c4e67d5"
+"checksum petgraph 0.4.10 (git+https://github.com/m4b/petgraph?branch=dominance_frontiers)" = "<none>"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum plain 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "da55423d5704ee357503ce020f88b90269610ec85708331e6a7879dd4cea3122"
-"checksum quickcheck 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0b333da40686cc05db13d933f8e7b450f403cfc5a4d005154d8d4a5ba9d14605"
 "checksum quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "02c2411d418cea2364325b18a205664f9ef8252e06b2e911db97c0b0d98b1406"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "61efcbcd9fa8d8fbb07c84e34a8af18a1ff177b449689ad38a6e9457ecc7b2ae"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,6 +528,7 @@ dependencies = [
  "panopticon-analysis 0.16.0",
  "panopticon-avr 0.16.0",
  "panopticon-core 0.16.0",
+ "panopticon-data-flow 0.16.0",
  "panopticon-graph-algos 0.11.0",
  "structopt 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt-derive 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,7 +512,7 @@ dependencies = [
  "panopticon-amd64 0.16.0",
  "panopticon-core 0.16.0",
  "panopticon-data-flow 0.16.0",
- "panopticon-graph-algos 0.11.0",
+ "petgraph 0.4.10 (git+https://github.com/m4b/petgraph?branch=dominance_frontiers)",
 ]
 
 [[package]]

--- a/amd64/Cargo.toml
+++ b/amd64/Cargo.toml
@@ -8,7 +8,7 @@ panopticon-core = { path = "../core" }
 log = "0.3.6"
 byteorder = "1"
 env_logger = "0.3"
-quickcheck = "0.3"
+quickcheck = "0.4"
 
 [dev-dependencies]
 regex = "0.1"

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["seu <seu@panopticon.re>"]
 panopticon-core = { path = "../core" }
 panopticon-data-flow = { path = "../data-flow" }
 panopticon-amd64 = { path = "../amd64" }
-panopticon-graph-algos = { path = "../graph-algos" }
+petgraph = { version = "0.4.10", features = ["serde-1"], git = "https://github.com/m4b/petgraph", branch = "dominance_frontiers" }
 bencher = "0.1.4"
 
 [[bench]]

--- a/benchmark/benches/core.rs
+++ b/benchmark/benches/core.rs
@@ -6,7 +6,7 @@ fn static_amd64_elf_new(b: &mut Bencher) {
     use panopticon_graph_algos::{VertexListGraphTrait,GraphTrait};
     use std::path::Path;
 
-    let (proj,_) = loader::load(Path::new("../test-data/static")).unwrap();
+    let (proj,_) = loader::load::<neo::Function>(Path::new("../test-data/static")).unwrap();
     let entries = proj.code[0].call_graph.vertices().filter_map(|vx| if let Some(&CallTarget::Todo(Rvalue::Constant{ value,.. },_,_)) = proj.code[0].call_graph.vertex_label(vx) { Some(value) } else { None }).collect::<Vec<_>>();
     let reg = proj.data.dependencies.vertex_label(proj.data.root).unwrap();
 
@@ -24,7 +24,7 @@ fn static_amd64_elf_old(b: &mut Bencher) {
     use panopticon_graph_algos::{VertexListGraphTrait,GraphTrait};
     use std::path::Path;
 
-    let (proj,_) = loader::load(Path::new("../test-data/static")).unwrap();
+    let (proj,_) = loader::load::<Function>(Path::new("../test-data/static")).unwrap();
     let entries = proj.code[0].call_graph.vertices().filter_map(|vx| if let Some(&CallTarget::Todo(Rvalue::Constant{ value,.. },_,_)) = proj.code[0].call_graph.vertex_label(vx) { Some(value) } else { None }).collect::<Vec<_>>();
     let reg = proj.data.dependencies.vertex_label(proj.data.root).unwrap();
 

--- a/benchmark/benches/core.rs
+++ b/benchmark/benches/core.rs
@@ -3,12 +3,11 @@ use panopticon_amd64 as amd64;
 
 fn static_amd64_elf_new(b: &mut Bencher) {
     use panopticon_core::{loader,neo,CallTarget,Rvalue};
-    use panopticon_graph_algos::{VertexListGraphTrait,GraphTrait};
     use std::path::Path;
 
     let (proj,_) = loader::load::<neo::Function>(Path::new("../test-data/static")).unwrap();
-    let entries = proj.code[0].call_graph.vertices().filter_map(|vx| if let Some(&CallTarget::Todo(Rvalue::Constant{ value,.. },_,_)) = proj.code[0].call_graph.vertex_label(vx) { Some(value) } else { None }).collect::<Vec<_>>();
-    let reg = proj.data.dependencies.vertex_label(proj.data.root).unwrap();
+    let entries = proj.code[0].iter_callgraph().filter_map(|vx| if let &CallTarget::Todo(Rvalue::Constant{ value,.. },_,_) = vx { Some (value) } else { None }).collect::<Vec<u64>>();
+    let reg = proj.region();
 
     b.bench_n(1,|b| {
         b.iter(|| {
@@ -21,12 +20,11 @@ fn static_amd64_elf_new(b: &mut Bencher) {
 
 fn static_amd64_elf_old(b: &mut Bencher) {
     use panopticon_core::{loader,Function,CallTarget,Rvalue};
-    use panopticon_graph_algos::{VertexListGraphTrait,GraphTrait};
     use std::path::Path;
 
     let (proj,_) = loader::load::<Function>(Path::new("../test-data/static")).unwrap();
-    let entries = proj.code[0].call_graph.vertices().filter_map(|vx| if let Some(&CallTarget::Todo(Rvalue::Constant{ value,.. },_,_)) = proj.code[0].call_graph.vertex_label(vx) { Some(value) } else { None }).collect::<Vec<_>>();
-    let reg = proj.data.dependencies.vertex_label(proj.data.root).unwrap();
+    let entries = proj.code[0].iter_callgraph().filter_map(|vx| if let &CallTarget::Todo(Rvalue::Constant{ value,.. },_,_) = vx { Some (value) } else { None }).collect::<Vec<u64>>();
+    let reg = proj.region();
 
     b.bench_n(1,|b| {
         b.iter(|| {

--- a/benchmark/benches/data_flow.rs
+++ b/benchmark/benches/data_flow.rs
@@ -40,6 +40,11 @@ fn ssa_convertion_old(b: &mut Bencher) {
 
     b.bench_n(1,|b| {
         b.iter(|| {
+            // NB: this is broken right now for old functions using petgraph, unwrap() on None
+            // 11: <petgraph::algo::dominators::Dominators<N>>::dominance_frontiers
+            // at /home/m4b/.cargo/git/checkouts/petgraph-d1e6db80f82b1362/6ea8c94/src/algo/dominators.rs:112
+            // 12: panopticon_data_flow::ssa::phi_functions
+            //  at /home/m4b/projects/panopticon/data-flow/src/ssa.rs:151
             for f in funcs.iter_mut() { f.ssa_conversion().unwrap(); }
         });
     });

--- a/benchmark/benches/data_flow.rs
+++ b/benchmark/benches/data_flow.rs
@@ -5,12 +5,11 @@ use panopticon_data_flow::neo::rewrite_to_ssa;
 
 fn ssa_convertion_new(b: &mut Bencher) {
     use panopticon_core::{loader,neo,CallTarget,Rvalue};
-    use panopticon_graph_algos::{VertexListGraphTrait,GraphTrait};
     use std::path::Path;
 
     let (proj,_) = loader::load::<neo::Function>(Path::new("../test-data/static")).unwrap();
-    let entries = proj.code[0].call_graph.vertices().filter_map(|vx| if let Some(&CallTarget::Todo(Rvalue::Constant{ value,.. },_,_)) = proj.code[0].call_graph.vertex_label(vx) { Some(value) } else { None }).collect::<Vec<_>>();
-    let reg = proj.data.dependencies.vertex_label(proj.data.root).unwrap();
+    let entries = proj.code[0].iter_callgraph().filter_map(|vx| if let &CallTarget::Todo(Rvalue::Constant{ value,.. },_,_) = vx { Some (value) } else { None }).collect::<Vec<_>>();
+    let reg = proj.region();
     let mut funcs = vec![];
 
     for &ep in entries.iter() {
@@ -27,12 +26,11 @@ fn ssa_convertion_new(b: &mut Bencher) {
 
 fn ssa_convertion_old(b: &mut Bencher) {
     use panopticon_core::{loader,Function,CallTarget,Rvalue};
-    use panopticon_graph_algos::{VertexListGraphTrait,GraphTrait};
     use std::path::Path;
 
     let (proj,_) = loader::load::<Function>(Path::new("../test-data/static")).unwrap();
-    let entries = proj.code[0].call_graph.vertices().filter_map(|vx| if let Some(&CallTarget::Todo(Rvalue::Constant{ value,.. },_,_)) = proj.code[0].call_graph.vertex_label(vx) { Some(value) } else { None }).collect::<Vec<_>>();
-    let reg = proj.data.dependencies.vertex_label(proj.data.root).unwrap();
+    let entries = proj.code[0].iter_callgraph().filter_map(|vx| if let &CallTarget::Todo(Rvalue::Constant{ value,.. },_,_) = vx { Some (value) } else { None }).collect::<Vec<_>>();
+    let reg = proj.region();
     let mut funcs = vec![];
 
     for &ep in entries.iter() {

--- a/benchmark/benches/data_flow.rs
+++ b/benchmark/benches/data_flow.rs
@@ -1,15 +1,14 @@
 use bencher::Bencher;
 use panopticon_amd64 as amd64;
-use panopticon_core::neo;
+use panopticon_data_flow::DataFlow;
 use panopticon_data_flow::neo::rewrite_to_ssa;
-use panopticon_data_flow::ssa_convertion;
 
 fn ssa_convertion_new(b: &mut Bencher) {
     use panopticon_core::{loader,neo,CallTarget,Rvalue};
     use panopticon_graph_algos::{VertexListGraphTrait,GraphTrait};
     use std::path::Path;
 
-    let (proj,_) = loader::load(Path::new("../test-data/static")).unwrap();
+    let (proj,_) = loader::load::<neo::Function>(Path::new("../test-data/static")).unwrap();
     let entries = proj.code[0].call_graph.vertices().filter_map(|vx| if let Some(&CallTarget::Todo(Rvalue::Constant{ value,.. },_,_)) = proj.code[0].call_graph.vertex_label(vx) { Some(value) } else { None }).collect::<Vec<_>>();
     let reg = proj.data.dependencies.vertex_label(proj.data.root).unwrap();
     let mut funcs = vec![];
@@ -31,7 +30,7 @@ fn ssa_convertion_old(b: &mut Bencher) {
     use panopticon_graph_algos::{VertexListGraphTrait,GraphTrait};
     use std::path::Path;
 
-    let (proj,_) = loader::load(Path::new("../test-data/static")).unwrap();
+    let (proj,_) = loader::load::<Function>(Path::new("../test-data/static")).unwrap();
     let entries = proj.code[0].call_graph.vertices().filter_map(|vx| if let Some(&CallTarget::Todo(Rvalue::Constant{ value,.. },_,_)) = proj.code[0].call_graph.vertex_label(vx) { Some(value) } else { None }).collect::<Vec<_>>();
     let reg = proj.data.dependencies.vertex_label(proj.data.root).unwrap();
     let mut funcs = vec![];
@@ -43,7 +42,7 @@ fn ssa_convertion_old(b: &mut Bencher) {
 
     b.bench_n(1,|b| {
         b.iter(|| {
-            for f in funcs.iter_mut() { ssa_convertion(f).unwrap(); }
+            for f in funcs.iter_mut() { f.ssa_conversion().unwrap(); }
         });
     });
 }

--- a/benchmark/benches/main.rs
+++ b/benchmark/benches/main.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate bencher;
 extern crate panopticon_amd64;
-extern crate panopticon_graph_algos;
 extern crate panopticon_data_flow;
 extern crate panopticon_core;
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,6 +12,7 @@ structopt-derive = "0.0.5"
 error-chain = "0.8"
 futures = "0.1"
 panopticon-core = { path = "../core" }
+panopticon-data-flow = { path = "../data-flow" }
 panopticon-analysis = { path = "../analysis" }
 panopticon-amd64 = { path = "../amd64" }
 panopticon-avr = { path = "../avr" }

--- a/cli/src/display.rs
+++ b/cli/src/display.rs
@@ -324,7 +324,7 @@ pub fn print_statement<W: Write + WriteColor>(fmt: &mut W, statement: &Statement
 }
 
 /// Prints the function in a human readable format, using `program`, with colors
-pub fn print_function<W: Write + WriteColor>(fmt: &mut W, function: &Function, bbs: &[&BasicBlock], program: &Program) -> Result<()> {
+pub fn print_function<W: Write + WriteColor>(fmt: &mut W, function: &Function, bbs: &[&BasicBlock], program: &Program<Function>) -> Result<()> {
     write!(fmt, "{:0>8x} <", function.start())?;
     color_bold!(fmt, Yellow, function.name)?;
     writeln!(fmt, ">:")?;
@@ -335,7 +335,7 @@ pub fn print_function<W: Write + WriteColor>(fmt: &mut W, function: &Function, b
 }
 
 /// Prints the basic block into `fmt`, in disassembly order, in human readable form, and looks up any functions calls in `program`
-pub fn print_basic_block<W: Write + WriteColor>(fmt: &mut W, basic_block: &BasicBlock, program: &Program) -> Result<()> {
+pub fn print_basic_block<W: Write + WriteColor>(fmt: &mut W, basic_block: &BasicBlock, program: &Program<Function>) -> Result<()> {
     for mnemonic in basic_block.mnemonics.iter() {
         if !mnemonic.opcode.starts_with("__") {
             write!(fmt, "{:8x}: ", mnemonic.area.start)?;
@@ -347,7 +347,7 @@ pub fn print_basic_block<W: Write + WriteColor>(fmt: &mut W, basic_block: &Basic
 }
 
 /// Prints the mnemonic into `fmt`, in human readable form, and looks up any functions calls in `program`
-pub fn print_mnemonic<W: Write + WriteColor>(fmt: &mut W, mnemonic: &Mnemonic, program: Option<&Program>) -> Result<()> {
+pub fn print_mnemonic<W: Write + WriteColor>(fmt: &mut W, mnemonic: &Mnemonic, program: Option<&Program<Function>>) -> Result<()> {
     let mut ops = mnemonic.operands.iter();
     color_bold!(fmt, Blue, mnemonic.opcode)?;
     write!(fmt, " ")?;

--- a/cli/src/display.rs
+++ b/cli/src/display.rs
@@ -1,8 +1,9 @@
 use std::io::Write;
 use termcolor::WriteColor;
 use termcolor::Color::*;
+use std::ops::Range;
 
-use panopticon_core::{Function, BasicBlock, Mnemonic, MnemonicFormatToken, Operation, Program, Rvalue, Result, Statement};
+use panopticon_core::{Fun, Function, BasicBlock, Mnemonic, MnemonicFormatToken, Operation, Program, Rvalue, Result, Statement, neo};
 
 macro_rules! color_bold {
     ($fmt:ident, $color:ident, $str:expr) => ({
@@ -20,325 +21,440 @@ macro_rules! color {
     })
 }
 
-/// Prints a sorted-by-start list of the RREIL implementing each mnemonic in a basic block, as well as phi functions and init code
-pub fn print_rreil<W: Write + WriteColor>(fmt: &mut W, bbs: &[&BasicBlock]) -> Result<()> {
-    color_bold!(fmt, White, "RREIL")?;
-    writeln!(fmt, ":")?;
-    for bb in bbs {
-        for mnemonic in bb.mnemonics() {
-            print_address_and_mnemonic(fmt, mnemonic)?;
-            for statement in &mnemonic.instructions {
-                print_statement(fmt, statement)?;
-            }
-        }
-    }
-    Ok(())
+pub trait PrintableFunction: Sized {
+    fn pretty_print<W: WriteColor + Write>(&self, fmt: &mut W, program: &Program<Self>) -> Result<()>;
 }
 
+pub trait PrintableStatements: Sized {
+    fn pretty_print_il<IL: PrintableIL, W: WriteColor + Write> (&self, fmt: &mut W) -> Result<()>;
+}
+
+pub trait PrintableIL {
+    fn pretty_print<W: WriteColor + Write>(&self, fmt: &mut W) -> Result<()>;
+}
+
+impl PrintableFunction for Function {
+    fn pretty_print<W: WriteColor + Write>(&self, fmt: &mut W, program: &Program<Function>) -> Result<()> {
+        let mut bbs = self.basic_blocks().collect::<Vec<_>>();
+        bbs.sort_by(|bb1, bb2| bb1.area.start.cmp(&bb2.area.start));
+        print_function(fmt, self, &bbs, program)
+    }
+}
+
+impl PrintableStatements for Function {
+    fn pretty_print_il<IL: PrintableIL, W: WriteColor + Write>(&self, fmt: &mut W) -> Result<()> {
+        color_bold!(fmt, White, "RREIL")?;
+        writeln!(fmt, ":")?;
+        for bb in self.basic_blocks() {
+            for mnemonic in bb.mnemonics() {
+                print_address_and_mnemonic::<Self, &Mnemonic, _>(fmt, &mnemonic)?;
+                for statement in &mnemonic.instructions {
+                    <Statement as PrintableIL>::pretty_print(statement, fmt)?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl PrintableStatements for neo::Function {
+    fn pretty_print_il<IL: PrintableIL, W: WriteColor + Write>(&self, fmt: &mut W) -> Result<()> {
+        writeln!(fmt, "UNIMPLEMENTED")?;
+        Ok(())
+    }
+}
+
+impl PrintableFunction for neo::Function {
+    fn pretty_print<W: WriteColor + Write>(&self, fmt: &mut W, program: &Program<neo::Function>) -> Result<()> {
+        let mut bbs = self.basic_blocks().map(|(_, bb)| NeoFunctionAndBasicBlock { function: self, bb} ).collect::<Vec<_>>();
+        bbs.sort_by(|f1, f2| f1.bb.area.start.cmp(&f2.bb.area.start));
+        print_function(fmt, self, &bbs, program)
+    }
+}
+
+pub trait PrintableMnemonic {
+    fn opcode(&self) -> &str;
+    fn operands(&self) -> Vec<Rvalue>;
+    fn format_tokens(&self) -> &[MnemonicFormatToken];
+    fn area(&self) -> Range<u64>;
+}
+
+impl<'a> PrintableMnemonic for &'a Mnemonic {
+    fn opcode(&self) -> &str {
+        self.opcode.as_str()
+    }
+    fn operands(&self) -> Vec<Rvalue> {
+        self.operands.clone()
+    }
+    fn format_tokens(&self) -> &[MnemonicFormatToken] {
+        &self.format_string
+    }
+    fn area(&self) -> Range<u64> {
+        self.area.start..self.area.end
+    }
+}
+
+pub trait PrintableBlock<M: PrintableMnemonic> {
+    type Iter: Iterator<Item = M>;
+    fn mnemonics(&self) -> Self::Iter;
+}
+
+impl<'a> PrintableBlock<&'a Mnemonic> for &'a BasicBlock {
+    type Iter = ::std::slice::Iter<'a, Mnemonic>;
+    fn mnemonics(&self) -> Self::Iter {
+        self.mnemonics.as_slice().iter()
+    }
+}
+
+struct NeoFunctionAndBasicBlock<'a> {
+    function: &'a neo::Function,
+    bb: &'a neo::BasicBlock,
+}
+
+impl<'a> PrintableBlock<&'a neo::Mnemonic> for NeoFunctionAndBasicBlock<'a> {
+    type Iter = Box<Iterator<Item = &'a neo::Mnemonic> + 'a>;
+    fn mnemonics(&self) -> Self::Iter {
+        Box::new(self.function.mnemonics_for(self.bb).map(|(_, m)| m))
+    }
+}
+
+impl<'a> PrintableMnemonic for &'a neo::Mnemonic {
+    fn opcode(&self) -> &str {
+        use std::borrow::Borrow;
+        self.opcode.borrow()
+    }
+    fn operands(&self) -> Vec<Rvalue> {
+        self.operands.clone()
+    }
+    fn format_tokens(&self) -> &[MnemonicFormatToken] {
+        &self.format_string
+    }
+    fn area(&self) -> Range<u64> {
+        self.area.start..self.area.end
+    }
+}
+
+///// Prints a sorted-by-start list of the RREIL implementing each mnemonic in a basic block, as well as phi functions and init code
+// pub fn print_il<IL: PrintableIL, M: PrintableMnemonic + ContainsInstructions, B: PrintableBlock<M>, W: Write + WriteColor>(fmt: &mut W, bbs: &[&B]) -> Result<()> {
+//     color_bold!(fmt, White, "RREIL")?;
+//     writeln!(fmt, ":")?;
+//     for bb in bbs {
+//         for mnemonic in bb.mnemonics() {
+//             //print_address_and_mnemonic(fmt, mnemonic)?;
+//             for statement in mnemonic.instructions() {
+//                 statement.pretty_print(fmt)?;
+//             }
+//         }
+//     }
+//     Ok(())
+// }
+
 /// Prints an address and its corresponding mnemonic at that address
-pub fn print_address_and_mnemonic<W: Write + WriteColor>(fmt: &mut W, mnemonic: &Mnemonic) -> Result<()> {
-    color_bold!(fmt, White, format!("{:8x}", mnemonic.area.start as usize))?;
+pub fn print_address_and_mnemonic<F: Fun, M: PrintableMnemonic, W: Write + WriteColor>(fmt: &mut W, mnemonic: &M) -> Result<()> {
+    color_bold!(fmt, White, format!("{:8x}", mnemonic.area().start as usize))?;
     write!(fmt, ": (")?;
-    print_mnemonic(fmt, mnemonic, None)?;
+    print_mnemonic(fmt, mnemonic, None::<&Program<F>>)?;
     writeln!(fmt, ")")?;
     Ok(())
 }
 
 /// Print colored RREIL statement
-pub fn print_statement<W: Write + WriteColor>(fmt: &mut W, statement: &Statement) -> Result<()> {
-    write!(fmt, "{: <8}  ", "")?;
-    match statement.op {
-        Operation::Add(ref a, ref b) => {
-            color_bold!(fmt, White, "add")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::Subtract(ref a, ref b) => {
-            color_bold!(fmt, White, "sub")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::Multiply(ref a, ref b) => {
-            color_bold!(fmt, White, "mul")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::DivideUnsigned(ref a, ref b) => {
-            color_bold!(fmt, White, "divu")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::DivideSigned(ref a, ref b) => {
-            color_bold!(fmt, White, "divs")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::ShiftLeft(ref a, ref b) => {
-            color_bold!(fmt, White, "shl")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::ShiftRightUnsigned(ref a, ref b) => {
-            color_bold!(fmt, White, "shru")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::ShiftRightSigned(ref a, ref b) => {
-            color_bold!(fmt, White, "shrs")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::Modulo(ref a, ref b) => {
-            color_bold!(fmt, White, "mod")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::And(ref a, ref b) => {
-            color_bold!(fmt, White, "and")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::InclusiveOr(ref a, ref b) => {
-            color_bold!(fmt, White, "or")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::ExclusiveOr(ref a, ref b) => {
-            color_bold!(fmt, White, "xor")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::Equal(ref a, ref b) => {
-            color_bold!(fmt, White, "cmpeq")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::LessOrEqualUnsigned(ref a, ref b) => {
-            color_bold!(fmt, White, "cmpleu")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::LessOrEqualSigned(ref a, ref b) => {
-            color_bold!(fmt, White, "cmples")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::LessUnsigned(ref a, ref b) => {
-            color_bold!(fmt, White, "cmplu")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::LessSigned(ref a, ref b) => {
-            color_bold!(fmt, White, "cmpls")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::Move(ref a) => {
-            color_bold!(fmt, White, "mov")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-        },
-        Operation::Call(ref a) => {
-            color_bold!(fmt, White, "call")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-        },
-        Operation::ZeroExtend(s, ref a) => {
-            color_bold!(fmt, White, format!("convert_{}", s))?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-        },
-        Operation::SignExtend(s, ref a) => {
-            color_bold!(fmt, White, format!("sign-extend_{}", s))?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-        },
-        Operation::Select(s, ref a, ref b) => {
-            color_bold!(fmt, White, format!("select_{}", s))?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::Initialize(ref r, sz) => {
-            color_bold!(fmt, White, "init")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, r)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, sz)?;
-        },
-        Operation::Load(ref r, e, sz, ref b) => {
-            color_bold!(fmt, White, format!("load/{}/{}/{}", r, e, sz))?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::Store(ref r, e, sz, ref a, ref b) => {
-            color_bold!(fmt, White, format!("store/{}/{}/{}", r, e, sz))?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::Phi(ref vec) => {
-            color_bold!(fmt, White, format!("phi"))?;
-            write!(fmt, " ")?;
-            for (i, x) in vec.iter().enumerate() {
-                color!(fmt, White, format!("{}", x))?;
-                if i < vec.len() - 1 {
-                    color_bold!(fmt, Green, ",")?;
-                    write!(fmt, " ")?;
+impl PrintableIL for Statement {
+    fn pretty_print<W: Write + WriteColor>(&self, fmt: &mut W) -> Result<()> {
+        write!(fmt, "{: <8}  ", "")?;
+        match self.op {
+            Operation::Add(ref a, ref b) => {
+                color_bold!(fmt, White, "add")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::Subtract(ref a, ref b) => {
+                color_bold!(fmt, White, "sub")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::Multiply(ref a, ref b) => {
+                color_bold!(fmt, White, "mul")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::DivideUnsigned(ref a, ref b) => {
+                color_bold!(fmt, White, "divu")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::DivideSigned(ref a, ref b) => {
+                color_bold!(fmt, White, "divs")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::ShiftLeft(ref a, ref b) => {
+                color_bold!(fmt, White, "shl")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::ShiftRightUnsigned(ref a, ref b) => {
+                color_bold!(fmt, White, "shru")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::ShiftRightSigned(ref a, ref b) => {
+                color_bold!(fmt, White, "shrs")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::Modulo(ref a, ref b) => {
+                color_bold!(fmt, White, "mod")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::And(ref a, ref b) => {
+                color_bold!(fmt, White, "and")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::InclusiveOr(ref a, ref b) => {
+                color_bold!(fmt, White, "or")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::ExclusiveOr(ref a, ref b) => {
+                color_bold!(fmt, White, "xor")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::Equal(ref a, ref b) => {
+                color_bold!(fmt, White, "cmpeq")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::LessOrEqualUnsigned(ref a, ref b) => {
+                color_bold!(fmt, White, "cmpleu")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::LessOrEqualSigned(ref a, ref b) => {
+                color_bold!(fmt, White, "cmples")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::LessUnsigned(ref a, ref b) => {
+                color_bold!(fmt, White, "cmplu")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::LessSigned(ref a, ref b) => {
+                color_bold!(fmt, White, "cmpls")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::Move(ref a) => {
+                color_bold!(fmt, White, "mov")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+            },
+            Operation::Call(ref a) => {
+                color_bold!(fmt, White, "call")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+            },
+            Operation::ZeroExtend(s, ref a) => {
+                color_bold!(fmt, White, format!("convert_{}", s))?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+            },
+            Operation::SignExtend(s, ref a) => {
+                color_bold!(fmt, White, format!("sign-extend_{}", s))?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+            },
+            Operation::Select(s, ref a, ref b) => {
+                color_bold!(fmt, White, format!("select_{}", s))?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::Initialize(ref r, sz) => {
+                color_bold!(fmt, White, "init")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, r)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, sz)?;
+            },
+            Operation::Load(ref r, e, sz, ref b) => {
+                color_bold!(fmt, White, format!("load/{}/{}/{}", r, e, sz))?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::Store(ref r, e, sz, ref a, ref b) => {
+                color_bold!(fmt, White, format!("store/{}/{}/{}", r, e, sz))?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::Phi(ref vec) => {
+                color_bold!(fmt, White, format!("phi"))?;
+                write!(fmt, " ")?;
+                for (i, x) in vec.iter().enumerate() {
+                    color!(fmt, White, format!("{}", x))?;
+                    if i < vec.len() - 1 {
+                        color_bold!(fmt, Green, ",")?;
+                        write!(fmt, " ")?;
+                    }
                 }
             }
         }
+        writeln!(fmt, "")?;
+        Ok(())
     }
-    writeln!(fmt, "")?;
-    Ok(())
 }
 
 /// Prints the function in a human readable format, using `program`, with colors
-pub fn print_function<W: Write + WriteColor>(fmt: &mut W, function: &Function, bbs: &[&BasicBlock], program: &Program<Function>) -> Result<()> {
+pub fn print_function<Function: Fun, M: PrintableMnemonic, B: PrintableBlock<M>, W: Write + WriteColor>(fmt: &mut W, function: &Function, bbs: &[B], program: &Program<Function>) -> Result<()> {
     write!(fmt, "{:0>8x} <", function.start())?;
-    color_bold!(fmt, Yellow, function.name)?;
+    color_bold!(fmt, Yellow, function.name())?;
     writeln!(fmt, ">:")?;
     for bb in bbs {
-        print_basic_block(fmt, &bb, program)?;
+        print_basic_block(fmt, bb, program)?;
     }
     Ok(())
 }
 
 /// Prints the basic block into `fmt`, in disassembly order, in human readable form, and looks up any functions calls in `program`
-pub fn print_basic_block<W: Write + WriteColor>(fmt: &mut W, basic_block: &BasicBlock, program: &Program<Function>) -> Result<()> {
-    for mnemonic in basic_block.mnemonics.iter() {
-        if !mnemonic.opcode.starts_with("__") {
-            write!(fmt, "{:8x}: ", mnemonic.area.start)?;
+pub fn print_basic_block<Function: Fun, M: PrintableMnemonic, B: PrintableBlock<M>, W: Write + WriteColor>(fmt: &mut W, basic_block: &B, program: &Program<Function>) -> Result<()> {
+    for mnemonic in basic_block.mnemonics() {
+        if !mnemonic.opcode().starts_with("__") {
+            write!(fmt, "{:8x}: ", mnemonic.area().start)?;
             print_mnemonic(fmt, &mnemonic, Some(program))?;
             writeln!(fmt)?;
         }
@@ -347,11 +463,12 @@ pub fn print_basic_block<W: Write + WriteColor>(fmt: &mut W, basic_block: &Basic
 }
 
 /// Prints the mnemonic into `fmt`, in human readable form, and looks up any functions calls in `program`
-pub fn print_mnemonic<W: Write + WriteColor>(fmt: &mut W, mnemonic: &Mnemonic, program: Option<&Program<Function>>) -> Result<()> {
-    let mut ops = mnemonic.operands.iter();
-    color_bold!(fmt, Blue, mnemonic.opcode)?;
+pub fn print_mnemonic<Function: Fun, M: PrintableMnemonic, W: Write + WriteColor>(fmt: &mut W, mnemonic: &M, program: Option<&Program<Function>>) -> Result<()> {
+    let ops = mnemonic.operands();
+    let mut ops = ops.iter();
+    color_bold!(fmt, Blue, mnemonic.opcode())?;
     write!(fmt, " ")?;
-    for token in &mnemonic.format_string {
+    for token in mnemonic.format_tokens() {
         match token {
             &MnemonicFormatToken::Literal(ref s) => {
                 color_bold!(fmt, Green, s)?;
@@ -392,7 +509,7 @@ pub fn print_mnemonic<W: Write + WriteColor>(fmt: &mut W, mnemonic: &Mnemonic, p
                                 if let Some(function) = program.find_function_by(|f| { f.start() == val }) {
                                     color!(fmt, Red, format!("{:x}",val))?;
                                     write!(fmt, " <", )?;
-                                    color_bold!(fmt, Yellow, function.name)?;
+                                    color_bold!(fmt, Yellow, function.name())?;
                                     write!(fmt, ">")?;
                                 } else {
                                     color_bold!(fmt, Magenta, format!("{:x}",val))?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -234,8 +234,8 @@ fn run(args: Args) -> Result<()> {
     let writer = BufferWriter::stdout(cc);
     let mut fmt = writer.buffer();
     if args.neo {
-//        let program = disassemble::<neo::Function>(&args.binary)?;
-//        app_logic(&mut fmt, program, args)?;
+       let program = disassemble::<neo::Function>(&args.binary)?;
+       app_logic(&mut fmt, program, args)?;
     } else {
         let program = disassemble::<Function>(&args.binary)?;
         app_logic(&mut fmt, program, args)?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -20,7 +20,7 @@ use panopticon_amd64 as amd64;
 use panopticon_analysis::analyze;
 use panopticon_avr as avr;
 use panopticon_core::{Machine, Fun, FunctionKind, Function, Program, Result, loader, neo};
-use panopticon_data_flow::SSAFunction;
+use panopticon_data_flow::{DataFlow};
 
 use std::path::Path;
 use std::result;
@@ -168,7 +168,7 @@ fn print_reverse_deps<Function: Fun, W: Write + WriteColor>(mut fmt: W, program:
     Ok(())
 }
 
-fn disassemble<Function: Fun + SSAFunction + Send>(binary: &str) -> Result<Program<Function>> {
+fn disassemble<Function: Fun + DataFlow + Send>(binary: &str) -> Result<Program<Function>> {
     let (mut proj, machine) = loader::load(Path::new(&binary))?;
     let program = proj.code.pop().unwrap();
     let reg = proj.region().clone();
@@ -180,7 +180,7 @@ fn disassemble<Function: Fun + SSAFunction + Send>(binary: &str) -> Result<Progr
     }?)
 }
 
-fn app_logic<Function: Fun + SSAFunction + PrintableFunction + PrintableStatements>(fmt: &mut termcolor::Buffer, mut program: Program<Function>, args: Args) -> Result<()> {
+fn app_logic<Function: Fun + DataFlow + PrintableFunction + PrintableStatements>(fmt: &mut termcolor::Buffer, mut program: Program<Function>, args: Args) -> Result<()> {
     let filter = Filter { name: args.function_filter, addr: args.address_filter.map(|addr| u64::from_str_radix(&addr, 16).unwrap()) };
 
     debug!("Program.imports: {:#?}", program.imports);
@@ -234,8 +234,8 @@ fn run(args: Args) -> Result<()> {
     let writer = BufferWriter::stdout(cc);
     let mut fmt = writer.buffer();
     if args.neo {
-        let program = disassemble::<neo::Function>(&args.binary)?;
-        app_logic(&mut fmt, program, args)?;
+//        let program = disassemble::<neo::Function>(&args.binary)?;
+//        app_logic(&mut fmt, program, args)?;
     } else {
         let program = disassemble::<Function>(&args.binary)?;
         app_logic(&mut fmt, program, args)?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,6 +8,7 @@ extern crate panopticon_amd64;
 extern crate panopticon_avr;
 extern crate panopticon_analysis;
 extern crate panopticon_graph_algos;
+extern crate panopticon_data_flow;
 extern crate futures;
 #[macro_use]
 extern crate log;
@@ -18,8 +19,9 @@ extern crate atty;
 use panopticon_amd64 as amd64;
 use panopticon_analysis::analyze;
 use panopticon_avr as avr;
-use panopticon_core::{Machine, Fun, FunctionKind, Function, Program, Result, loader};
-//pub use panopticon_core::neo::Function as Function;
+use panopticon_core::{Machine, Fun, FunctionKind, Function, Program, Result, loader, neo};
+use panopticon_data_flow::SSAFunction;
+
 use std::path::Path;
 use std::result;
 use structopt::StructOpt;
@@ -29,6 +31,7 @@ use termcolor::Color::*;
 
 #[macro_use]
 mod display;
+use display::{PrintableStatements, PrintableFunction};
 
 mod errors {
     error_chain! {
@@ -41,6 +44,8 @@ mod errors {
 #[derive(StructOpt, Debug)]
 #[structopt(name = "panop", about = "A libre cross-platform disassembler.")]
 struct Args {
+    #[structopt(long = "neo", help = "Use the new bincode")]
+    neo: bool,
     #[structopt(long = "reverse-deps", help = "Print every function that calls the function in -f")]
     reverse_deps: bool,
     /// Dumps the il of the matched function
@@ -79,9 +84,9 @@ impl Filter {
     pub fn filtering(&self) -> bool {
         self.name.is_some() || self.addr.is_some()
     }
-    pub fn is_match(&self, func: &Function) -> bool {
+    pub fn is_match<Function: Fun>(&self, func: &Function) -> bool {
         if let Some(ref name) = self.name {
-            if name == &func.name || func.aliases().contains(name){ return true }
+            if name == &func.name() || func.aliases().contains(name){ return true }
         }
         if let Some(ref addr) = self.addr {
             return *addr == func.start()
@@ -99,17 +104,17 @@ impl Filter {
     }
 }
 
-fn print_reverse_deps<W: Write + WriteColor>(mut fmt: W, program: &Program<Function>, filter: &Filter) -> Result<()> {
-    let name_and_address = {
-        if let Some(f) = program.find_function_by(|f| filter.is_match_with(&f.name, f.start())) {
-            Some((f.start(), &f.name))
+fn print_reverse_deps<Function: Fun, W: Write + WriteColor>(mut fmt: W, program: &Program<Function>, filter: &Filter) -> Result<()> {
+    let name_and_address: Option<(u64, &str)> = {
+        if let Some(f) = program.find_function_by(|f| filter.is_match_with(&f.name(), f.start())) {
+            Some((f.start(), f.name()))
         } else {
             // not a function, so we search imports
             let mut name_and_address = None;
             for (addr, name) in program.imports.iter() {
                 if filter.is_match_with(name, *addr) {
                     debug!("Found import with matching name or address, {:#x} - {}", addr, name);
-                    name_and_address = Some((*addr, name));
+                    name_and_address = Some((*addr, name.as_str()));
                 }
             }
             name_and_address
@@ -119,19 +124,19 @@ fn print_reverse_deps<W: Write + WriteColor>(mut fmt: W, program: &Program<Funct
         Some((addr, name)) => {
             let mut reverse_deps: Vec<_> = program.functions().filter_map(|f| {
                 let call_addresses = f.collect_call_addresses();
-                debug!("Total call addresses for {}: {}", f.name, call_addresses.len());
+                debug!("Total call addresses for {}: {}", f.name(), call_addresses.len());
                 if call_addresses.contains(&addr) {
-                    Some((f.start(), f.name.to_string()))
+                    Some((f.start(), f.name().to_string()))
                 } else {
                     for call_address in call_addresses {
-                        let function = program.find_function_by(|f| f.start() == call_address).expect(&format!("{} has a call address {:#x}, but there isn't a function with that address in the program object", f.name, call_address));
-                        debug!("Checking function {} with call address {:#x} for plt stub", function.name, call_address);
+                        let function = program.find_function_by(|f| f.start() == call_address).expect(&format!("{} has a call address {:#x}, but there isn't a function with that address in the program object", f.name(), call_address));
+                        debug!("Checking function {} with call address {:#x} for plt stub", function.name(), call_address);
                         match function.kind() {
                             &FunctionKind::Stub { ref plt_address, ref name } => {
-                                debug!("Function {} is a plt stub for {}", function.name, name);
+                                debug!("Function {} is a plt stub for {}", function.name(), name);
                                 if *plt_address == addr {
-                                    debug!("Function {} plt address {:#x} matches reverse dep address {:#x}, returning", f.name, plt_address, addr);
-                                    return Some((f.start(), f.name.to_string()))
+                                    debug!("Function {} plt address {:#x} matches reverse dep address {:#x}, returning", f.name(), plt_address, addr);
+                                    return Some((f.start(), f.name().to_string()))
                                 }
                             },
                             _ => ()
@@ -163,7 +168,7 @@ fn print_reverse_deps<W: Write + WriteColor>(mut fmt: W, program: &Program<Funct
     Ok(())
 }
 
-fn disassemble<Function: Fun + Send>(binary: &str) -> Result<Program<Function>> {
+fn disassemble<Function: Fun + SSAFunction + Send>(binary: &str) -> Result<Program<Function>> {
     let (mut proj, machine) = loader::load(Path::new(&binary))?;
     let program = proj.code.pop().unwrap();
     let reg = proj.region().clone();
@@ -175,14 +180,25 @@ fn disassemble<Function: Fun + Send>(binary: &str) -> Result<Program<Function>> 
     }?)
 }
 
-fn app_logic(fmt: &mut termcolor::Buffer, program: Program<Function>, args: Args) -> Result<()> {
+fn app_logic<Function: Fun + SSAFunction + PrintableFunction + PrintableStatements>(fmt: &mut termcolor::Buffer, mut program: Program<Function>, args: Args) -> Result<()> {
     let filter = Filter { name: args.function_filter, addr: args.address_filter.map(|addr| u64::from_str_radix(&addr, 16).unwrap()) };
 
     debug!("Program.imports: {:#?}", program.imports);
     if args.reverse_deps && filter.filtering() {
         return print_reverse_deps(fmt, &program, &filter);
     }
-    let mut functions = program.functions().filter_map(|f| if filter.is_match(f) { Some(f) } else { None }).collect::<Vec<&Function>>();
+    let mut functions = {
+        // we iterate twice because rust ownership system sucks sometimes
+        for f in program.functions_mut() {
+            if filter.is_match(f) {
+                // we use less memory and take less time if we perform the ssa conversion _only_ on functions
+                // we want to examine (e.g., ones that match our filter)
+                f.ssa_conversion()?;
+            }
+        }
+        program.functions().filter_map(|f| if filter.is_match(f) { Some(f.clone()) } else { None }).collect::<Vec<&Function>>()
+    };
+
     info!("disassembly thread finished with {} functions", functions.len());
 
     functions.sort_by(|f1, f2| {
@@ -192,11 +208,7 @@ fn app_logic(fmt: &mut termcolor::Buffer, program: Program<Function>, args: Args
     });
 
     for function in functions {
-        let mut bbs = function.basic_blocks().collect::<Vec<_>>();
-        // sort them by start so we can use them later
-        bbs.sort_by(|bb1, bb2| bb1.area.start.cmp(&bb2.area.start));
-
-        display::print_function(fmt, &function, &bbs, &program)?;
+        function.pretty_print(fmt, &program)?;
         if args.calls {
             let calls = function.collect_call_addresses();
             write!(fmt, "Calls (")?;
@@ -208,8 +220,9 @@ fn app_logic(fmt: &mut termcolor::Buffer, program: Program<Function>, args: Args
             }
         }
         if args.dump_il {
-            display::print_rreil(fmt, &bbs)?;
+            // function.pretty_print_il(fmt)?;
         }
+        // move this into pretty_print
         writeln!(fmt, "Aliases: {:?}", function.aliases())?;
     }
     Ok(())
@@ -217,11 +230,16 @@ fn app_logic(fmt: &mut termcolor::Buffer, program: Program<Function>, args: Args
 
 fn run(args: Args) -> Result<()> {
     exists_path_val(&args.binary)?;
-    let program = disassemble::<Function>(&args.binary)?;
     let cc = if args.color || atty::is(atty::Stream::Stdout) { ColorChoice::Auto } else { ColorChoice::Never };
     let writer = BufferWriter::stdout(cc);
     let mut fmt = writer.buffer();
-    app_logic(&mut fmt, program, args)?;
+    if args.neo {
+        let program = disassemble::<neo::Function>(&args.binary)?;
+        app_logic(&mut fmt, program, args)?;
+    } else {
+        let program = disassemble::<Function>(&args.binary)?;
+        app_logic(&mut fmt, program, args)?;
+    }
     writer.print(&fmt)?;
     Ok(())
 }
@@ -237,3 +255,36 @@ fn main() {
         }
     }
 }
+
+/*
+INFO:panopticon_analysis::pipeline: first wave done: success: 1748 failures: 0 targets: 806
+INFO:panopticon_analysis::pipeline: targets - (806)
+INFO:panopticon_analysis::pipeline: targets - (456)
+INFO:panopticon_analysis::pipeline: targets - (245)
+INFO:panopticon_analysis::pipeline: targets - (95)
+INFO:panopticon_analysis::pipeline: targets - (49)
+INFO:panopticon_analysis::pipeline: targets - (20)
+INFO:panopticon_analysis::pipeline: Finished analysis: 2286 failures 0
+INFO:panop: disassembly thread finished with 2286 functions
+Total bytes: 753214720
+15.62user 0.48system 0:05.32elapsed 302%CPU (0avgtext+0avgdata 1243060maxresident)k
+0inputs+0outputs (0major+322752minor)pagefaults 0swaps
+
+INFO:panopticon_analysis::pipeline: first wave done: success: 1748 failures: 0 targets: 0
+INFO:panopticon_analysis::pipeline: Finished analysis: 1748 failures 0
+Total_bytes: 13561144
+3.67user 0.19system 0:01.31elapsed 294%CPU (0avgtext+0avgdata 154000maxresident)k
+0inputs+0outputs (0major+80572minor)pagefaults 0swaps
+
+Aliases: ["printf"]
+21.74user 0.39system 0:07.71elapsed 287%CPU (0avgtext+0avgdata 443572maxresident)k
+0inputs+0outputs (0major+133326minor)pagefaults 0swaps
+
+RUST_LOG=panop=info /usr/bin/time ./panop /usr/lib/libc.so.6
+52.02user 1.20system 0:16.66elapsed 319%CPU (0avgtext+0avgdata 2756540maxresident)k
+0inputs+0outputs (0major+658616minor)pagefaults 0swaps
+
+RUST_LOG=panop=info /usr/bin/time ./panop --neo /usr/lib/libc.so.6
+21.26user 0.34system 0:06.98elapsed 309%CPU (0avgtext+0avgdata 450880maxresident)k
+104inputs+0outputs (0major+134643minor)pagefaults 0swaps
+*/

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,7 +18,7 @@ panopticon-graph-algos = { path = "../graph-algos" }
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_cbor = "0.6"
-petgraph = "0.4.9"
+petgraph = { version = "0.4.10", features = ["serde-1"], git = "https://github.com/m4b/petgraph", branch = "dominance_frontiers" }
 leb128 = "0.2.1"
 error-chain = "0.11.0"
 quickcheck = "0.4.1"

--- a/core/src/disassembler.rs
+++ b/core/src/disassembler.rs
@@ -788,7 +788,7 @@ impl Architecture for TestArch {
                         Ok(Rvalue::Constant{ value: (b - b'0') as u64, size: len })
                     }
                     _ => Err(format!("'{}' is nor a variable name neither a constant",b).into())
-                }
+                },
                 Some(None) => Err(format!("Undefined cell at {}",*entry - 1).into()),
                 None => Err(format!("Premature end while decoding rvalue at {}",*entry).into())
             }
@@ -803,7 +803,7 @@ impl Architecture for TestArch {
                         Ok(Lvalue::Variable{ name: format!("{}",char::from(b)).into(), size: len, subscript: None })
                     }
                     _ => Err(format!("'{}' is not a variable name",b).into())
-                }
+                },
                 Some(None) => Err(format!("Undefined cell at {}",*entry - 1).into()),
                 None => Err(format!("Premature end while decoding lvalue at {}",*entry).into())
             }

--- a/core/src/function.rs
+++ b/core/src/function.rs
@@ -28,7 +28,7 @@
 //! on the front-end.
 
 
-use {Architecture, BasicBlock, Guard, Mnemonic, Operation, Region, Result, Rvalue, Statement};
+use {Architecture, BasicBlock, Fun, Guard, Mnemonic, Operation, Region, Result, Rvalue, Statement};
 
 use panopticon_graph_algos::{AdjacencyList, EdgeListGraphTrait, GraphTrait, MutableGraphTrait, VertexListGraphTrait};
 use panopticon_graph_algos::adjacency_list::{AdjacencyListEdgeDescriptor, AdjacencyListVertexDescriptor, VertexLabelIterator};
@@ -120,6 +120,57 @@ pub struct Function {
 enum MnemonicOrError {
     Mnemonic(Mnemonic),
     Error(u64, Cow<'static, str>),
+}
+
+impl Fun for Function {
+    fn entry_point_mut(&mut self) -> &mut BasicBlock {
+        Function::entry_point_mut(self)
+    }
+    // fn entry_point(&self) -> &BasicBlock {
+    //     Function::entry_point(self)
+    // }
+    fn entry_point_ref(&self) -> ControlFlowRef {
+        Function::entry_point_ref(self)
+    }
+    fn cfg(&self) -> &ControlFlowGraph {
+        &self.cflow_graph
+    }
+    fn cfg_mut(&mut self) -> &mut ControlFlowGraph {
+        &mut self.cflow_graph
+    }
+    fn postorder(&self) -> Vec<ControlFlowRef> {
+        Function::postorder(self)
+    }
+    fn add_alias(&mut self, name: String) {
+        Function::add_alias(self, name)
+    }
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn uuid(&self) -> &Uuid {
+        &*self.uuid()
+    }
+    fn set_uuid(&mut self, uuid: Uuid) {
+        self.uuid = uuid;
+    }
+    fn start(&self) -> u64 {
+        Function::start(self)
+    }
+    fn collect_call_addresses(&self) -> Vec<u64> {
+        Function::collect_call_addresses(self)
+    }
+    fn collect_calls(&self) -> Vec<Rvalue> {
+        Function::collect_calls(self)
+    }
+    fn statements<'a>(&'a self) -> Box<Iterator<Item=&'a Statement> + 'a> {
+        Function::statements(self)
+    }
+    fn set_plt(&mut self, import: &str, address: u64) {
+        Function::set_plt(self, import, address)
+    }
+    fn new<A: Architecture>(start: u64, region: &Region, name: Option<String>, init: A::Configuration) -> Result<Function> {
+        Function::new::<A>(start, region, name, init)
+    }
 }
 
 impl Function {

--- a/core/src/function.rs
+++ b/core/src/function.rs
@@ -30,13 +30,12 @@
 
 use {Architecture, BasicBlock, Fun, Guard, Mnemonic, Operation, Region, Result, Rvalue, Statement};
 
-use std::borrow::Cow;
-use std::collections::{BTreeMap, HashMap, HashSet};
-use uuid::Uuid;
-
 use petgraph::Graph;
 use petgraph::graph::{NodeIndex, EdgeIndex};
 use petgraph::prelude::*;
+use std::borrow::Cow;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use uuid::Uuid;
 
 /// An iterator over every BasicBlock in a Function
 pub struct BasicBlockIterator<'a> {

--- a/core/src/function.rs
+++ b/core/src/function.rs
@@ -123,23 +123,11 @@ enum MnemonicOrError {
 }
 
 impl Fun for Function {
-    fn entry_point_mut(&mut self) -> &mut BasicBlock {
-        Function::entry_point_mut(self)
+    fn aliases(&self) -> &[String] {
+        Function::aliases(self)
     }
-    // fn entry_point(&self) -> &BasicBlock {
-    //     Function::entry_point(self)
-    // }
-    fn entry_point_ref(&self) -> ControlFlowRef {
-        Function::entry_point_ref(self)
-    }
-    fn cfg(&self) -> &ControlFlowGraph {
-        &self.cflow_graph
-    }
-    fn cfg_mut(&mut self) -> &mut ControlFlowGraph {
-        &mut self.cflow_graph
-    }
-    fn postorder(&self) -> Vec<ControlFlowRef> {
-        Function::postorder(self)
+    fn kind(&self) -> &FunctionKind {
+        Function::kind(self)
     }
     fn add_alias(&mut self, name: String) {
         Function::add_alias(self, name)

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -99,6 +99,30 @@ extern crate env_logger;
 #[cfg(test)]
 #[macro_use] extern crate quickcheck;
 
+pub trait Fun: Sized {
+    fn entry_point_mut(&mut self) -> &mut BasicBlock;
+    // fn entry_point(&self) -> &BasicBlock;
+    fn entry_point_ref(&self) -> ControlFlowRef;
+    fn cfg(&self) -> &ControlFlowGraph;
+    fn cfg_mut(&mut self) -> &mut ControlFlowGraph;
+    fn postorder(&self) -> Vec<ControlFlowRef>;
+    fn add_alias(&mut self, String);
+    fn name(&self) -> &str;
+    fn uuid(&self) -> &uuid::Uuid;
+    fn set_uuid(&mut self, uuid::Uuid);
+    fn start(&self) -> u64;
+    fn collect_call_addresses(&self) -> Vec<u64>;
+    fn collect_calls(&self) -> Vec<Rvalue>;
+    fn statements<'a>(&'a self) -> Box<Iterator<Item=&'a Statement> + 'a>;
+    fn set_plt(&mut self, import: &str, address: u64);
+    fn new<A: Architecture>(start: u64, region: &Region, name: Option<String>, init: A::Configuration) -> Result<Self>;
+    fn with_uuid<A: Architecture>(start: u64, uuid: &uuid::Uuid, region: &Region, name: Option<String>, init: A::Configuration) -> Result<Self> {
+        let mut f = Self::new::<A>(start, region, name, init)?;
+        f.set_uuid(uuid.clone());
+        Ok(f)
+    }
+}
+
 // core
 pub mod disassembler;
 pub use disassembler::{Architecture, Disassembler, Match, State, TestArch};

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -100,12 +100,8 @@ extern crate env_logger;
 #[macro_use] extern crate quickcheck;
 
 pub trait Fun: Sized {
-    fn entry_point_mut(&mut self) -> &mut BasicBlock;
-    // fn entry_point(&self) -> &BasicBlock;
-    fn entry_point_ref(&self) -> ControlFlowRef;
-    fn cfg(&self) -> &ControlFlowGraph;
-    fn cfg_mut(&mut self) -> &mut ControlFlowGraph;
-    fn postorder(&self) -> Vec<ControlFlowRef>;
+    fn aliases(&self) -> &[String];
+    fn kind(&self) -> &FunctionKind;
     fn add_alias(&mut self, String);
     fn name(&self) -> &str;
     fn uuid(&self) -> &uuid::Uuid;

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -19,7 +19,7 @@
 //! Loader for 32 and 64-bit ELF, PE, and Mach-o files.
 
 
-use {Bound, CallTarget, Layer, Program, Project, Region, Result, Rvalue};
+use {Bound, CallTarget, Layer, Fun, Program, Project, Region, Result, Rvalue};
 use goblin::{self, Hint, archive, elf, mach, pe};
 use goblin::elf::program_header;
 
@@ -42,7 +42,7 @@ pub enum Machine {
 
 /// Parses a non-fat Mach-o binary from `bytes` at `offset` and creates a `Project` from it. Returns the `Project` instance and
 /// the CPU its intended for.
-pub fn load_mach(bytes: &[u8], offset: usize, name: String) -> Result<(Project, Machine)> {
+pub fn load_mach<F: Fun>(bytes: &[u8], offset: usize, name: String) -> Result<(Project<F>, Machine)> {
     let binary = mach::MachO::parse(&bytes, offset)?;
     debug!("mach: {:#?}", &binary);
     let mut base = 0x0;
@@ -142,7 +142,7 @@ pub fn load_mach(bytes: &[u8], offset: usize, name: String) -> Result<(Project, 
 
 /// Parses an ELF 32/64-bit binary from `bytes` and creates a `Project` from it. Returns the `Project` instance and
 /// the CPU its intended for.
-fn load_elf(bytes: &[u8], name: String) -> Result<(Project, Machine)> {
+fn load_elf<F: Fun>(bytes: &[u8], name: String) -> Result<(Project<F>, Machine)> {
     use std::collections::HashSet;
 
     let mut cursor = Cursor::new(&bytes);
@@ -201,7 +201,7 @@ fn load_elf(bytes: &[u8], name: String) -> Result<(Project, Machine)> {
 
     prog.call_graph.add_vertex(CallTarget::Todo(Rvalue::new_u64(entry as u64), Some(name), Uuid::new_v4()));
 
-    let add_sym = |prog: &mut Program, sym: &elf::Sym, name: &str| {
+    let add_sym = |prog: &mut Program<F>, sym: &elf::Sym, name: &str| {
         let name = name.to_string();
         let addr = sym.st_value;
         debug!("Symbol: {} @ 0x{:x}: {:?}", name, addr, sym);
@@ -214,7 +214,7 @@ fn load_elf(bytes: &[u8], name: String) -> Result<(Project, Machine)> {
         }
     };
 
-    let resolve_import_address = |proj: &mut Project, relocs: &[elf::Reloc], name: &str| {
+    let resolve_import_address = |proj: &mut Project<F>, relocs: &[elf::Reloc], name: &str| {
         for reloc in relocs {
             let pltsym = &binary.dynsyms[reloc.r_sym];
             let pltname = &binary.dynstrtab[pltsym.st_name];
@@ -263,7 +263,7 @@ fn load_elf(bytes: &[u8], name: String) -> Result<(Project, Machine)> {
 }
 
 /// Parses a PE32/PE32+ file from `bytes` and create a project from it.
-fn load_pe(bytes: &[u8], name: String) -> Result<(Project, Machine)> {
+fn load_pe<F: Fun>(bytes: &[u8], name: String) -> Result<(Project<F>, Machine)> {
     let pe = pe::PE::parse(&bytes)?;
     debug!("pe: {:#?}", &pe);
     let image_base = pe.image_base as u64;
@@ -345,7 +345,7 @@ fn load_pe(bytes: &[u8], name: String) -> Result<(Project, Machine)> {
 
 /// Load an ELF or PE file from disk and creates a `Project` from it. Returns the `Project` instance and
 /// the CPU its intended for.
-pub fn load(path: &Path) -> Result<(Project, Machine)> {
+pub fn load<F: Fun>(path: &Path) -> Result<(Project<F>, Machine)> {
     let name = path.file_name().map(|x| x.to_string_lossy().to_string()).unwrap_or("(encoding error)".to_string());
     let mut fd = File::open(path)?;
     let peek = goblin::peek(&mut fd)?;

--- a/core/src/neo/function.rs
+++ b/core/src/neo/function.rs
@@ -833,7 +833,10 @@ fn to_statement(stmt: &core::Statement) -> Statement {
         }
 
 
-        _ => unimplemented!("{:?}",stmt)
+        _ => {
+            let res = format!("{:?}", stmt);
+            unimplemented!();
+        }
     }
 }
 

--- a/core/src/neo/mod.rs
+++ b/core/src/neo/mod.rs
@@ -17,7 +17,7 @@ pub use neo::errors::*;
 pub use self::il::{Operation,Statement,Endianess,CallTarget};
 pub use self::value::{Variable,Constant,Value};
 pub use self::bitcode::{Bitcode,BitcodeIter};
-pub use self::function::{Function,CfgNode,Mnemonic,BasicBlock,BasicBlockIndex};
+pub use self::function::{Function, CfgNode, Mnemonic, MnemonicIndex, MnemonicIterator, BasicBlockIterator, BasicBlock, BasicBlockIndex};
 
 use std::borrow::Cow;
 pub type Str = Cow<'static,str>;

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -28,22 +28,26 @@
 //! function fails, it will still be added to the call graph. The function will only have a single
 //! error node.
 
+use std::collections::HashMap;
 
 use {Fun, Statement, Operation, Rvalue};
-use panopticon_graph_algos::{AdjacencyList, AdjacencyMatrixGraphTrait, GraphTrait, MutableGraphTrait, VertexListGraphTrait};
-use panopticon_graph_algos::adjacency_list::{AdjacencyListVertexDescriptor, VertexLabelIterator, VertexLabelMutIterator};
 use uuid::Uuid;
+use petgraph::visit::{IntoNodeReferences};
+// use stable when API is at parity with Graph
+//use petgraph::stable_graph::{NodeIndex, StableGraph};
+use petgraph::graph::{NodeIndex, Graph};
 
 /// An iterator over every Function in this Program
 pub struct FunctionIterator<'a, F: 'a> {
-    iter: VertexLabelIterator<'a, CallGraphRef, CallTarget<F>>
+    iter: Box<Iterator<Item = &'a CallTarget<F>> + 'a>
 }
 
 impl<'a, F> FunctionIterator<'a, F> {
     /// Create a new function iterator from the `cfg`
     pub fn new(cfg: &'a CallGraph<F>) -> Self {
+        let iter = Box::new(cfg.node_indices().filter_map(move |idx| cfg.node_weight(idx)));
         FunctionIterator {
-            iter: cfg.vertex_labels(),
+            iter
         }
     }
 }
@@ -63,14 +67,15 @@ impl<'a, F> Iterator for FunctionIterator<'a, F> {
 
 /// An iterator over every Function in this Program
 pub struct FunctionMutIterator<'a, F: 'a> {
-    iter: VertexLabelMutIterator<'a, CallGraphRef, CallTarget<F>>
+    iter: Box<Iterator<Item = &'a mut CallTarget<F>> + 'a>
 }
 
 impl<'a, F> FunctionMutIterator<'a, F> {
     /// Create a new function iterator from the `cfg`
     pub fn new(cfg: &'a mut CallGraph<F>) -> Self {
+        let iter = Box::new(cfg.node_weights_mut());
         FunctionMutIterator {
-            iter: cfg.vertex_labels_mut(),
+            iter
         }
     }
 }
@@ -111,9 +116,9 @@ impl<F: Fun> CallTarget<F> {
 }
 
 /// Graph of functions/symbolic references
-pub type CallGraph<F> = AdjacencyList<CallTarget<F>, ()>;
+pub type CallGraph<F> = Graph<CallTarget<F>, ()>;
 /// Stable reference to a call graph node
-pub type CallGraphRef = AdjacencyListVertexDescriptor;
+pub type CallGraphRef = NodeIndex<u32>;
 
 /// A collection of functions calling each other.
 #[derive(Serialize,Deserialize,Debug)]
@@ -125,7 +130,7 @@ pub struct Program<F> {
     /// Graph of functions
     pub call_graph: CallGraph<F>,
     /// Symbolic References (Imports)
-    pub imports: ::std::collections::HashMap<u64, String>,
+    pub imports: HashMap<u64, String>,
 }
 
 impl<'a, F> IntoIterator for &'a Program<F> {
@@ -143,14 +148,14 @@ impl<F: Fun> Program<F> {
             uuid: Uuid::new_v4(),
             name: n.to_string(),
             call_graph: CallGraph::new(),
-            imports: ::std::collections::HashMap::new(),
+            imports: HashMap::new(),
         }
     }
 
     /// Returns a function if it matches the condition in the `filter` closure.
     pub fn find_function_by<'a, Filter: (Fn(&F) -> bool)>(&'a self, filter: Filter) -> Option<&'a F> {
-        for ct in self.call_graph.vertex_labels() {
-            match ct {
+        for (_, node) in self.call_graph.node_references() {
+            match node {
                 &CallTarget::Concrete(ref function) => if filter(function) { return Some(function) },
                 _ => (),
             }
@@ -160,21 +165,31 @@ impl<F: Fun> Program<F> {
 
     /// Returns a mutable reference to the first function that matches the condition in the `filter` closure.
     pub fn find_function_mut<'a, Filter: (Fn(&F) -> bool)>(&'a mut self, filter: Filter) -> Option<&'a mut F> {
-        for ct in self.call_graph.vertex_labels_mut() {
-            match ct {
-                &mut CallTarget::Concrete(ref mut function) => if filter(function) { return Some(function) },
+        let mut idx = None;
+        for (nidx, node) in self.call_graph.node_references() {
+            match node {
+                &CallTarget::Concrete(ref function) => if filter(function) { idx = Some(nidx); break },
                 _ => (),
             }
         }
-        None
+        match idx {
+            Some(idx) => {
+                let ct = self.call_graph.node_weight_mut(idx).unwrap();
+                match ct {
+                    &mut CallTarget::Concrete(ref mut function) => Some(function),
+                    _ => unreachable!()
+                }
+            },
+            None => None
+        }
     }
 
     /// Returns a reference to the function with an entry point starting at `start`.
     pub fn find_function_by_entry(&self, start: u64) -> Option<CallGraphRef> {
         self.call_graph
-            .vertices()
+            .node_indices()
             .find(
-                |&x| match self.call_graph.vertex_label(x) {
+                |&x| match self.call_graph.node_weight(x) {
                     Some(&CallTarget::Concrete(ref s)) => {
                         s.start() == start
                     }
@@ -185,9 +200,9 @@ impl<F: Fun> Program<F> {
 
     /// Returns the function with UUID `a`.
     pub fn find_function_by_uuid<'a>(&'a self, a: &Uuid) -> Option<&'a F> {
-        for ct in self.call_graph.vertex_labels() {
-            match ct {
-                &CallTarget::Concrete(ref s) => if s.uuid() == a { return Some(s) },
+        for (_, node) in self.call_graph.node_references() {
+            match node {
+                &CallTarget::Concrete(ref function) => if function.uuid() == a { return Some(function) },
                 _ => (),
             }
         }
@@ -196,7 +211,7 @@ impl<F: Fun> Program<F> {
 
     /// Returns the function with UUID `a`.
     pub fn find_function_by_uuid_mut<'a>(&'a mut self, a: &Uuid) -> Option<&'a mut F> {
-        for ct in self.call_graph.vertex_labels_mut() {
+        for ct in self.call_graph.node_weights_mut() {
             match ct {
                 &mut CallTarget::Concrete(ref mut s) => if s.uuid() == a { return Some(s) },
                 _ => (),
@@ -208,14 +223,14 @@ impl<F: Fun> Program<F> {
     /// Puts `function` into the call graph, returning the UUIDs of all _new_ `Todo`s
     /// that are called by `function`
     pub fn insert(&mut self, function: F) -> Vec<Uuid> {
-        let maybe_vx = self.call_graph.vertices().find(|ct| self.call_graph.vertex_label(*ct).unwrap().uuid() == function.uuid());
+        let maybe_vx = self.call_graph.node_indices().find(|ct| self.call_graph.node_weight(*ct).unwrap().uuid() == function.uuid());
 
         let calls = function.collect_calls();
         let new_vx = if let Some(vx) = maybe_vx {
-            *self.call_graph.vertex_label_mut(vx).unwrap() = CallTarget::Concrete(function);
+            *self.call_graph.node_weight_mut(vx).unwrap() = CallTarget::Concrete(function);
             vx
         } else {
-            self.call_graph.add_vertex(CallTarget::Concrete(function))
+            self.call_graph.add_node(CallTarget::Concrete(function))
         };
 
         let mut other_funs = Vec::new();
@@ -224,8 +239,8 @@ impl<F: Fun> Program<F> {
         for a in calls {
             let l = other_funs.len();
 
-            for w in self.call_graph.vertices() {
-                match self.call_graph.vertex_label(w) {
+            for w in self.call_graph.node_indices() {
+                match self.call_graph.node_weight(w) {
                     Some(&CallTarget::Concrete(ref function)) => {
                         if let Rvalue::Constant { ref value, .. } = a {
                             if *value == function.start() {
@@ -246,16 +261,16 @@ impl<F: Fun> Program<F> {
 
             if l == other_funs.len() {
                 let uu = Uuid::new_v4();
-                let v = self.call_graph.add_vertex(CallTarget::Todo(a, None, uu));
+                let v = self.call_graph.add_node(CallTarget::Todo(a, None, uu));
 
-                self.call_graph.add_edge((), new_vx, v);
+                self.call_graph.add_edge(new_vx, v, ());
                 todos.push(uu);
             }
         }
 
         for other_fun in other_funs {
-            if self.call_graph.edge(new_vx, other_fun) == None {
-                self.call_graph.add_edge((), new_vx, other_fun);
+            if self.call_graph.find_edge(new_vx, other_fun) == None {
+                self.call_graph.add_edge(new_vx, other_fun, ());
             }
         }
 
@@ -264,16 +279,11 @@ impl<F: Fun> Program<F> {
 
     /// Returns the function, todo item or symbolic reference with UUID `uu`.
     pub fn find_call_target_by_uuid<'a>(&'a self, uu: &Uuid) -> Option<CallGraphRef> {
-        for vx in self.call_graph.vertices() {
-            if let Some(lb) = self.call_graph.vertex_label(vx) {
-                if lb.uuid() == uu {
-                    return Some(vx);
-                }
-            } else {
-                unreachable!();
+        for (id, node) in self.call_graph.node_references() {
+            if node.uuid() == uu {
+                return Some(id);
             }
         }
-
         None
     }
 
@@ -288,8 +298,8 @@ impl<F: Fun> Program<F> {
     }
     /// Calls [Function::set_plt](../function/struct.Function.html#method.set_plt) on all matching functions
     pub fn update_plt(&mut self) {
-        for ct in self.call_graph.vertex_labels_mut() {
-            match ct {
+        for ct in self.call_graph.node_indices() {
+            match self.call_graph.node_weight_mut(ct).unwrap() {
                 &mut CallTarget::Concrete(ref mut function) => {
                     let address = {
                         let mut last = None;
@@ -320,6 +330,10 @@ impl<F: Fun> Program<F> {
                 _ => (),
             }
         }
+    }
+
+    pub fn iter_callgraph<'a>(&'a self) -> Box<Iterator<Item = &'a CallTarget<F>> + 'a> {
+        Box::new(self.call_graph.node_references().map(|(_, node)| node))
     }
 }
 

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -28,14 +28,14 @@
 //! function fails, it will still be added to the call graph. The function will only have a single
 //! error node.
 
-use std::collections::HashMap;
-
 use {Fun, Statement, Operation, Rvalue};
-use uuid::Uuid;
 use petgraph::visit::{IntoNodeReferences};
 // use stable when API is at parity with Graph
 //use petgraph::stable_graph::{NodeIndex, StableGraph};
 use petgraph::graph::{NodeIndex, Graph};
+use uuid::Uuid;
+
+use std::collections::HashMap;
 
 /// An iterator over every Function in this Program
 pub struct FunctionIterator<'a, F: 'a> {

--- a/core/src/project.rs
+++ b/core/src/project.rs
@@ -21,7 +21,7 @@
 //! Projects are a set of `Program`s, associated memory `Region`s and comments.
 
 
-use {CallGraphRef, Function, Program, Region, Result, World};
+use {CallGraphRef, Fun, Program, Region, Result, World};
 use panopticon_graph_algos::GraphTrait;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use flate2::Compression;
@@ -39,11 +39,11 @@ use uuid::Uuid;
 
 /// Complete Panopticon session
 #[derive(Serialize,Deserialize,Debug)]
-pub struct Project {
+pub struct Project<F> {
     /// Human-readable name
     pub name: String,
     /// Recognized code
-    pub code: Vec<Program>,
+    pub code: Vec<Program<F>>,
     /// Memory regions
     pub data: World,
     /// Comments
@@ -52,26 +52,9 @@ pub struct Project {
     pub imports: HashMap<u64, String>,
 }
 
-impl Project {
-    /// Returns a new `Project` named `s` from memory `Region` `r`.
-    pub fn new(s: String, r: Region) -> Project {
-        Project {
-            name: s,
-            code: Vec::new(),
-            data: World::new(r),
-            comments: HashMap::new(),
-            imports: HashMap::new(),
-        }
-    }
-
-    /// Returns this project's root Region
-    pub fn region(&self) -> &Region {
-        // this cannot fail because World::new guarantees that data.root = r
-        self.data.dependencies.vertex_label(self.data.root).unwrap()
-    }
-
+impl<'de, F: Fun + Deserialize<'de> + Serialize> Project<F> {
     /// Reads a serialized project from disk.
-    pub fn open(p: &Path) -> Result<Project> {
+    pub fn open(p: &Path) -> Result<Self> {
         let mut fd = match File::open(p) {
             Ok(fd) => fd,
             Err(e) => return Err(format!("failed to open file: {:?}", e).into()),
@@ -94,60 +77,6 @@ impl Project {
         }
     }
 
-    /// Returns the program with UUID `uu`
-    pub fn find_program_by_uuid(&self, uu: &Uuid) -> Option<&Program> {
-        self.code.iter().find(|x| x.uuid == *uu)
-    }
-
-    /// Returns the program with UUID `uu`
-    pub fn find_program_by_uuid_mut(&mut self, uu: &Uuid) -> Option<&mut Program> {
-        self.code.iter_mut().find(|x| x.uuid == *uu)
-    }
-
-    /// Returns function and enclosing program with UUID `uu`
-    pub fn find_function_by_uuid<'a>(&'a self, uu: &Uuid) -> Option<&'a Function> {
-        for p in self.code.iter() {
-            if let Some(f) = p.find_function_by_uuid(uu) {
-                return Some(f);
-            }
-        }
-
-        None
-    }
-
-    /// Returns function and enclosing program with UUID `uu`
-    pub fn find_function_by_uuid_mut<'a>(&'a mut self, uu: &Uuid) -> Option<&'a mut Function> {
-        for p in self.code.iter_mut() {
-            if let Some(f) = p.find_function_by_uuid_mut(uu) {
-                return Some(f);
-            }
-        }
-
-        None
-    }
-
-    /// Returns function/reference and enclosing program with UUID `uu`
-    pub fn find_call_target_by_uuid<'a>(&'a self, uu: &Uuid) -> Option<(CallGraphRef, &'a Program)> {
-        for p in self.code.iter() {
-            if let Some(ct) = p.find_call_target_by_uuid(uu) {
-                return Some((ct, p));
-            }
-        }
-
-        None
-    }
-
-    /// Returns function/reference and enclosing program with UUID `uu`
-    pub fn find_call_target_by_uuid_mut<'a>(&'a mut self, uu: &Uuid) -> Option<(CallGraphRef, &'a mut Program)> {
-        for p in self.code.iter_mut() {
-            if let Some(ct) = p.find_call_target_by_uuid(uu) {
-                return Some((ct, p));
-            }
-        }
-
-        None
-    }
-
     /// Serializes the project into the file at `p`. The format looks like this:
     /// [u8;10] magic = "PANOPTICON"
     /// u32     version = 0
@@ -165,6 +94,83 @@ impl Project {
             Ok(()) => Ok(()),
             Err(e) => Err(format!("failed to write to save file: {}",e).into()),
         }
+    }
+
+}
+
+impl<F> Project<F> {
+    /// Returns a new `Project` named `s` from memory `Region` `r`.
+    pub fn new(s: String, r: Region) -> Self {
+        Project {
+            name: s,
+            code: Vec::new(),
+            data: World::new(r),
+            comments: HashMap::new(),
+            imports: HashMap::new(),
+        }
+    }
+
+    /// Returns this project's root Region
+    pub fn region(&self) -> &Region {
+        // this cannot fail because World::new guarantees that data.root = r
+        self.data.dependencies.vertex_label(self.data.root).unwrap()
+    }
+}
+
+
+impl<F: Fun> Project<F> {
+    /// Returns the program with UUID `uu`
+    pub fn find_program_by_uuid(&self, uu: &Uuid) -> Option<&Program<F>> {
+        self.code.iter().find(|x| x.uuid == *uu)
+    }
+
+    /// Returns the program with UUID `uu`
+    pub fn find_program_by_uuid_mut(&mut self, uu: &Uuid) -> Option<&mut Program<F>> {
+        self.code.iter_mut().find(|x| x.uuid == *uu)
+    }
+
+    /// Returns function and enclosing program with UUID `uu`
+    pub fn find_function_by_uuid<'a>(&'a self, uu: &Uuid) -> Option<&'a F> {
+        for p in self.code.iter() {
+            if let Some(f) = p.find_function_by_uuid(uu) {
+                return Some(f);
+            }
+        }
+
+        None
+    }
+
+    /// Returns function and enclosing program with UUID `uu`
+    pub fn find_function_by_uuid_mut<'a>(&'a mut self, uu: &Uuid) -> Option<&'a mut F> {
+        for p in self.code.iter_mut() {
+            if let Some(f) = p.find_function_by_uuid_mut(uu) {
+                return Some(f);
+            }
+        }
+
+        None
+    }
+
+    /// Returns function/reference and enclosing program with UUID `uu`
+    pub fn find_call_target_by_uuid<'a>(&'a self, uu: &Uuid) -> Option<(CallGraphRef, &'a Program<F>)> {
+        for p in self.code.iter() {
+            if let Some(ct) = p.find_call_target_by_uuid(uu) {
+                return Some((ct, p));
+            }
+        }
+
+        None
+    }
+
+    /// Returns function/reference and enclosing program with UUID `uu`
+    pub fn find_call_target_by_uuid_mut<'a>(&'a mut self, uu: &Uuid) -> Option<(CallGraphRef, &'a mut Program<F>)> {
+        for p in self.code.iter_mut() {
+            if let Some(ct) = p.find_call_target_by_uuid(uu) {
+                return Some((ct, p));
+            }
+        }
+
+        None
     }
 }
 

--- a/data-flow/Cargo.toml
+++ b/data-flow/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["seu <seu@panopticon.re>"]
 
 [dependencies]
 bit-set = "0.4.0"
-petgraph = "0.4.9"
 env_logger = "0.3"
 log = "0.3.6"
 smallvec = "0.4.4"
+petgraph = { version = "0.4.10", features = ["serde-1"], git = "https://github.com/m4b/petgraph", branch = "dominance_frontiers" }
 panopticon-core = { path = "../core" }
 panopticon-graph-algos = { path = "../graph-algos" }

--- a/data-flow/src/lib.rs
+++ b/data-flow/src/lib.rs
@@ -133,6 +133,26 @@ impl DataFlow for Function {
     }
 }
 
+impl DataFlow for panopticon_core::neo::Function {
+    fn ssa_conversion(&mut self) -> Result<()> {
+        Ok(())
+    }
+    fn entry_point_mut(&mut self) -> &mut BasicBlock {
+        unimplemented!()
+    }
+    fn entry_point_ref(&self) -> ControlFlowRef {
+        unimplemented!()
+    }
+
+    fn cfg(&self) -> &Graph<ControlFlowTarget, Guard> {
+        unimplemented!()
+    }
+
+    fn cfg_mut(&mut self) -> &mut Graph<ControlFlowTarget, Guard> {
+        unimplemented!()
+    }
+}
+
 mod liveness;
 mod ssa;
 

--- a/data-flow/src/lib.rs
+++ b/data-flow/src/lib.rs
@@ -32,6 +32,59 @@ extern crate log;
 #[cfg(test)]
 extern crate env_logger;
 
+use panopticon_core::{Function, BasicBlock, Result, ControlFlowGraph, ControlFlowRef};
+
+pub trait SSAFunction {
+    fn ssa_conversion(&mut self) -> Result<()>;
+    fn cfg(&self) -> &ControlFlowGraph;
+    fn cfg_mut(&mut self) -> &mut ControlFlowGraph;
+    fn entry_point_mut(&mut self) -> &mut BasicBlock;
+    fn entry_point_ref(&self) -> ControlFlowRef;
+    fn postorder(&self) -> Vec<ControlFlowRef>;
+}
+
+impl SSAFunction for Function {
+    fn ssa_conversion(&mut self) -> Result<()> {
+        ssa_convertion(self)
+    }
+    fn cfg(&self) -> &ControlFlowGraph {
+        Function::cfg(self)
+    }
+    fn cfg_mut(&mut self) -> &mut ControlFlowGraph {
+        Function::cfg_mut(self)
+    }
+    fn entry_point_mut(&mut self) -> &mut BasicBlock {
+        Function::entry_point_mut(self)
+    }
+    fn entry_point_ref(&self) -> ControlFlowRef {
+        Function::entry_point_ref(self)
+    }
+    fn postorder(&self) -> Vec<ControlFlowRef> {
+        Function::postorder(self)
+    }
+}
+
+impl SSAFunction for panopticon_core::neo::Function {
+    fn ssa_conversion(&mut self) -> Result<()> {
+        Ok(())
+    }
+    fn entry_point_mut(&mut self) -> &mut BasicBlock {
+        unimplemented!()
+    }
+    fn entry_point_ref(&self) -> ControlFlowRef {
+        unimplemented!()
+    }
+    fn cfg(&self) -> &ControlFlowGraph {
+        unimplemented!()
+    }
+    fn cfg_mut(&mut self) -> &mut ControlFlowGraph {
+        unimplemented!()
+    }
+    fn postorder(&self) -> Vec<ControlFlowRef> {
+        unimplemented!()
+    }
+}
+
 mod liveness;
 pub use liveness::{liveness, liveness_sets};
 

--- a/data-flow/src/lib.rs
+++ b/data-flow/src/lib.rs
@@ -32,7 +32,43 @@ extern crate log;
 #[cfg(test)]
 extern crate env_logger;
 
-use panopticon_core::{Function, BasicBlock, Result, ControlFlowGraph, ControlFlowRef};
+//use panopticon_core::{Function, BasicBlock, Result, ControlFlowGraph, ControlFlowRef};
+use panopticon_core::*;
+use std::ops::Range;
+use std::collections::{HashMap, HashSet};
+use std::borrow::Cow;
+
+use petgraph::Graph;
+
+pub trait StandardMnemonic {
+    fn opcode(&self) -> &str;
+    fn operands(&self) -> Vec<Rvalue>;
+    fn area(&self) -> Range<u64>;
+}
+
+impl<'a> StandardMnemonic for &'a Mnemonic {
+    fn opcode(&self) -> &str {
+        self.opcode.as_str()
+    }
+    fn operands(&self) -> Vec<Rvalue> {
+        self.operands.clone()
+    }
+    fn area(&self) -> Range<u64> {
+        self.area.start..self.area.end
+    }
+}
+
+pub trait StandardBlock<M: StandardMnemonic> {
+    type Iter: Iterator<Item = M>;
+    fn mnemonics(&self) -> Self::Iter;
+}
+
+impl<'a> StandardBlock<&'a Mnemonic> for &'a BasicBlock {
+    type Iter = ::std::slice::Iter<'a, Mnemonic>;
+    fn mnemonics(&self) -> Self::Iter {
+        self.mnemonics.as_slice().iter()
+    }
+}
 
 pub trait SSAFunction {
     fn ssa_conversion(&mut self) -> Result<()>;
@@ -85,8 +121,83 @@ impl SSAFunction for panopticon_core::neo::Function {
     }
 }
 
+pub trait DataFlow: Sized {
+    fn ssa_conversion(&mut self) -> Result<()> {
+        Ok(())
+    }
+    /// Computes the set of global variables in `func` and their points of usage. Globals are
+    /// variables that are used in multiple basic blocks. Returns (Globals,Usage).
+    fn global_names(&self) -> (HashSet<Cow<'static, str>>, HashMap<Cow<'static, str>, HashSet<u32>>) {
+        let (varkill, uevar) = liveness_sets_pet(self);
+        let mut usage = HashMap::<Cow<'static, str>, HashSet<u32>>::new();
+        let mut globals = HashSet::<Cow<'static, str>>::new();
+
+        for (_, uev) in uevar {
+            for v in uev {
+                globals.insert(v);
+            }
+        }
+
+        for (vx, vk) in varkill {
+            for v in vk {
+                usage.entry(v.clone()).or_insert(HashSet::new()).insert(vx);
+            }
+        }
+
+        (globals, usage)
+    }
+
+    fn type_check(&self) -> Result<HashMap<Cow<'static, str>, usize>> {
+        let mut ret = HashMap::<Cow<'static, str>, usize>::new();
+        let cfg = self.cfg();
+        fn set_len(v: &Rvalue, ret: &mut HashMap<Cow<'static, str>, usize>) {
+            match v {
+                &Rvalue::Variable { ref name, ref size, .. } => {
+                    let val = *::std::cmp::max(ret.get(name).unwrap_or(&0), size);
+                    ret.insert(name.clone(), val);
+                }
+                _ => {}
+            }
+        }
+        for vx in cfg.node_indices() {
+            if let Some(&ControlFlowTarget::Resolved(ref bb)) = cfg.node_weight(vx) {
+                for mne in bb.mnemonics.iter() {
+                    for o in mne.operands.iter() {
+                        set_len(o, &mut ret);
+                    }
+
+                    for instr in mne.instructions.iter() {
+                        let ops = instr.op.operands();
+                        match ops.len() {
+                            0 => return Err("Operation w/o arguments".into()),
+                            _ => {
+                                for o in ops.iter() {
+                                    set_len(o, &mut ret);
+                                }
+                            }
+                        }
+                        set_len(&instr.assignee.clone().into(), &mut ret);
+                    }
+                }
+            }
+        }
+
+        for ed in cfg.edge_indices() {
+            if let Some(&Guard::Predicate { ref flag, .. }) = cfg.edge_weight(ed) {
+                set_len(flag, &mut ret);
+            }
+        }
+        Ok(ret)
+    }
+    fn entry_point_mut(&mut self) -> &mut BasicBlock;
+    fn entry_point_ref(&self) -> u32;
+    fn cfg(&self) -> &Graph<ControlFlowTarget, Guard>;
+    fn cfg_mut(&mut self) -> &mut Graph<ControlFlowTarget, Guard>;
+    fn postorder(&self) -> Vec<u32>;
+}
+
 mod liveness;
-pub use liveness::{liveness, liveness_sets};
+pub use liveness::{liveness, liveness_sets, liveness_sets_pet};
 
 mod ssa;
 pub use ssa::{flag_operations, ssa_convertion, type_check};

--- a/data-flow/src/liveness.rs
+++ b/data-flow/src/liveness.rs
@@ -16,15 +16,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-use panopticon_core::{ControlFlowRef, ControlFlowTarget, Fun, Function, Guard, Lvalue, Operation, Rvalue, Statement};
+use panopticon_core::{ControlFlowRef, ControlFlowTarget, Function, Guard, Lvalue, Operation, Rvalue, Statement};
 use panopticon_graph_algos::{GraphTrait, IncidenceGraphTrait};
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
+use SSAFunction;
 
 /// Computes the set of killed (VarKill) and upward exposed variables (UEvar) for each basic block
 /// in `func`. Returns (VarKill,UEvar).
-pub fn liveness_sets<Function: Fun>(func: &Function) -> (HashMap<ControlFlowRef, HashSet<Cow<'static, str>>>, HashMap<ControlFlowRef, HashSet<Cow<'static, str>>>) {
+pub fn liveness_sets<Function: SSAFunction>(func: &Function) -> (HashMap<ControlFlowRef, HashSet<Cow<'static, str>>>, HashMap<ControlFlowRef, HashSet<Cow<'static, str>>>) {
     let mut uevar = HashMap::<ControlFlowRef, HashSet<&str>>::new();
     let mut varkill = HashMap::<ControlFlowRef, HashSet<Cow<'static, str>>>::new();
     let ord = func.postorder();

--- a/data-flow/src/liveness.rs
+++ b/data-flow/src/liveness.rs
@@ -17,13 +17,12 @@
  */
 
 use panopticon_core::{ControlFlowTarget, ControlFlowRef, Guard, Lvalue, Operation, Rvalue, Statement};
+use petgraph::Direction;
+use petgraph::visit::{Walker, EdgeRef, DfsPostOrder};
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
 use DataFlow;
-
-use petgraph::Direction;
-use petgraph::visit::{Walker, EdgeRef, DfsPostOrder};
 
 /// Computes the set of killed (VarKill) and upward exposed variables (UEvar) for each basic block
 /// in `func`. Returns (VarKill,UEvar).

--- a/data-flow/src/liveness.rs
+++ b/data-flow/src/liveness.rs
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-use panopticon_core::{ControlFlowRef, ControlFlowTarget, Function, Guard, Lvalue, Operation, Rvalue, Statement};
+use panopticon_core::{ControlFlowRef, ControlFlowTarget, Fun, Function, Guard, Lvalue, Operation, Rvalue, Statement};
 use panopticon_graph_algos::{GraphTrait, IncidenceGraphTrait};
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
@@ -24,7 +24,7 @@ use std::iter::FromIterator;
 
 /// Computes the set of killed (VarKill) and upward exposed variables (UEvar) for each basic block
 /// in `func`. Returns (VarKill,UEvar).
-pub fn liveness_sets(func: &Function) -> (HashMap<ControlFlowRef, HashSet<Cow<'static, str>>>, HashMap<ControlFlowRef, HashSet<Cow<'static, str>>>) {
+pub fn liveness_sets<Function: Fun>(func: &Function) -> (HashMap<ControlFlowRef, HashSet<Cow<'static, str>>>, HashMap<ControlFlowRef, HashSet<Cow<'static, str>>>) {
     let mut uevar = HashMap::<ControlFlowRef, HashSet<&str>>::new();
     let mut varkill = HashMap::<ControlFlowRef, HashSet<Cow<'static, str>>>::new();
     let ord = func.postorder();

--- a/data-flow/src/ssa.rs
+++ b/data-flow/src/ssa.rs
@@ -17,7 +17,7 @@
  */
 
 use liveness_sets;
-use panopticon_core::{ControlFlowEdge, ControlFlowGraph, ControlFlowRef, ControlFlowTarget, Function, Guard, Lvalue, Mnemonic, Operation, Result, Rvalue,
+use panopticon_core::{ControlFlowEdge, ControlFlowGraph, ControlFlowRef, ControlFlowTarget, Fun, Function, Guard, Lvalue, Mnemonic, Operation, Result, Rvalue,
                       Statement};
 use panopticon_graph_algos::{BidirectionalGraphTrait, EdgeListGraphTrait, GraphTrait, IncidenceGraphTrait, MutableGraphTrait, VertexListGraphTrait};
 use panopticon_graph_algos::dominator::{dominance_frontiers, immediate_dominator};
@@ -28,7 +28,7 @@ use std::iter::FromIterator;
 
 /// Does a simple sanity check on all RREIL statements in `func`, returns every variable name
 /// found and its maximal size in bits.
-pub fn type_check(func: &Function) -> Result<HashMap<Cow<'static, str>, usize>> {
+pub fn type_check<Function: Fun>(func: &Function) -> Result<HashMap<Cow<'static, str>, usize>> {
     let mut ret = HashMap::<Cow<'static, str>, usize>::new();
     let cfg = func.cfg();
     fn set_len(v: &Rvalue, ret: &mut HashMap<Cow<'static, str>, usize>) {
@@ -76,7 +76,7 @@ pub fn type_check(func: &Function) -> Result<HashMap<Cow<'static, str>, usize>> 
 
 /// Computes the set of gloable variables in `func` and their points of usage. Globales are
 /// variables that are used in multiple basic blocks. Returns (Globals,Usage).
-pub fn global_names(func: &Function) -> (HashSet<Cow<'static, str>>, HashMap<Cow<'static, str>, HashSet<ControlFlowRef>>) {
+pub fn global_names<Function: Fun>(func: &Function) -> (HashSet<Cow<'static, str>>, HashMap<Cow<'static, str>, HashSet<ControlFlowRef>>) {
     let (varkill, uevar) = liveness_sets(func);
     let mut usage = HashMap::<Cow<'static, str>, HashSet<ControlFlowRef>>::new();
     let mut globals = HashSet::<Cow<'static, str>>::new();
@@ -98,7 +98,7 @@ pub fn global_names(func: &Function) -> (HashSet<Cow<'static, str>>, HashMap<Cow
 
 /// Inserts SSA Phi functions at junction points in the control flow graph of `func`. The
 /// algorithm produces the semi-pruned SSA form found in Cooper, Torczon: "Engineering a Compiler".
-pub fn phi_functions(func: &mut Function) -> Result<()> {
+pub fn phi_functions<Function: Fun>(func: &mut Function) -> Result<()> {
     let lens = type_check(func)?;
     let (globals, usage) = global_names(func);
 
@@ -148,7 +148,7 @@ pub fn phi_functions(func: &mut Function) -> Result<()> {
 
     let df = dominance_frontiers(&idom, func.cfg());
     let mut phis = HashSet::<(&Cow<'static, str>, ControlFlowRef)>::new();
-    let mut cfg = &mut func.cfg_mut();
+    let cfg = &mut func.cfg_mut();
 
     for v in globals.iter() {
         let mut worklist = if let Some(wl) = usage.get(v) {
@@ -200,7 +200,7 @@ pub fn phi_functions(func: &mut Function) -> Result<()> {
 /// Sets the SSA subscripts of all variables in `func`. Follows the algorithm outlined
 /// Cooper, Torczon: "Engineering a Compiler". The function expects that Phi functions to be
 /// already inserted.
-pub fn rename_variables(func: &mut Function) -> Result<()> {
+pub fn rename_variables<Function: Fun>(func: &mut Function) -> Result<()> {
     let (globals, _) = global_names(func);
     let mut stack = HashMap::<Cow<'static, str>, Vec<usize>>::from_iter(globals.iter().map(|x| (x.clone(), Vec::new())));
     let mut counter = HashMap::<Cow<'static, str>, usize>::new();
@@ -327,7 +327,7 @@ pub fn rename_variables(func: &mut Function) -> Result<()> {
 }
 
 /// Convert `func` into semi-pruned SSA form.
-pub fn ssa_convertion(func: &mut Function) -> Result<()> {
+pub fn ssa_convertion<Function: Fun>(func: &mut Function) -> Result<()> {
     phi_functions(func)?;
     rename_variables(func)
 }

--- a/data-flow/src/ssa.rs
+++ b/data-flow/src/ssa.rs
@@ -17,17 +17,15 @@
  */
 
 use liveness;
-//use panopticon_core::{ControlFlowGraph, ControlFlowTarget, Guard, Result, Rvalue, Statement};
-use panopticon_core::*;
-
-use std::cmp::max;
-use std::collections::{HashMap, HashSet};
-use std::iter::FromIterator;
-use std::borrow::Cow;
-
+use panopticon_core::{ControlFlowGraph, ControlFlowTarget, ControlFlowRef, ControlFlowEdge, Guard, Lvalue, Mnemonic, Operation, Result, Rvalue, Statement};
 use petgraph::{Direction};
 use petgraph::algo::dominators::{self, Dominators};
 use petgraph::visit::EdgeRef;
+
+use std::borrow::Cow;
+use std::cmp::max;
+use std::collections::{HashMap, HashSet};
+use std::iter::FromIterator;
 
 use DataFlow;
 

--- a/qt/Cargo.toml
+++ b/qt/Cargo.toml
@@ -36,7 +36,7 @@ num = "0.1"
 
 [dev-dependencies]
 regex = "0.1"
-quickcheck = "0.3"
+quickcheck = "0.4"
 
 [target.i686-unknown-linux-gnu.dependencies]
 xdg = "^2.0"

--- a/qt/src/main.rs
+++ b/qt/src/main.rs
@@ -139,14 +139,14 @@ fn exists_path_val(filepath: String) -> result::Result<(), String> {
 fn read_recent_sessions() -> Result<Vec<(String, String, PathBuf, u32)>> {
     use std::fs;
     use std::time;
-    use panopticon_core::Project;
+    use panopticon_core::{Function, Project};
 
     let path = paths::session_directory()?;
     let mut ret = vec![];
 
     if let Ok(dir) = fs::read_dir(path) {
         for ent in dir.filter_map(|x| x.ok()) {
-            if let Ok(ref project) = Project::open(&ent.path()) {
+            if let Ok(ref project) = <Project<Function>>::open(&ent.path()) {
                 if let Ok(ref md) = ent.metadata() {
                     let mtime = md.modified()?.duration_since(time::UNIX_EPOCH)?.as_secs() as u32;
                     let fname = ent.path();

--- a/qt/src/singleton.rs
+++ b/qt/src/singleton.rs
@@ -65,7 +65,7 @@ pub struct Panopticon {
     pub unresolved_calls: MultiMap<Option<u64>, (Uuid, u64)>,
     pub resolved_calls: MultiMap<Uuid, (Uuid, u64)>, // callee -> caller
     pub region: Option<Region>,
-    pub project: Option<Project>,
+    pub project: Option<Project<Function>>,
 
     pub undo_stack: Vec<Action>,
     pub undo_stack_top: usize,
@@ -126,7 +126,7 @@ impl Panopticon {
 
     pub fn open_program(&mut self, path: String) -> Result<()> {
         use std::path::Path;
-        use panopticon_core::{CallTarget, Machine};
+        use panopticon_core::{Function, CallTarget, Machine};
         use panopticon_amd64 as amd64;
         use panopticon_avr as avr;
         use panopticon_analysis::pipeline;
@@ -135,7 +135,7 @@ impl Panopticon {
 
         debug!("open_program() path={}", path);
 
-        if let Ok(proj) = Project::open(&Path::new(&path)) {
+        if let Ok(proj) = <Project<Function>>::open(&Path::new(&path)) {
             if !proj.code.is_empty() {
                 {
                     let cg = &proj.code[0].call_graph;


### PR DESCRIPTION
If you like, can merge this and you will be able to test new and old functions side by side.

Additionally, almost everything has been ported to petgraph (except `World`).

Note:

1. petgraph old function version of `ssa_conversion()` is broken; i note this in benchmarks, and line numbers.  I believe its my dominator implementation
2. you can test new and old via `panop` cli, using `--neo` flag for new; it will even run the new `rewite_to_ssa` (unfortunately, does not seem to be working, as testing on `libfoo.so.` etc., the function is  unfinished
3. We don't have to commit to generic function; its just very easy at the moment to have it generic so can run both side by side.
4. Re generic functions: I have a proposal/idea for this that i think is going to work beautifully, and I think we be best of both worlds, but will require petgraph across the board
5. I believe we want petgraph across the board; as I mentioned in PR, it looks like much of the savings are actually due to switching to petgraph.
6. some functions I added randomly, etc., don't consider `Fun` the final say, etc. We can remove anything you don't like, etc.

Some numbers, specifically testing the effect of porting the `Program` cfg to petgraph:

libc, f2d92e1 and ae19d49, 2999 functions:
  -------------------------------------------------------------------
  |   function lib | program lib | neo func |     time | RES memory |
  |:--------------:|:-----------:|:--------:|:--------:|:----------:|
  |    petgraph    | panopticon  |    yes   |  0:07.14 |  499440 KB |
  |    petgraph    | panopticon  |    no    |  0:06.00 | 1822716 KB |
  |    petgraph    |   petgraph  |    yes   |  0:06.13 |  494684 KB |
  |    petgraph    |   petgraph  |    no    |  0:04.75 | 1818756 KB |
  -------------------------------------------------------------------

rust binary, ae19d49, 2843 (long) functions:
  -------------------------------------------------------------------
  |   function lib | program lib | neo func |     time | RES memory |
  |:--------------:|:-----------:|:--------:|:--------:|:----------:|
  |    petgraph    |   petgraph  |    yes   |  0:32.40 | 1807908 KB |
  |    petgraph    |   petgraph  |    no    |  1:06.85 | 6751640 KB |
  -------------------------------------------------------------------
