### PR TITLE
Completely removes graph_algos from core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@ name = "panopticon-mos6502"
 version = "0.16.0"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "panopticon-core 0.16.0",
 ]
@@ -23,35 +23,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "atty"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "backtrace"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.12"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -90,6 +91,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "cassowary"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cc"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -134,26 +140,25 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.26.0"
+version = "2.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "textwrap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cmake"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -161,22 +166,9 @@ name = "coco"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "scopeguard 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "conv"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "custom_derive"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "dbghelp-sys"
@@ -189,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -206,7 +198,7 @@ name = "error-chain"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -214,7 +206,7 @@ name = "error-chain"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -224,31 +216,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "flate2"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "miniz-sys 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fuchsia-zircon-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "futures"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "futures-cpupool"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "gcc"
-version = "0.3.51"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "goblin"
@@ -282,7 +285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -292,7 +295,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.28"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -301,37 +304,20 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "magenta"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "magenta-sys"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "memchr"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "miniz-sys"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -359,7 +345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -407,10 +393,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num_cpus"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -438,14 +424,14 @@ dependencies = [
  "cassowary 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono-humanize 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.26.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-cpupool 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-cpupool 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hamt 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "multimap 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -458,7 +444,7 @@ dependencies = [
  "panopticon-glue 0.16.0",
  "panopticon-graph-algos 0.11.0",
  "panopticon-mos6502 0.16.0",
- "parking_lot 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -476,8 +462,8 @@ dependencies = [
  "panopticon-data-flow 0.16.0",
  "panopticon-graph-algos 0.11.0",
  "quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -497,12 +483,12 @@ name = "panopticon-analysis"
 version = "0.16.0"
 dependencies = [
  "chashmap 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "panopticon-core 0.16.0",
  "panopticon-data-flow 0.16.0",
  "panopticon-graph-algos 0.11.0",
- "parking_lot 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -525,6 +511,7 @@ dependencies = [
  "bencher 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "panopticon-amd64 0.16.0",
  "panopticon-core 0.16.0",
+ "panopticon-data-flow 0.16.0",
  "panopticon-graph-algos 0.11.0",
 ]
 
@@ -532,10 +519,10 @@ dependencies = [
 name = "panopticon-cli"
 version = "0.16.0"
 dependencies = [
- "atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "panopticon-amd64 0.16.0",
  "panopticon-analysis 0.16.0",
@@ -544,7 +531,7 @@ dependencies = [
  "panopticon-graph-algos 0.11.0",
  "structopt 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt-derive 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -554,10 +541,10 @@ dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "goblin 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "leb128 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "panopticon-avr 0.16.0",
@@ -565,9 +552,10 @@ dependencies = [
  "petgraph 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -577,18 +565,21 @@ name = "panopticon-data-flow"
 version = "0.16.0"
 dependencies = [
  "bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "panopticon-core 0.16.0",
  "panopticon-graph-algos 0.11.0",
  "petgraph 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "panopticon-glue"
 version = "0.16.0"
 dependencies = [
- "cmake 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cmake 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "panopticon-core 0.16.0",
  "panopticon-graph-algos 0.11.0",
@@ -601,9 +592,9 @@ name = "panopticon-graph-algos"
 version = "0.11.0"
 dependencies = [
  "bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rmp-serde 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -612,29 +603,28 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "owning_ref 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread-id 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "parking_lot"
-version = "0.4.4"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread-id 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.2.2"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -664,7 +654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -674,7 +664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -684,11 +674,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -705,17 +695,25 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "redox_termios"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "regex"
@@ -736,7 +734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rmp"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -745,17 +743,17 @@ dependencies = [
 
 [[package]]
 name = "rmp-serde"
-version = "0.13.5"
+version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rmp 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -765,7 +763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "scopeguard"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -784,15 +782,15 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.11"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_bytes"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -801,23 +799,23 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_bytes 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_bytes 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.11"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive_internals 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_internals 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -826,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "0.4.1"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -844,7 +842,7 @@ name = "structopt"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.26.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -879,7 +877,7 @@ name = "tempdir"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -888,21 +886,31 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "termcolor"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "wincolor 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "termion"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "textwrap"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -915,7 +923,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -924,8 +932,8 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -942,15 +950,10 @@ version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-width"
@@ -972,8 +975,8 @@ name = "uuid"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1008,9 +1011,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
-"checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
-"checksum backtrace 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "72f9b4182546f4b04ebc4ab7f84948953a118bd6021a1b6a6c909e3e94f6be76"
-"checksum backtrace-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "afccc5772ba333abccdf60d55200fa3406f8c59dcf54d5f7998c9107d3799c7c"
+"checksum atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "21e50800ec991574876040fff8ee46b136a53e985286fbe6a3bdfe6421b78860"
+"checksum backtrace 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "99f2ce94e22b8e664d95c57fff45b98a966c2252b60691d0b7aeeccd88d70983"
+"checksum backtrace-sys 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "b17fc3beec932aac5aa70edd2abb3c9948bfb04df4abe5cec36190655a9c02b8"
 "checksum bencher 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1668b311500dd3b240933ee5ca5a80505e8378a4fa0a6457f629760e97d6c992"
 "checksum bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9bf6104718e80d7b26a68fdbacff3481cfc05df670821affc7e9cbc1884400c"
 "checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
@@ -1018,38 +1021,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
 "checksum cassowary 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "934c4515ec7266e7f1c0206d9e1f9efb92b321cc180073c4ad4ad7691fe524e6"
+"checksum cc 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2c674f0870e3dbd4105184ea035acb1c32c8ae69939c9e228d2b11bbfe29efad"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum chashmap 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "47e651a8c1eb0cbbaa730f705e2531e75276c6f2bbe2eb12662cfd305213dff8"
 "checksum chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9213f7cd7c27e95c2b57c49f0e69b1ea65b27138da84a170133fd21b07659c00"
 "checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 "checksum chrono-humanize 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "37f0c1ab0076303dd9cca44c5d6386c875f8f4809a3cbd20dec719cda27b0c31"
-"checksum clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2267a8fdd4dce6956ba6649e130f62fb279026e5e84b92aa939ac8f85ce3f9f0"
-"checksum cmake 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ebbb35d3dc9cd09497168f33de1acb79b265d350ab0ac34133b98f8509af1f"
+"checksum clap 2.26.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3451e409013178663435d6f15fdb212f14ee4424a3d74f979d081d0a66b6f1f2"
+"checksum cmake 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "357c07e7a1fc95732793c1edb5901e1a1f305cfcf63a90eb12dbd22bdb6b789d"
 "checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
-"checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
-"checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
-"checksum either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18785c1ba806c258137c937e44ada9ee7e69a37e3c72077542cd2f069d78562a"
+"checksum either 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cbee135e9245416869bf52bd6ccc9b59e2482651510784e089b874272f02a252"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6930e04918388a9a2e41d518c25cf679ccafe26733fb4127dbf21993f2575d46"
 "checksum fixedbitset 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "85cb8fec437468d86dc7c83ca7cfc933341d561873275f22dd5eedefa63a6478"
-"checksum flate2 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)" = "36df0166e856739905cd3d7e0b210fe818592211a008862599845e012d8d304c"
-"checksum futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4b63a4792d4f8f686defe3b39b92127fea6344de5d38202b2ee5a11bbbf29d6a"
-"checksum futures-cpupool 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a283c84501e92cade5ea673a2a7ca44f71f209ccdd302a3e0896f50083d2c5ff"
-"checksum gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)" = "120d07f202dcc3f72859422563522b66fe6463a4c513df062874daad05f85f0a"
+"checksum flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "e6234dd4468ae5d1e2dbb06fe2b058696fdc50a339c68a393aefbf00bc81e423"
+"checksum fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f6c0581a4e363262e52b87f59ee2afe3415361c6ec35e665924eb08afe8ff159"
+"checksum fuchsia-zircon-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43f3795b4bae048dc6123a6b972cadde2e676f9ded08aef6bb77f5f157684a82"
+"checksum futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "05a23db7bd162d4e8265968602930c476f688f0c180b44bdaf55e0cb2c687558"
+"checksum futures-cpupool 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "e86f49cc0d92fe1b97a5980ec32d56208272cbb00f15044ea9e2799dde766fdf"
 "checksum goblin 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "af2eef72dbdc4f41bb8d5401ca7edb2f97e58e5606d51715ba3767e7dad4a4ae"
 "checksum hamt 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a348cf9404ba4aeff9fe6f5e9f5d12eaf236b5e51f129f876e8666af7e21cb50"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
-"checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
+"checksum lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c9e5e58fa1a4c3b915a561a78a22ee0cac6ab97dca2504428bc1cb074375f8d5"
 "checksum leb128 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "792224a73787e4b0f59e387e4f53d23dfc1d72e3c82fcbf6d3e14de6aabad212"
-"checksum libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb7b49972ee23d8aa1026c365a5b440ba08e35075f18c459980c7395c221ec48"
+"checksum libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "56cce3130fd040c28df6f495c8492e5ec5808fb4c9093c310df02b0c8f030148"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
-"checksum magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf0336886480e671965f794bc9b6fce88503563013d1bfb7a502c81fe3ac527"
-"checksum magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40d014c7011ac470ae28e2f76a02bfea4a8480f73e701353b49ad7a8d75f4699"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
-"checksum miniz-sys 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "28eaee17666671fa872e567547e8428e83308ebe5808cdf6a0e28397dbe2c726"
+"checksum miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "609ce024854aeb19a0ef7567d348aaa5a746b32fb72e336df7fcc16869d7e2b4"
 "checksum multimap 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9223f4774d08e06185e44e555b9a7561243d387bac49c78a6205c42d6975fbf2"
 "checksum num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "a311b77ebdc5dd4cf6449d81e4135d9f0e3b153839ac90e648a8ef538f923525"
 "checksum num-bigint 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "8fd0f8dbb4c0960998958a796281d88c16fbe68d87b1baa6f31e2979e81fd0bd"
@@ -1058,38 +1059,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "7485fcc84f85b4ecd0ea527b14189281cf27d60e583ae65ebc9c088b13dffe01"
 "checksum num-rational 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "288629c76fac4b33556f4b7ab57ba21ae202da65ba8b77466e6d598e31990790"
 "checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
-"checksum num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aec53c34f2d0247c5ca5d32cca1478762f301740468ee9ee6dcb7a0dd7a0c584"
+"checksum num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "514f0d73e64be53ff320680ca671b64fe3fb91da01e1ae2ddc99eb51d453b20d"
 "checksum ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b81cf3b8cb96aa0e73bbedfcdc9708d09fec2854ba8d474be4e6f666d7379e8b"
 "checksum owning_ref 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9d52571ddcb42e9c900c901a18d8d67e393df723fcd51dd59c5b1a85d0acb6cc"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum parking_lot 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "fa12d706797d42551663426a45e2db2e0364bd1dbf6aeada87e89c5f981f43e9"
-"checksum parking_lot 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "37f364e2ce5efa24c7d0b6646d5bb61145551a0112f107ffd7499f1a3e322fbd"
-"checksum parking_lot_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0ad2c4d148942b3560034785bf19df586ebba53351e8c78f84984147d5795eef"
+"checksum parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "149d8f5b97f3c1133e3cfcd8886449959e856b557ff281e292b733d7c69e005e"
+"checksum parking_lot_core 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4f610cb9664da38e417ea3225f23051f589851999535290e077939838ab7a595"
 "checksum petgraph 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "2c960f99a9b3962c6a942e0e8f1f47fe72c82202dae8539ded32d3bb8c4e67d5"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum plain 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "da55423d5704ee357503ce020f88b90269610ec85708331e6a7879dd4cea3122"
 "checksum quickcheck 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0b333da40686cc05db13d933f8e7b450f403cfc5a4d005154d8d4a5ba9d14605"
 "checksum quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "02c2411d418cea2364325b18a205664f9ef8252e06b2e911db97c0b0d98b1406"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-"checksum rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "eb250fd207a4729c976794d03db689c9be1d634ab5a1c9da9492a13d8fecbcdf"
+"checksum rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "61efcbcd9fa8d8fbb07c84e34a8af18a1ff177b449689ad38a6e9457ecc7b2ae"
 "checksum rayon 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b614fe08b6665cb9a231d07ac1364b0ef3cb3698f1239ee0c4c3a88a524f54c8"
 "checksum rayon-core 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7febc28567082c345f10cddc3612c6ea020fc3297a1977d472cf9fdb73e6e493"
-"checksum redox_syscall 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "ddab7acd8e7bf3e49dfdf78ac1209b992329eb2f66e0bf672ab49c70a76d1d68"
+"checksum redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "8dde11f18c108289bef24469638a04dce49da56084f2d50618b226e47eb04509"
+"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
-"checksum rmp 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7ce560a5728f4eec697f07f8d7fa20608893d44b4f5b8f9f5f51a2987f3cffe2"
-"checksum rmp-serde 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)" = "dbb19882ba4aa5fbd0e5dc5f1550a4195c36f2ff02353e26b2c94dd255982e97"
-"checksum rustc-demangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3058a43ada2c2d0b92b3ae38007a2d0fa5e9db971be260e0171408a4ff471c95"
+"checksum rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a3d45d7afc9b132b34a2479648863aa95c5c88e98b32285326a6ebadc80ec5c9"
+"checksum rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)" = "011e1d58446e9fa3af7cdc1fb91295b10621d3ac4cb3a85cc86385ee9ca50cd3"
+"checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
-"checksum scopeguard 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c79eb2c3ac4bc2507cda80e7f3ac5b88bd8eae4c0914d5663e6a8933994be918"
+"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum scroll 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8b7f03feefe9fb109f395b78c1d6d5a91bd25e1df6c50170a1647f16bcc9debf"
 "checksum scroll_derive 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "78b635a7daaf51a06b19bc2e7bbb64381d61733809dd202b4059b30cbdc5a2b8"
-"checksum serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f7726f29ddf9731b17ff113c461e362c381d9d69433f79de4f3dd572488823e9"
-"checksum serde_bytes 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "12b8ae62bf2de9844de7506deb95667943b156ac18136a5c8124cb2ac0c51e19"
+"checksum serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "6a7046c9d4c6c522d10b2d098f9bebe2bef227e0e74044d8c1bfcf6b476af799"
+"checksum serde_bytes 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5a35acc737295444cf7eb136236563f13dcddbfef65ac00d07870b590df77ed5"
 "checksum serde_cbor 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "27181cf088428830792d77a40dd44f59d663f3e909bd56cef8c815403cf814ba"
-"checksum serde_derive 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cf823e706be268e73e7747b147aa31c8f633ab4ba31f115efb57e5047c3a76dd"
-"checksum serde_derive_internals 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37aee4e0da52d801acfbc0cc219eb1eda7142112339726e427926a6f6ee65d3a"
-"checksum smallvec 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "26aa2afb825226fa29f0315de04d5a4af5fd44adadf837296accc01a49929724"
+"checksum serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "1afcaae083fd1c46952a315062326bc9957f182358eb7da03b57ef1c688f7aa9"
+"checksum serde_derive_internals 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd381f6d01a6616cdba8530492d453b7761b456ba974e98768a18cad2cd76f58"
+"checksum smallvec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ee4f357e8cd37bf8822e1b964e96fd39e2cb5a0424f8aaa284ccaccc2162411c"
 "checksum stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15132e0e364248108c5e2c02e3ab539be8d6f5d52a01ca9bbf27ed657316f02b"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum structopt 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "79f07532bff6d657b904f2e6258f7b51aa62ba95ac623bed728decbaf29ca499"
@@ -1098,13 +1100,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
 "checksum term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b6b55df3198cc93372e85dd2ed817f0e38ce8cc0f22eb32391bfad9c4bf209"
-"checksum termcolor 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9a5193a56b8d82014662c4b933dea6bec851daf018a2b01722e007daaf5f9dca"
-"checksum textwrap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f728584ea33b0ad19318e20557cb0a39097751dbb07171419673502f848c7af6"
+"checksum termcolor 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9065bced9c3e43453aa3d56f1e98590b8455b341d2fa191a1090c0dd0b242c75"
+"checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
+"checksum textwrap 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df8e08afc40ae3459e4838f303e465aa50d823df8d7f83ca88108f6d3afe7edd"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread-id 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2af4d6289a69a35c4d3aea737add39685f2784122c28119a7713165a63d68c9d"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520"
-"checksum unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8083c594e02b8ae1654ae26f0ade5158b119bd88ad0e8227a5d8fcd72407946"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,7 +549,6 @@ dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "panopticon-avr 0.16.0",
- "panopticon-graph-algos 0.11.0",
  "petgraph 0.4.10 (git+https://github.com/m4b/petgraph?branch=dominance_frontiers)",
  "quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "bencher"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bit-set"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,6 +519,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "panopticon-benchmark"
+version = "0.16.0"
+dependencies = [
+ "bencher 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "panopticon-amd64 0.16.0",
+ "panopticon-core 0.16.0",
+ "panopticon-graph-algos 0.11.0",
+]
+
+[[package]]
 name = "panopticon-cli"
 version = "0.16.0"
 dependencies = [
@@ -561,8 +576,10 @@ dependencies = [
 name = "panopticon-data-flow"
 version = "0.16.0"
 dependencies = [
+ "bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "panopticon-core 0.16.0",
  "panopticon-graph-algos 0.11.0",
+ "petgraph 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -994,6 +1011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
 "checksum backtrace 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "72f9b4182546f4b04ebc4ab7f84948953a118bd6021a1b6a6c909e3e94f6be76"
 "checksum backtrace-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "afccc5772ba333abccdf60d55200fa3406f8c59dcf54d5f7998c9107d3799c7c"
+"checksum bencher 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1668b311500dd3b240933ee5ca5a80505e8378a4fa0a6457f629760e97d6c992"
 "checksum bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9bf6104718e80d7b26a68fdbacff3481cfc05df670821affc7e9cbc1884400c"
 "checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fixedbitset"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "flate2"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +278,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "lazy_static"
 version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "leb128"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -391,6 +409,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordermap"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "owning_ref"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,7 +470,7 @@ dependencies = [
  "panopticon-core 0.16.0",
  "panopticon-data-flow 0.16.0",
  "panopticon-graph-algos 0.11.0",
- "quickcheck 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -515,14 +538,17 @@ version = "0.16.0"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "goblin 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "leb128 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "panopticon-avr 0.16.0",
  "panopticon-graph-algos 0.11.0",
- "quickcheck 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -596,6 +622,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fixedbitset 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +643,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "quickcheck"
 version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quickcheck"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -968,7 +1013,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18785c1ba806c258137c937e44ada9ee7e69a37e3c72077542cd2f069d78562a"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
+"checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6930e04918388a9a2e41d518c25cf679ccafe26733fb4127dbf21993f2575d46"
+"checksum fixedbitset 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "85cb8fec437468d86dc7c83ca7cfc933341d561873275f22dd5eedefa63a6478"
 "checksum flate2 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)" = "36df0166e856739905cd3d7e0b210fe818592211a008862599845e012d8d304c"
 "checksum futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4b63a4792d4f8f686defe3b39b92127fea6344de5d38202b2ee5a11bbbf29d6a"
 "checksum futures-cpupool 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a283c84501e92cade5ea673a2a7ca44f71f209ccdd302a3e0896f50083d2c5ff"
@@ -978,6 +1025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
+"checksum leb128 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "792224a73787e4b0f59e387e4f53d23dfc1d72e3c82fcbf6d3e14de6aabad212"
 "checksum libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb7b49972ee23d8aa1026c365a5b440ba08e35075f18c459980c7395c221ec48"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
 "checksum magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf0336886480e671965f794bc9b6fce88503563013d1bfb7a502c81fe3ac527"
@@ -993,14 +1041,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-rational 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "288629c76fac4b33556f4b7ab57ba21ae202da65ba8b77466e6d598e31990790"
 "checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
 "checksum num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aec53c34f2d0247c5ca5d32cca1478762f301740468ee9ee6dcb7a0dd7a0c584"
+"checksum ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b81cf3b8cb96aa0e73bbedfcdc9708d09fec2854ba8d474be4e6f666d7379e8b"
 "checksum owning_ref 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9d52571ddcb42e9c900c901a18d8d67e393df723fcd51dd59c5b1a85d0acb6cc"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum parking_lot 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "fa12d706797d42551663426a45e2db2e0364bd1dbf6aeada87e89c5f981f43e9"
 "checksum parking_lot 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "37f364e2ce5efa24c7d0b6646d5bb61145551a0112f107ffd7499f1a3e322fbd"
 "checksum parking_lot_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0ad2c4d148942b3560034785bf19df586ebba53351e8c78f84984147d5795eef"
+"checksum petgraph 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "2c960f99a9b3962c6a942e0e8f1f47fe72c82202dae8539ded32d3bb8c4e67d5"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum plain 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "da55423d5704ee357503ce020f88b90269610ec85708331e6a7879dd4cea3122"
 "checksum quickcheck 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0b333da40686cc05db13d933f8e7b450f403cfc5a4d005154d8d4a5ba9d14605"
+"checksum quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "02c2411d418cea2364325b18a205664f9ef8252e06b2e911db97c0b0d98b1406"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "eb250fd207a4729c976794d03db689c9be1d634ab5a1c9da9492a13d8fecbcdf"
 "checksum rayon 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b614fe08b6665cb9a231d07ac1364b0ef3cb3698f1239ee0c4c3a88a524f54c8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "ordermap"
-version = "0.2.13"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -445,7 +445,7 @@ dependencies = [
  "panopticon-graph-algos 0.11.0",
  "panopticon-mos6502 0.16.0",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quickcheck 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -474,7 +474,7 @@ dependencies = [
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "panopticon-core 0.16.0",
- "quickcheck 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -512,7 +512,7 @@ dependencies = [
  "panopticon-amd64 0.16.0",
  "panopticon-core 0.16.0",
  "panopticon-data-flow 0.16.0",
- "panopticon-graph-algos 0.11.0",
+ "petgraph 0.4.10 (git+https://github.com/m4b/petgraph?branch=dominance_frontiers)",
 ]
 
 [[package]]
@@ -528,6 +528,7 @@ dependencies = [
  "panopticon-analysis 0.16.0",
  "panopticon-avr 0.16.0",
  "panopticon-core 0.16.0",
+ "panopticon-data-flow 0.16.0",
  "panopticon-graph-algos 0.11.0",
  "structopt 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt-derive 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -549,7 +550,7 @@ dependencies = [
  "num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "panopticon-avr 0.16.0",
  "panopticon-graph-algos 0.11.0",
- "petgraph 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.10 (git+https://github.com/m4b/petgraph?branch=dominance_frontiers)",
  "quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -569,7 +570,7 @@ dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "panopticon-core 0.16.0",
  "panopticon-graph-algos 0.11.0",
- "petgraph 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.10 (git+https://github.com/m4b/petgraph?branch=dominance_frontiers)",
  "smallvec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -630,11 +631,13 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.4.10"
+source = "git+https://github.com/m4b/petgraph?branch=dominance_frontiers#6ea8c947b679780ee156e445ea0edfa01676dcdc"
 dependencies = [
  "fixedbitset 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordermap 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -646,16 +649,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "plain"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "quickcheck"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "quickcheck"
@@ -1060,16 +1053,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-rational 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "288629c76fac4b33556f4b7ab57ba21ae202da65ba8b77466e6d598e31990790"
 "checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
 "checksum num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "514f0d73e64be53ff320680ca671b64fe3fb91da01e1ae2ddc99eb51d453b20d"
-"checksum ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b81cf3b8cb96aa0e73bbedfcdc9708d09fec2854ba8d474be4e6f666d7379e8b"
+"checksum ordermap 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8c7790b1bc9bf27776cd5cdeaae1263758c2c597d4ae02b58aa63c320f94d778"
 "checksum owning_ref 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9d52571ddcb42e9c900c901a18d8d67e393df723fcd51dd59c5b1a85d0acb6cc"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum parking_lot 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "fa12d706797d42551663426a45e2db2e0364bd1dbf6aeada87e89c5f981f43e9"
 "checksum parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "149d8f5b97f3c1133e3cfcd8886449959e856b557ff281e292b733d7c69e005e"
 "checksum parking_lot_core 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4f610cb9664da38e417ea3225f23051f589851999535290e077939838ab7a595"
-"checksum petgraph 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "2c960f99a9b3962c6a942e0e8f1f47fe72c82202dae8539ded32d3bb8c4e67d5"
+"checksum petgraph 0.4.10 (git+https://github.com/m4b/petgraph?branch=dominance_frontiers)" = "<none>"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum plain 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "da55423d5704ee357503ce020f88b90269610ec85708331e6a7879dd4cea3122"
-"checksum quickcheck 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0b333da40686cc05db13d933f8e7b450f403cfc5a4d005154d8d4a5ba9d14605"
 "checksum quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "02c2411d418cea2364325b18a205664f9ef8252e06b2e911db97c0b0d98b1406"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "61efcbcd9fa8d8fbb07c84e34a8af18a1ff177b449689ad38a6e9457ecc7b2ae"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,7 +632,7 @@ dependencies = [
 [[package]]
 name = "petgraph"
 version = "0.4.10"
-source = "git+https://github.com/m4b/petgraph?branch=dominance_frontiers#6ea8c947b679780ee156e445ea0edfa01676dcdc"
+source = "git+https://github.com/m4b/petgraph?branch=dominance_frontiers#9a6af51bf9803414d68e27f5e8d08600ce2a6212"
 dependencies = [
  "fixedbitset 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordermap 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["qt", "cli"]
+members = ["qt", "cli", "benchmark"]

--- a/abstract-interp/Cargo.toml
+++ b/abstract-interp/Cargo.toml
@@ -8,7 +8,7 @@ panopticon-core = { path = "../core" }
 panopticon-data-flow = { path = "../data-flow" }
 panopticon-graph-algos = { path = "../graph-algos" }
 log = "0.3.6"
-quickcheck = "0.3"
+quickcheck = "0.4.1"
 env_logger = "0.3"
 serde = "1.0"
 serde_derive = "1.0"

--- a/amd64/Cargo.toml
+++ b/amd64/Cargo.toml
@@ -8,7 +8,7 @@ panopticon-core = { path = "../core" }
 log = "0.3.6"
 byteorder = "1"
 env_logger = "0.3"
-quickcheck = "0.3"
+quickcheck = "0.4"
 
 [dev-dependencies]
 regex = "0.1"

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["seu <seu@panopticon.re>"]
 panopticon-core = { path = "../core" }
 panopticon-data-flow = { path = "../data-flow" }
 panopticon-amd64 = { path = "../amd64" }
-panopticon-graph-algos = { path = "../graph-algos" }
+petgraph = { version = "0.4.10", features = ["serde-1"], git = "https://github.com/m4b/petgraph", branch = "dominance_frontiers" }
 bencher = "0.1.4"
 
 [[bench]]

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "panopticon-benchmark"
+version = "0.16.0"
+authors = ["seu <seu@panopticon.re>"]
+
+[dependencies]
+panopticon-core = { path = "../core" }
+panopticon-amd64 = { path = "../amd64" }
+panopticon-graph-algos = { path = "../graph-algos" }
+bencher = "0.1.4"
+
+[[bench]]
+name = "core"
+harness = false

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -5,10 +5,11 @@ authors = ["seu <seu@panopticon.re>"]
 
 [dependencies]
 panopticon-core = { path = "../core" }
+panopticon-data-flow = { path = "../data-flow" }
 panopticon-amd64 = { path = "../amd64" }
 panopticon-graph-algos = { path = "../graph-algos" }
 bencher = "0.1.4"
 
 [[bench]]
-name = "core"
+name = "main"
 harness = false

--- a/benchmark/benches/core.rs
+++ b/benchmark/benches/core.rs
@@ -3,12 +3,11 @@ use panopticon_amd64 as amd64;
 
 fn static_amd64_elf_new(b: &mut Bencher) {
     use panopticon_core::{loader,neo,CallTarget,Rvalue};
-    use panopticon_graph_algos::{VertexListGraphTrait,GraphTrait};
     use std::path::Path;
 
-    let (proj,_) = loader::load(Path::new("../test-data/static")).unwrap();
-    let entries = proj.code[0].call_graph.vertices().filter_map(|vx| if let Some(&CallTarget::Todo(Rvalue::Constant{ value,.. },_,_)) = proj.code[0].call_graph.vertex_label(vx) { Some(value) } else { None }).collect::<Vec<_>>();
-    let reg = proj.data.dependencies.vertex_label(proj.data.root).unwrap();
+    let (proj,_) = loader::load::<neo::Function>(Path::new("../test-data/static")).unwrap();
+    let entries = proj.code[0].iter_callgraph().filter_map(|vx| if let &CallTarget::Todo(Rvalue::Constant{ value,.. },_,_) = vx { Some (value) } else { None }).collect::<Vec<u64>>();
+    let reg = proj.region();
 
     b.bench_n(1,|b| {
         b.iter(|| {
@@ -21,12 +20,11 @@ fn static_amd64_elf_new(b: &mut Bencher) {
 
 fn static_amd64_elf_old(b: &mut Bencher) {
     use panopticon_core::{loader,Function,CallTarget,Rvalue};
-    use panopticon_graph_algos::{VertexListGraphTrait,GraphTrait};
     use std::path::Path;
 
-    let (proj,_) = loader::load(Path::new("../test-data/static")).unwrap();
-    let entries = proj.code[0].call_graph.vertices().filter_map(|vx| if let Some(&CallTarget::Todo(Rvalue::Constant{ value,.. },_,_)) = proj.code[0].call_graph.vertex_label(vx) { Some(value) } else { None }).collect::<Vec<_>>();
-    let reg = proj.data.dependencies.vertex_label(proj.data.root).unwrap();
+    let (proj,_) = loader::load::<Function>(Path::new("../test-data/static")).unwrap();
+    let entries = proj.code[0].iter_callgraph().filter_map(|vx| if let &CallTarget::Todo(Rvalue::Constant{ value,.. },_,_) = vx { Some (value) } else { None }).collect::<Vec<u64>>();
+    let reg = proj.region();
 
     b.bench_n(1,|b| {
         b.iter(|| {

--- a/benchmark/benches/core.rs
+++ b/benchmark/benches/core.rs
@@ -1,12 +1,7 @@
-#[macro_use]
-extern crate bencher;
-extern crate panopticon_amd64 as amd64;
-extern crate panopticon_graph_algos;
-extern crate panopticon_core;
-
 use bencher::Bencher;
+use panopticon_amd64 as amd64;
 
-fn disassemble_static_amd64_elf_new(b: &mut Bencher) {
+fn static_amd64_elf_new(b: &mut Bencher) {
     use panopticon_core::{loader,neo,CallTarget,Rvalue};
     use panopticon_graph_algos::{VertexListGraphTrait,GraphTrait};
     use std::path::Path;
@@ -24,7 +19,7 @@ fn disassemble_static_amd64_elf_new(b: &mut Bencher) {
     });
 }
 
-fn disassemble_static_amd64_elf_old(b: &mut Bencher) {
+fn static_amd64_elf_old(b: &mut Bencher) {
     use panopticon_core::{loader,Function,CallTarget,Rvalue};
     use panopticon_graph_algos::{VertexListGraphTrait,GraphTrait};
     use std::path::Path;
@@ -42,5 +37,4 @@ fn disassemble_static_amd64_elf_old(b: &mut Bencher) {
     });
 }
 
-benchmark_group!(benches, disassemble_static_amd64_elf_new, disassemble_static_amd64_elf_old);
-benchmark_main!(benches);
+benchmark_group!(disassemble, static_amd64_elf_new, static_amd64_elf_old);

--- a/benchmark/benches/core.rs
+++ b/benchmark/benches/core.rs
@@ -1,0 +1,46 @@
+#[macro_use]
+extern crate bencher;
+extern crate panopticon_amd64 as amd64;
+extern crate panopticon_graph_algos;
+extern crate panopticon_core;
+
+use bencher::Bencher;
+
+fn disassemble_static_amd64_elf_new(b: &mut Bencher) {
+    use panopticon_core::{loader,neo,CallTarget,Rvalue};
+    use panopticon_graph_algos::{VertexListGraphTrait,GraphTrait};
+    use std::path::Path;
+
+    let (proj,_) = loader::load(Path::new("../test-data/static")).unwrap();
+    let entries = proj.code[0].call_graph.vertices().filter_map(|vx| if let Some(&CallTarget::Todo(Rvalue::Constant{ value,.. },_,_)) = proj.code[0].call_graph.vertex_label(vx) { Some(value) } else { None }).collect::<Vec<_>>();
+    let reg = proj.data.dependencies.vertex_label(proj.data.root).unwrap();
+
+    b.bench_n(1,|b| {
+        b.iter(|| {
+            for &ep in entries.iter() {
+                neo::Function::new::<amd64::Amd64>(amd64::Mode::Long,ep,&reg,Some("".into())).unwrap();
+            }
+        });
+    });
+}
+
+fn disassemble_static_amd64_elf_old(b: &mut Bencher) {
+    use panopticon_core::{loader,Function,CallTarget,Rvalue};
+    use panopticon_graph_algos::{VertexListGraphTrait,GraphTrait};
+    use std::path::Path;
+
+    let (proj,_) = loader::load(Path::new("../test-data/static")).unwrap();
+    let entries = proj.code[0].call_graph.vertices().filter_map(|vx| if let Some(&CallTarget::Todo(Rvalue::Constant{ value,.. },_,_)) = proj.code[0].call_graph.vertex_label(vx) { Some(value) } else { None }).collect::<Vec<_>>();
+    let reg = proj.data.dependencies.vertex_label(proj.data.root).unwrap();
+
+    b.bench_n(1,|b| {
+        b.iter(|| {
+            for &ep in entries.iter() {
+                Function::new::<amd64::Amd64>(ep,&reg,None,amd64::Mode::Long).unwrap();
+            }
+        });
+    });
+}
+
+benchmark_group!(benches, disassemble_static_amd64_elf_new, disassemble_static_amd64_elf_old);
+benchmark_main!(benches);

--- a/benchmark/benches/data_flow.rs
+++ b/benchmark/benches/data_flow.rs
@@ -1,17 +1,15 @@
 use bencher::Bencher;
 use panopticon_amd64 as amd64;
-use panopticon_core::neo;
+use panopticon_data_flow::DataFlow;
 use panopticon_data_flow::neo::rewrite_to_ssa;
-use panopticon_data_flow::ssa_convertion;
 
 fn ssa_convertion_new(b: &mut Bencher) {
     use panopticon_core::{loader,neo,CallTarget,Rvalue};
-    use panopticon_graph_algos::{VertexListGraphTrait,GraphTrait};
     use std::path::Path;
 
-    let (proj,_) = loader::load(Path::new("../test-data/static")).unwrap();
-    let entries = proj.code[0].call_graph.vertices().filter_map(|vx| if let Some(&CallTarget::Todo(Rvalue::Constant{ value,.. },_,_)) = proj.code[0].call_graph.vertex_label(vx) { Some(value) } else { None }).collect::<Vec<_>>();
-    let reg = proj.data.dependencies.vertex_label(proj.data.root).unwrap();
+    let (proj,_) = loader::load::<neo::Function>(Path::new("../test-data/static")).unwrap();
+    let entries = proj.code[0].iter_callgraph().filter_map(|vx| if let &CallTarget::Todo(Rvalue::Constant{ value,.. },_,_) = vx { Some (value) } else { None }).collect::<Vec<_>>();
+    let reg = proj.region();
     let mut funcs = vec![];
 
     for &ep in entries.iter() {
@@ -28,12 +26,11 @@ fn ssa_convertion_new(b: &mut Bencher) {
 
 fn ssa_convertion_old(b: &mut Bencher) {
     use panopticon_core::{loader,Function,CallTarget,Rvalue};
-    use panopticon_graph_algos::{VertexListGraphTrait,GraphTrait};
     use std::path::Path;
 
-    let (proj,_) = loader::load(Path::new("../test-data/static")).unwrap();
-    let entries = proj.code[0].call_graph.vertices().filter_map(|vx| if let Some(&CallTarget::Todo(Rvalue::Constant{ value,.. },_,_)) = proj.code[0].call_graph.vertex_label(vx) { Some(value) } else { None }).collect::<Vec<_>>();
-    let reg = proj.data.dependencies.vertex_label(proj.data.root).unwrap();
+    let (proj,_) = loader::load::<Function>(Path::new("../test-data/static")).unwrap();
+    let entries = proj.code[0].iter_callgraph().filter_map(|vx| if let &CallTarget::Todo(Rvalue::Constant{ value,.. },_,_) = vx { Some (value) } else { None }).collect::<Vec<_>>();
+    let reg = proj.region();
     let mut funcs = vec![];
 
     for &ep in entries.iter() {
@@ -43,7 +40,12 @@ fn ssa_convertion_old(b: &mut Bencher) {
 
     b.bench_n(1,|b| {
         b.iter(|| {
-            for f in funcs.iter_mut() { ssa_convertion(f).unwrap(); }
+            // NB: this is broken right now for old functions using petgraph, unwrap() on None
+            // 11: <petgraph::algo::dominators::Dominators<N>>::dominance_frontiers
+            // at /home/m4b/.cargo/git/checkouts/petgraph-d1e6db80f82b1362/6ea8c94/src/algo/dominators.rs:112
+            // 12: panopticon_data_flow::ssa::phi_functions
+            //  at /home/m4b/projects/panopticon/data-flow/src/ssa.rs:151
+            for f in funcs.iter_mut() { f.ssa_conversion().unwrap(); }
         });
     });
 }

--- a/benchmark/benches/data_flow.rs
+++ b/benchmark/benches/data_flow.rs
@@ -1,0 +1,51 @@
+use bencher::Bencher;
+use panopticon_amd64 as amd64;
+use panopticon_core::neo;
+use panopticon_data_flow::neo::rewrite_to_ssa;
+use panopticon_data_flow::ssa_convertion;
+
+fn ssa_convertion_new(b: &mut Bencher) {
+    use panopticon_core::{loader,neo,CallTarget,Rvalue};
+    use panopticon_graph_algos::{VertexListGraphTrait,GraphTrait};
+    use std::path::Path;
+
+    let (proj,_) = loader::load(Path::new("../test-data/static")).unwrap();
+    let entries = proj.code[0].call_graph.vertices().filter_map(|vx| if let Some(&CallTarget::Todo(Rvalue::Constant{ value,.. },_,_)) = proj.code[0].call_graph.vertex_label(vx) { Some(value) } else { None }).collect::<Vec<_>>();
+    let reg = proj.data.dependencies.vertex_label(proj.data.root).unwrap();
+    let mut funcs = vec![];
+
+    for &ep in entries.iter() {
+        let func = neo::Function::new::<amd64::Amd64>(amd64::Mode::Long,ep,&reg,Some("".into())).unwrap();
+        funcs.push(func);
+    }
+
+    b.bench_n(1,|b| {
+        b.iter(|| {
+            for f in funcs.iter_mut() { rewrite_to_ssa(f).unwrap(); }
+        });
+    });
+}
+
+fn ssa_convertion_old(b: &mut Bencher) {
+    use panopticon_core::{loader,Function,CallTarget,Rvalue};
+    use panopticon_graph_algos::{VertexListGraphTrait,GraphTrait};
+    use std::path::Path;
+
+    let (proj,_) = loader::load(Path::new("../test-data/static")).unwrap();
+    let entries = proj.code[0].call_graph.vertices().filter_map(|vx| if let Some(&CallTarget::Todo(Rvalue::Constant{ value,.. },_,_)) = proj.code[0].call_graph.vertex_label(vx) { Some(value) } else { None }).collect::<Vec<_>>();
+    let reg = proj.data.dependencies.vertex_label(proj.data.root).unwrap();
+    let mut funcs = vec![];
+
+    for &ep in entries.iter() {
+        let func = Function::new::<amd64::Amd64>(ep,&reg,None,amd64::Mode::Long).unwrap();
+        funcs.push(func);
+    }
+
+    b.bench_n(1,|b| {
+        b.iter(|| {
+            for f in funcs.iter_mut() { ssa_convertion(f).unwrap(); }
+        });
+    });
+}
+
+benchmark_group!(ssa, ssa_convertion_new, ssa_convertion_old);

--- a/benchmark/benches/main.rs
+++ b/benchmark/benches/main.rs
@@ -1,0 +1,12 @@
+#[macro_use]
+extern crate bencher;
+extern crate panopticon_amd64;
+extern crate panopticon_graph_algos;
+extern crate panopticon_data_flow;
+extern crate panopticon_core;
+
+mod core;
+mod data_flow;
+
+
+benchmark_main!(core::disassemble, data_flow::ssa);

--- a/benchmark/benches/main.rs
+++ b/benchmark/benches/main.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate bencher;
 extern crate panopticon_amd64;
-extern crate panopticon_graph_algos;
 extern crate panopticon_data_flow;
 extern crate panopticon_core;
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,6 +12,7 @@ structopt-derive = "0.0.5"
 error-chain = "0.8"
 futures = "0.1"
 panopticon-core = { path = "../core" }
+panopticon-data-flow = { path = "../data-flow" }
 panopticon-analysis = { path = "../analysis" }
 panopticon-amd64 = { path = "../amd64" }
 panopticon-avr = { path = "../avr" }

--- a/cli/src/display.rs
+++ b/cli/src/display.rs
@@ -1,8 +1,9 @@
 use std::io::Write;
 use termcolor::WriteColor;
 use termcolor::Color::*;
+use std::ops::Range;
 
-use panopticon_core::{Function, BasicBlock, Mnemonic, MnemonicFormatToken, Operation, Program, Rvalue, Result, Statement};
+use panopticon_core::{Fun, Function, BasicBlock, Mnemonic, MnemonicFormatToken, Operation, Program, Rvalue, Result, Statement, neo};
 
 macro_rules! color_bold {
     ($fmt:ident, $color:ident, $str:expr) => ({
@@ -20,325 +21,440 @@ macro_rules! color {
     })
 }
 
-/// Prints a sorted-by-start list of the RREIL implementing each mnemonic in a basic block, as well as phi functions and init code
-pub fn print_rreil<W: Write + WriteColor>(fmt: &mut W, bbs: &[&BasicBlock]) -> Result<()> {
-    color_bold!(fmt, White, "RREIL")?;
-    writeln!(fmt, ":")?;
-    for bb in bbs {
-        for mnemonic in bb.mnemonics() {
-            print_address_and_mnemonic(fmt, mnemonic)?;
-            for statement in &mnemonic.instructions {
-                print_statement(fmt, statement)?;
-            }
-        }
-    }
-    Ok(())
+pub trait PrintableFunction: Sized {
+    fn pretty_print<W: WriteColor + Write>(&self, fmt: &mut W, program: &Program<Self>) -> Result<()>;
 }
 
+pub trait PrintableStatements: Sized {
+    fn pretty_print_il<IL: PrintableIL, W: WriteColor + Write> (&self, fmt: &mut W) -> Result<()>;
+}
+
+pub trait PrintableIL {
+    fn pretty_print<W: WriteColor + Write>(&self, fmt: &mut W) -> Result<()>;
+}
+
+impl PrintableFunction for Function {
+    fn pretty_print<W: WriteColor + Write>(&self, fmt: &mut W, program: &Program<Function>) -> Result<()> {
+        let mut bbs = self.basic_blocks().collect::<Vec<_>>();
+        bbs.sort_by(|bb1, bb2| bb1.area.start.cmp(&bb2.area.start));
+        print_function(fmt, self, &bbs, program)
+    }
+}
+
+impl PrintableStatements for Function {
+    fn pretty_print_il<IL: PrintableIL, W: WriteColor + Write>(&self, fmt: &mut W) -> Result<()> {
+        color_bold!(fmt, White, "RREIL")?;
+        writeln!(fmt, ":")?;
+        for bb in self.basic_blocks() {
+            for mnemonic in bb.mnemonics() {
+                print_address_and_mnemonic::<Self, &Mnemonic, _>(fmt, &mnemonic)?;
+                for statement in &mnemonic.instructions {
+                    <Statement as PrintableIL>::pretty_print(statement, fmt)?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl PrintableStatements for neo::Function {
+    fn pretty_print_il<IL: PrintableIL, W: WriteColor + Write>(&self, fmt: &mut W) -> Result<()> {
+        writeln!(fmt, "UNIMPLEMENTED")?;
+        Ok(())
+    }
+}
+
+impl PrintableFunction for neo::Function {
+    fn pretty_print<W: WriteColor + Write>(&self, fmt: &mut W, program: &Program<neo::Function>) -> Result<()> {
+        let mut bbs = self.basic_blocks().map(|(_, bb)| NeoFunctionAndBasicBlock { function: self, bb} ).collect::<Vec<_>>();
+        bbs.sort_by(|f1, f2| f1.bb.area.start.cmp(&f2.bb.area.start));
+        print_function(fmt, self, &bbs, program)
+    }
+}
+
+pub trait PrintableMnemonic {
+    fn opcode(&self) -> &str;
+    fn operands(&self) -> Vec<Rvalue>;
+    fn format_tokens(&self) -> &[MnemonicFormatToken];
+    fn area(&self) -> Range<u64>;
+}
+
+impl<'a> PrintableMnemonic for &'a Mnemonic {
+    fn opcode(&self) -> &str {
+        self.opcode.as_str()
+    }
+    fn operands(&self) -> Vec<Rvalue> {
+        self.operands.clone()
+    }
+    fn format_tokens(&self) -> &[MnemonicFormatToken] {
+        &self.format_string
+    }
+    fn area(&self) -> Range<u64> {
+        self.area.start..self.area.end
+    }
+}
+
+pub trait PrintableBlock<M: PrintableMnemonic> {
+    type Iter: Iterator<Item = M>;
+    fn mnemonics(&self) -> Self::Iter;
+}
+
+impl<'a> PrintableBlock<&'a Mnemonic> for &'a BasicBlock {
+    type Iter = ::std::slice::Iter<'a, Mnemonic>;
+    fn mnemonics(&self) -> Self::Iter {
+        self.mnemonics.as_slice().iter()
+    }
+}
+
+struct NeoFunctionAndBasicBlock<'a> {
+    function: &'a neo::Function,
+    bb: &'a neo::BasicBlock,
+}
+
+impl<'a> PrintableBlock<&'a neo::Mnemonic> for NeoFunctionAndBasicBlock<'a> {
+    type Iter = Box<Iterator<Item = &'a neo::Mnemonic> + 'a>;
+    fn mnemonics(&self) -> Self::Iter {
+        Box::new(self.function.mnemonics_for(self.bb).map(|(_, m)| m))
+    }
+}
+
+impl<'a> PrintableMnemonic for &'a neo::Mnemonic {
+    fn opcode(&self) -> &str {
+        use std::borrow::Borrow;
+        self.opcode.borrow()
+    }
+    fn operands(&self) -> Vec<Rvalue> {
+        self.operands.clone()
+    }
+    fn format_tokens(&self) -> &[MnemonicFormatToken] {
+        &self.format_string
+    }
+    fn area(&self) -> Range<u64> {
+        self.area.start..self.area.end
+    }
+}
+
+///// Prints a sorted-by-start list of the RREIL implementing each mnemonic in a basic block, as well as phi functions and init code
+// pub fn print_il<IL: PrintableIL, M: PrintableMnemonic + ContainsInstructions, B: PrintableBlock<M>, W: Write + WriteColor>(fmt: &mut W, bbs: &[&B]) -> Result<()> {
+//     color_bold!(fmt, White, "RREIL")?;
+//     writeln!(fmt, ":")?;
+//     for bb in bbs {
+//         for mnemonic in bb.mnemonics() {
+//             //print_address_and_mnemonic(fmt, mnemonic)?;
+//             for statement in mnemonic.instructions() {
+//                 statement.pretty_print(fmt)?;
+//             }
+//         }
+//     }
+//     Ok(())
+// }
+
 /// Prints an address and its corresponding mnemonic at that address
-pub fn print_address_and_mnemonic<W: Write + WriteColor>(fmt: &mut W, mnemonic: &Mnemonic) -> Result<()> {
-    color_bold!(fmt, White, format!("{:8x}", mnemonic.area.start as usize))?;
+pub fn print_address_and_mnemonic<F: Fun, M: PrintableMnemonic, W: Write + WriteColor>(fmt: &mut W, mnemonic: &M) -> Result<()> {
+    color_bold!(fmt, White, format!("{:8x}", mnemonic.area().start as usize))?;
     write!(fmt, ": (")?;
-    print_mnemonic(fmt, mnemonic, None)?;
+    print_mnemonic(fmt, mnemonic, None::<&Program<F>>)?;
     writeln!(fmt, ")")?;
     Ok(())
 }
 
 /// Print colored RREIL statement
-pub fn print_statement<W: Write + WriteColor>(fmt: &mut W, statement: &Statement) -> Result<()> {
-    write!(fmt, "{: <8}  ", "")?;
-    match statement.op {
-        Operation::Add(ref a, ref b) => {
-            color_bold!(fmt, White, "add")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::Subtract(ref a, ref b) => {
-            color_bold!(fmt, White, "sub")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::Multiply(ref a, ref b) => {
-            color_bold!(fmt, White, "mul")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::DivideUnsigned(ref a, ref b) => {
-            color_bold!(fmt, White, "divu")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::DivideSigned(ref a, ref b) => {
-            color_bold!(fmt, White, "divs")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::ShiftLeft(ref a, ref b) => {
-            color_bold!(fmt, White, "shl")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::ShiftRightUnsigned(ref a, ref b) => {
-            color_bold!(fmt, White, "shru")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::ShiftRightSigned(ref a, ref b) => {
-            color_bold!(fmt, White, "shrs")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::Modulo(ref a, ref b) => {
-            color_bold!(fmt, White, "mod")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::And(ref a, ref b) => {
-            color_bold!(fmt, White, "and")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::InclusiveOr(ref a, ref b) => {
-            color_bold!(fmt, White, "or")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::ExclusiveOr(ref a, ref b) => {
-            color_bold!(fmt, White, "xor")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::Equal(ref a, ref b) => {
-            color_bold!(fmt, White, "cmpeq")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::LessOrEqualUnsigned(ref a, ref b) => {
-            color_bold!(fmt, White, "cmpleu")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::LessOrEqualSigned(ref a, ref b) => {
-            color_bold!(fmt, White, "cmples")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::LessUnsigned(ref a, ref b) => {
-            color_bold!(fmt, White, "cmplu")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::LessSigned(ref a, ref b) => {
-            color_bold!(fmt, White, "cmpls")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::Move(ref a) => {
-            color_bold!(fmt, White, "mov")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-        },
-        Operation::Call(ref a) => {
-            color_bold!(fmt, White, "call")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-        },
-        Operation::ZeroExtend(s, ref a) => {
-            color_bold!(fmt, White, format!("convert_{}", s))?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-        },
-        Operation::SignExtend(s, ref a) => {
-            color_bold!(fmt, White, format!("sign-extend_{}", s))?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-        },
-        Operation::Select(s, ref a, ref b) => {
-            color_bold!(fmt, White, format!("select_{}", s))?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::Initialize(ref r, sz) => {
-            color_bold!(fmt, White, "init")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, r)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, sz)?;
-        },
-        Operation::Load(ref r, e, sz, ref b) => {
-            color_bold!(fmt, White, format!("load/{}/{}/{}", r, e, sz))?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::Store(ref r, e, sz, ref a, ref b) => {
-            color_bold!(fmt, White, format!("store/{}/{}/{}", r, e, sz))?;
-            write!(fmt, " ")?;
-            color!(fmt, White, statement.assignee)?;
-            color_bold!(fmt, Green, ",")?;
-            write!(fmt, " ")?;
-            color!(fmt, White, a)?;
-            write!(fmt, " ")?;
-            color!(fmt, White, b)?;
-        },
-        Operation::Phi(ref vec) => {
-            color_bold!(fmt, White, format!("phi"))?;
-            write!(fmt, " ")?;
-            for (i, x) in vec.iter().enumerate() {
-                color!(fmt, White, format!("{}", x))?;
-                if i < vec.len() - 1 {
-                    color_bold!(fmt, Green, ",")?;
-                    write!(fmt, " ")?;
+impl PrintableIL for Statement {
+    fn pretty_print<W: Write + WriteColor>(&self, fmt: &mut W) -> Result<()> {
+        write!(fmt, "{: <8}  ", "")?;
+        match self.op {
+            Operation::Add(ref a, ref b) => {
+                color_bold!(fmt, White, "add")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::Subtract(ref a, ref b) => {
+                color_bold!(fmt, White, "sub")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::Multiply(ref a, ref b) => {
+                color_bold!(fmt, White, "mul")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::DivideUnsigned(ref a, ref b) => {
+                color_bold!(fmt, White, "divu")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::DivideSigned(ref a, ref b) => {
+                color_bold!(fmt, White, "divs")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::ShiftLeft(ref a, ref b) => {
+                color_bold!(fmt, White, "shl")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::ShiftRightUnsigned(ref a, ref b) => {
+                color_bold!(fmt, White, "shru")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::ShiftRightSigned(ref a, ref b) => {
+                color_bold!(fmt, White, "shrs")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::Modulo(ref a, ref b) => {
+                color_bold!(fmt, White, "mod")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::And(ref a, ref b) => {
+                color_bold!(fmt, White, "and")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::InclusiveOr(ref a, ref b) => {
+                color_bold!(fmt, White, "or")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::ExclusiveOr(ref a, ref b) => {
+                color_bold!(fmt, White, "xor")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::Equal(ref a, ref b) => {
+                color_bold!(fmt, White, "cmpeq")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::LessOrEqualUnsigned(ref a, ref b) => {
+                color_bold!(fmt, White, "cmpleu")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::LessOrEqualSigned(ref a, ref b) => {
+                color_bold!(fmt, White, "cmples")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::LessUnsigned(ref a, ref b) => {
+                color_bold!(fmt, White, "cmplu")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::LessSigned(ref a, ref b) => {
+                color_bold!(fmt, White, "cmpls")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::Move(ref a) => {
+                color_bold!(fmt, White, "mov")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+            },
+            Operation::Call(ref a) => {
+                color_bold!(fmt, White, "call")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+            },
+            Operation::ZeroExtend(s, ref a) => {
+                color_bold!(fmt, White, format!("convert_{}", s))?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+            },
+            Operation::SignExtend(s, ref a) => {
+                color_bold!(fmt, White, format!("sign-extend_{}", s))?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+            },
+            Operation::Select(s, ref a, ref b) => {
+                color_bold!(fmt, White, format!("select_{}", s))?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::Initialize(ref r, sz) => {
+                color_bold!(fmt, White, "init")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, r)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, sz)?;
+            },
+            Operation::Load(ref r, e, sz, ref b) => {
+                color_bold!(fmt, White, format!("load/{}/{}/{}", r, e, sz))?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::Store(ref r, e, sz, ref a, ref b) => {
+                color_bold!(fmt, White, format!("store/{}/{}/{}", r, e, sz))?;
+                write!(fmt, " ")?;
+                color!(fmt, White, self.assignee)?;
+                color_bold!(fmt, Green, ",")?;
+                write!(fmt, " ")?;
+                color!(fmt, White, a)?;
+                write!(fmt, " ")?;
+                color!(fmt, White, b)?;
+            },
+            Operation::Phi(ref vec) => {
+                color_bold!(fmt, White, format!("phi"))?;
+                write!(fmt, " ")?;
+                for (i, x) in vec.iter().enumerate() {
+                    color!(fmt, White, format!("{}", x))?;
+                    if i < vec.len() - 1 {
+                        color_bold!(fmt, Green, ",")?;
+                        write!(fmt, " ")?;
+                    }
                 }
             }
         }
+        writeln!(fmt, "")?;
+        Ok(())
     }
-    writeln!(fmt, "")?;
-    Ok(())
 }
 
 /// Prints the function in a human readable format, using `program`, with colors
-pub fn print_function<W: Write + WriteColor>(fmt: &mut W, function: &Function, bbs: &[&BasicBlock], program: &Program) -> Result<()> {
+pub fn print_function<Function: Fun, M: PrintableMnemonic, B: PrintableBlock<M>, W: Write + WriteColor>(fmt: &mut W, function: &Function, bbs: &[B], program: &Program<Function>) -> Result<()> {
     write!(fmt, "{:0>8x} <", function.start())?;
-    color_bold!(fmt, Yellow, function.name)?;
+    color_bold!(fmt, Yellow, function.name())?;
     writeln!(fmt, ">:")?;
     for bb in bbs {
-        print_basic_block(fmt, &bb, program)?;
+        print_basic_block(fmt, bb, program)?;
     }
     Ok(())
 }
 
 /// Prints the basic block into `fmt`, in disassembly order, in human readable form, and looks up any functions calls in `program`
-pub fn print_basic_block<W: Write + WriteColor>(fmt: &mut W, basic_block: &BasicBlock, program: &Program) -> Result<()> {
-    for mnemonic in basic_block.mnemonics.iter() {
-        if !mnemonic.opcode.starts_with("__") {
-            write!(fmt, "{:8x}: ", mnemonic.area.start)?;
+pub fn print_basic_block<Function: Fun, M: PrintableMnemonic, B: PrintableBlock<M>, W: Write + WriteColor>(fmt: &mut W, basic_block: &B, program: &Program<Function>) -> Result<()> {
+    for mnemonic in basic_block.mnemonics() {
+        if !mnemonic.opcode().starts_with("__") {
+            write!(fmt, "{:8x}: ", mnemonic.area().start)?;
             print_mnemonic(fmt, &mnemonic, Some(program))?;
             writeln!(fmt)?;
         }
@@ -347,11 +463,12 @@ pub fn print_basic_block<W: Write + WriteColor>(fmt: &mut W, basic_block: &Basic
 }
 
 /// Prints the mnemonic into `fmt`, in human readable form, and looks up any functions calls in `program`
-pub fn print_mnemonic<W: Write + WriteColor>(fmt: &mut W, mnemonic: &Mnemonic, program: Option<&Program>) -> Result<()> {
-    let mut ops = mnemonic.operands.iter();
-    color_bold!(fmt, Blue, mnemonic.opcode)?;
+pub fn print_mnemonic<Function: Fun, M: PrintableMnemonic, W: Write + WriteColor>(fmt: &mut W, mnemonic: &M, program: Option<&Program<Function>>) -> Result<()> {
+    let ops = mnemonic.operands();
+    let mut ops = ops.iter();
+    color_bold!(fmt, Blue, mnemonic.opcode())?;
     write!(fmt, " ")?;
-    for token in &mnemonic.format_string {
+    for token in mnemonic.format_tokens() {
         match token {
             &MnemonicFormatToken::Literal(ref s) => {
                 color_bold!(fmt, Green, s)?;
@@ -392,7 +509,7 @@ pub fn print_mnemonic<W: Write + WriteColor>(fmt: &mut W, mnemonic: &Mnemonic, p
                                 if let Some(function) = program.find_function_by(|f| { f.start() == val }) {
                                     color!(fmt, Red, format!("{:x}",val))?;
                                     write!(fmt, " <", )?;
-                                    color_bold!(fmt, Yellow, function.name)?;
+                                    color_bold!(fmt, Yellow, function.name())?;
                                     write!(fmt, ">")?;
                                 } else {
                                     color_bold!(fmt, Magenta, format!("{:x}",val))?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -171,7 +171,7 @@ fn print_reverse_deps<Function: Fun, W: Write + WriteColor>(mut fmt: W, program:
 fn disassemble<Function: Fun + DataFlow + Send>(binary: &str) -> Result<Program<Function>> {
     let (mut proj, machine) = loader::load(Path::new(&binary))?;
     let program = proj.code.pop().unwrap();
-    let reg = proj.region().clone();
+    let reg = proj.region();
     info!("disassembly thread started");
     Ok(match machine {
         Machine::Avr => analyze::<avr::Avr, Function>(program, reg.clone(), avr::Mcu::atmega103()),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,6 +8,7 @@ extern crate panopticon_amd64;
 extern crate panopticon_avr;
 extern crate panopticon_analysis;
 extern crate panopticon_graph_algos;
+extern crate panopticon_data_flow;
 extern crate futures;
 #[macro_use]
 extern crate log;
@@ -18,7 +19,9 @@ extern crate atty;
 use panopticon_amd64 as amd64;
 use panopticon_analysis::analyze;
 use panopticon_avr as avr;
-use panopticon_core::{Machine, Function, FunctionKind, Program, Result, loader};
+use panopticon_core::{Machine, Fun, FunctionKind, Function, Program, Result, loader, neo};
+use panopticon_data_flow::{DataFlow};
+
 use std::path::Path;
 use std::result;
 use structopt::StructOpt;
@@ -28,6 +31,7 @@ use termcolor::Color::*;
 
 #[macro_use]
 mod display;
+use display::{PrintableStatements, PrintableFunction};
 
 mod errors {
     error_chain! {
@@ -40,6 +44,8 @@ mod errors {
 #[derive(StructOpt, Debug)]
 #[structopt(name = "panop", about = "A libre cross-platform disassembler.")]
 struct Args {
+    #[structopt(long = "neo", help = "Use the new bincode")]
+    neo: bool,
     #[structopt(long = "reverse-deps", help = "Print every function that calls the function in -f")]
     reverse_deps: bool,
     /// Dumps the il of the matched function
@@ -78,9 +84,9 @@ impl Filter {
     pub fn filtering(&self) -> bool {
         self.name.is_some() || self.addr.is_some()
     }
-    pub fn is_match(&self, func: &Function) -> bool {
+    pub fn is_match<Function: Fun>(&self, func: &Function) -> bool {
         if let Some(ref name) = self.name {
-            if name == &func.name || func.aliases().contains(name){ return true }
+            if name == &func.name() || func.aliases().contains(name){ return true }
         }
         if let Some(ref addr) = self.addr {
             return *addr == func.start()
@@ -98,17 +104,17 @@ impl Filter {
     }
 }
 
-fn print_reverse_deps<W: Write + WriteColor>(mut fmt: W, program: &Program, filter: &Filter) -> Result<()> {
-    let name_and_address = {
-        if let Some(f) = program.find_function_by(|f| filter.is_match_with(&f.name, f.start())) {
-            Some((f.start(), &f.name))
+fn print_reverse_deps<Function: Fun, W: Write + WriteColor>(mut fmt: W, program: &Program<Function>, filter: &Filter) -> Result<()> {
+    let name_and_address: Option<(u64, &str)> = {
+        if let Some(f) = program.find_function_by(|f| filter.is_match_with(&f.name(), f.start())) {
+            Some((f.start(), f.name()))
         } else {
             // not a function, so we search imports
             let mut name_and_address = None;
             for (addr, name) in program.imports.iter() {
                 if filter.is_match_with(name, *addr) {
                     debug!("Found import with matching name or address, {:#x} - {}", addr, name);
-                    name_and_address = Some((*addr, name));
+                    name_and_address = Some((*addr, name.as_str()));
                 }
             }
             name_and_address
@@ -118,19 +124,19 @@ fn print_reverse_deps<W: Write + WriteColor>(mut fmt: W, program: &Program, filt
         Some((addr, name)) => {
             let mut reverse_deps: Vec<_> = program.functions().filter_map(|f| {
                 let call_addresses = f.collect_call_addresses();
-                debug!("Total call addresses for {}: {}", f.name, call_addresses.len());
+                debug!("Total call addresses for {}: {}", f.name(), call_addresses.len());
                 if call_addresses.contains(&addr) {
-                    Some((f.start(), f.name.to_string()))
+                    Some((f.start(), f.name().to_string()))
                 } else {
                     for call_address in call_addresses {
-                        let function = program.find_function_by(|f| f.start() == call_address).expect(&format!("{} has a call address {:#x}, but there isn't a function with that address in the program object", f.name, call_address));
-                        debug!("Checking function {} with call address {:#x} for plt stub", function.name, call_address);
+                        let function = program.find_function_by(|f| f.start() == call_address).expect(&format!("{} has a call address {:#x}, but there isn't a function with that address in the program object", f.name(), call_address));
+                        debug!("Checking function {} with call address {:#x} for plt stub", function.name(), call_address);
                         match function.kind() {
                             &FunctionKind::Stub { ref plt_address, ref name } => {
-                                debug!("Function {} is a plt stub for {}", function.name, name);
+                                debug!("Function {} is a plt stub for {}", function.name(), name);
                                 if *plt_address == addr {
-                                    debug!("Function {} plt address {:#x} matches reverse dep address {:#x}, returning", f.name, plt_address, addr);
-                                    return Some((f.start(), f.name.to_string()))
+                                    debug!("Function {} plt address {:#x} matches reverse dep address {:#x}, returning", f.name(), plt_address, addr);
+                                    return Some((f.start(), f.name().to_string()))
                                 }
                             },
                             _ => ()
@@ -162,26 +168,37 @@ fn print_reverse_deps<W: Write + WriteColor>(mut fmt: W, program: &Program, filt
     Ok(())
 }
 
-fn disassemble(binary: &str) -> Result<Program> {
+fn disassemble<Function: Fun + DataFlow + Send>(binary: &str) -> Result<Program<Function>> {
     let (mut proj, machine) = loader::load(Path::new(&binary))?;
     let program = proj.code.pop().unwrap();
     let reg = proj.region().clone();
     info!("disassembly thread started");
     Ok(match machine {
-        Machine::Avr => analyze::<avr::Avr>(program, reg.clone(), avr::Mcu::atmega103()),
-        Machine::Ia32 => analyze::<amd64::Amd64>(program, reg.clone(), amd64::Mode::Protected),
-        Machine::Amd64 => analyze::<amd64::Amd64>(program, reg.clone(), amd64::Mode::Long),
+        Machine::Avr => analyze::<avr::Avr, Function>(program, reg.clone(), avr::Mcu::atmega103()),
+        Machine::Ia32 => analyze::<amd64::Amd64, Function>(program, reg.clone(), amd64::Mode::Protected),
+        Machine::Amd64 => analyze::<amd64::Amd64, Function>(program, reg.clone(), amd64::Mode::Long),
     }?)
 }
 
-fn app_logic(fmt: &mut termcolor::Buffer, program: Program, args: Args) -> Result<()> {
+fn app_logic<Function: Fun + DataFlow + PrintableFunction + PrintableStatements>(fmt: &mut termcolor::Buffer, mut program: Program<Function>, args: Args) -> Result<()> {
     let filter = Filter { name: args.function_filter, addr: args.address_filter.map(|addr| u64::from_str_radix(&addr, 16).unwrap()) };
 
     debug!("Program.imports: {:#?}", program.imports);
     if args.reverse_deps && filter.filtering() {
         return print_reverse_deps(fmt, &program, &filter);
     }
-    let mut functions = program.functions().filter_map(|f| if filter.is_match(f) { Some(f) } else { None }).collect::<Vec<&Function>>();
+    let mut functions = {
+        // we iterate twice because rust ownership system sucks sometimes
+        for f in program.functions_mut() {
+            if filter.is_match(f) {
+                // we use less memory and take less time if we perform the ssa conversion _only_ on functions
+                // we want to examine (e.g., ones that match our filter)
+                f.ssa_conversion()?;
+            }
+        }
+        program.functions().filter_map(|f| if filter.is_match(f) { Some(f.clone()) } else { None }).collect::<Vec<&Function>>()
+    };
+
     info!("disassembly thread finished with {} functions", functions.len());
 
     functions.sort_by(|f1, f2| {
@@ -191,11 +208,7 @@ fn app_logic(fmt: &mut termcolor::Buffer, program: Program, args: Args) -> Resul
     });
 
     for function in functions {
-        let mut bbs = function.basic_blocks().collect::<Vec<_>>();
-        // sort them by start so we can use them later
-        bbs.sort_by(|bb1, bb2| bb1.area.start.cmp(&bb2.area.start));
-
-        display::print_function(fmt, &function, &bbs, &program)?;
+        function.pretty_print(fmt, &program)?;
         if args.calls {
             let calls = function.collect_call_addresses();
             write!(fmt, "Calls (")?;
@@ -207,8 +220,9 @@ fn app_logic(fmt: &mut termcolor::Buffer, program: Program, args: Args) -> Resul
             }
         }
         if args.dump_il {
-            display::print_rreil(fmt, &bbs)?;
+            // function.pretty_print_il(fmt)?;
         }
+        // move this into pretty_print
         writeln!(fmt, "Aliases: {:?}", function.aliases())?;
     }
     Ok(())
@@ -216,11 +230,16 @@ fn app_logic(fmt: &mut termcolor::Buffer, program: Program, args: Args) -> Resul
 
 fn run(args: Args) -> Result<()> {
     exists_path_val(&args.binary)?;
-    let program = disassemble(&args.binary)?;
     let cc = if args.color || atty::is(atty::Stream::Stdout) { ColorChoice::Auto } else { ColorChoice::Never };
     let writer = BufferWriter::stdout(cc);
     let mut fmt = writer.buffer();
-    app_logic(&mut fmt, program, args)?;
+    if args.neo {
+       let program = disassemble::<neo::Function>(&args.binary)?;
+       app_logic(&mut fmt, program, args)?;
+    } else {
+        let program = disassemble::<Function>(&args.binary)?;
+        app_logic(&mut fmt, program, args)?;
+    }
     writer.print(&fmt)?;
     Ok(())
 }
@@ -236,3 +255,36 @@ fn main() {
         }
     }
 }
+
+/*
+INFO:panopticon_analysis::pipeline: first wave done: success: 1748 failures: 0 targets: 806
+INFO:panopticon_analysis::pipeline: targets - (806)
+INFO:panopticon_analysis::pipeline: targets - (456)
+INFO:panopticon_analysis::pipeline: targets - (245)
+INFO:panopticon_analysis::pipeline: targets - (95)
+INFO:panopticon_analysis::pipeline: targets - (49)
+INFO:panopticon_analysis::pipeline: targets - (20)
+INFO:panopticon_analysis::pipeline: Finished analysis: 2286 failures 0
+INFO:panop: disassembly thread finished with 2286 functions
+Total bytes: 753214720
+15.62user 0.48system 0:05.32elapsed 302%CPU (0avgtext+0avgdata 1243060maxresident)k
+0inputs+0outputs (0major+322752minor)pagefaults 0swaps
+
+INFO:panopticon_analysis::pipeline: first wave done: success: 1748 failures: 0 targets: 0
+INFO:panopticon_analysis::pipeline: Finished analysis: 1748 failures 0
+Total_bytes: 13561144
+3.67user 0.19system 0:01.31elapsed 294%CPU (0avgtext+0avgdata 154000maxresident)k
+0inputs+0outputs (0major+80572minor)pagefaults 0swaps
+
+Aliases: ["printf"]
+21.74user 0.39system 0:07.71elapsed 287%CPU (0avgtext+0avgdata 443572maxresident)k
+0inputs+0outputs (0major+133326minor)pagefaults 0swaps
+
+RUST_LOG=panop=info /usr/bin/time ./panop /usr/lib/libc.so.6
+52.02user 1.20system 0:16.66elapsed 319%CPU (0avgtext+0avgdata 2756540maxresident)k
+0inputs+0outputs (0major+658616minor)pagefaults 0swaps
+
+RUST_LOG=panop=info /usr/bin/time ./panop --neo /usr/lib/libc.so.6
+21.26user 0.34system 0:06.98elapsed 309%CPU (0avgtext+0avgdata 450880maxresident)k
+104inputs+0outputs (0major+134643minor)pagefaults 0swaps
+*/

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,3 +26,4 @@ quickcheck = "0.4.1"
 [dev-dependencies]
 regex = "0.1"
 panopticon-avr = { path = "../avr" }
+

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,7 +18,7 @@ panopticon-graph-algos = { path = "../graph-algos" }
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_cbor = "0.6"
-petgraph = "0.4.9"
+petgraph = { version = "0.4.10", features = ["serde-1"], git = "https://github.com/m4b/petgraph", branch = "dominance_frontiers" }
 leb128 = "0.2.1"
 error-chain = "0.11.0"
 quickcheck = "0.4.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,7 +14,6 @@ uuid = { version = "0.5", features = ["v4", "serde"]}
 flate2 = "0.2.13"
 byteorder = "1"
 goblin = "0.0.11"
-panopticon-graph-algos = { path = "../graph-algos" }
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_cbor = "0.6"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,11 +14,14 @@ uuid = { version = "0.5", features = ["v4", "serde"]}
 flate2 = "0.2.13"
 byteorder = "1"
 goblin = "0.0.11"
-quickcheck = "0.3"
 panopticon-graph-algos = { path = "../graph-algos" }
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_cbor = "0.6"
+petgraph = "0.4.9"
+leb128 = "0.2.1"
+error-chain = "0.11.0"
+quickcheck = "0.4.1"
 
 [dev-dependencies]
 regex = "0.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,6 +22,7 @@ petgraph = "0.4.9"
 leb128 = "0.2.1"
 error-chain = "0.11.0"
 quickcheck = "0.4.1"
+smallvec = "0.4.4"
 
 [dev-dependencies]
 regex = "0.1"

--- a/core/src/disassembler.rs
+++ b/core/src/disassembler.rs
@@ -788,7 +788,7 @@ impl Architecture for TestArch {
                         Ok(Rvalue::Constant{ value: (b - b'0') as u64, size: len })
                     }
                     _ => Err(format!("'{}' is nor a variable name neither a constant",b).into())
-                }
+                },
                 Some(None) => Err(format!("Undefined cell at {}",*entry - 1).into()),
                 None => Err(format!("Premature end while decoding rvalue at {}",*entry).into())
             }
@@ -803,7 +803,7 @@ impl Architecture for TestArch {
                         Ok(Lvalue::Variable{ name: format!("{}",char::from(b)).into(), size: len, subscript: None })
                     }
                     _ => Err(format!("'{}' is not a variable name",b).into())
-                }
+                },
                 Some(None) => Err(format!("Undefined cell at {}",*entry - 1).into()),
                 None => Err(format!("Premature end while decoding lvalue at {}",*entry).into())
             }

--- a/core/src/disassembler.rs
+++ b/core/src/disassembler.rs
@@ -673,7 +673,7 @@ pub struct OptionalRule<A: Architecture>(pub Rule<A>);
 impl<A: Architecture> AddToRuleGen<A> for OptionalRule<A> {
     fn push(&self, rules: &mut Vec<Vec<Rule<A>>>) {
         let mut copy = rules.clone();
-        for mut c in copy.iter_mut() {
+        for c in copy.iter_mut() {
             c.push(self.0.clone());
         }
 
@@ -683,7 +683,7 @@ impl<A: Architecture> AddToRuleGen<A> for OptionalRule<A> {
 
 impl<A: Architecture, T: Into<Rule<A>> + Clone> AddToRuleGen<A> for T {
     fn push(&self, rules: &mut Vec<Vec<Rule<A>>>) {
-        for mut c in rules.iter_mut() {
+        for c in rules.iter_mut() {
             let s: Self = self.clone();
             c.push(s.into());
         }

--- a/core/src/disassembler.rs
+++ b/core/src/disassembler.rs
@@ -759,6 +759,184 @@ macro_rules! new_disassembler {
     };
 }
 
+#[derive(Debug,Clone)]
+pub struct TestArch;
+
+impl Architecture for TestArch {
+    type Token = u8;
+    type Configuration = ();
+
+    fn prepare(_: &Region, _: &()) -> Result<Vec<(&'static str, u64, &'static str)>> {
+        Ok(vec![])
+    }
+
+    fn decode(reg: &Region, mut entry: u64, _: &()) -> Result<Match<Self>> {
+        use {Statement,Operation,Rvalue,Lvalue};
+        use std::iter;
+
+        fn read_rvalue(reg: &Region, entry: &mut u64, len: usize) -> Result<Rvalue> {
+            let b = reg.iter().seek(*entry).next();
+
+            match b {
+                Some(Some(b)) => match b {
+                    b'a'...b'z' => {
+                        *entry += 1;
+                        Ok(Rvalue::Variable{ name: format!("{}",char::from(b)).into(), size: len, offset: 0, subscript: None })
+                    }
+                    b'0'...b'9' => {
+                        *entry += 1;
+                        Ok(Rvalue::Constant{ value: (b - b'0') as u64, size: len })
+                    }
+                    _ => Err(format!("'{}' is nor a variable name neither a constant",b).into())
+                }
+                Some(None) => Err(format!("Undefined cell at {}",*entry - 1).into()),
+                None => Err(format!("Premature end while decoding rvalue at {}",*entry).into())
+            }
+        }
+        fn read_lvalue(reg: &Region, entry: &mut u64, len: usize) -> Result<Lvalue> {
+            let b = reg.iter().seek(*entry).next();
+
+            match b {
+                Some(Some(b)) => match b {
+                    b'a'...b'z' => {
+                        *entry += 1;
+                        Ok(Lvalue::Variable{ name: format!("{}",char::from(b)).into(), size: len, subscript: None })
+                    }
+                    _ => Err(format!("'{}' is not a variable name",b).into())
+                }
+                Some(None) => Err(format!("Undefined cell at {}",*entry - 1).into()),
+                None => Err(format!("Premature end while decoding lvalue at {}",*entry).into())
+            }
+        }
+
+        fn read_address(reg: &Region, entry: &mut u64) -> Result<i64> {
+            let b = reg.iter().seek(*entry).next();
+
+            match b {
+                Some(Some(b@b'0'...b'9')) => {
+                    let value = (b - b'0') as i64;
+
+                    *entry += 1;
+                    match read_address(reg,entry) {
+                        Ok(x) => Ok(value * 10 + x),
+                        Err(_) => Ok(value)
+                    }
+                }
+                Some(Some(b)) => Err(format!("'{}' is not a number",b).into()),
+                Some(None) => Err(format!("Undefined cell at {}",*entry - 1).into()),
+                None => Err(format!("Premature end while decoding address at {}",*entry).into())
+            }
+        }
+
+        let start = entry;
+        let opcode = reg.iter().seek(entry).next();
+        entry += 1;
+
+        match opcode {
+            Some(Some(b'M')) => {
+                let var = read_lvalue(reg, &mut entry, 32)?;
+                let val = read_rvalue(reg, &mut entry, 32)?;
+                let ops = vec![var.clone().into(),val.clone()];
+                let instr = Statement{
+                    assignee: var,
+                    op: Operation::Move(val)
+                };
+                let mne = Mnemonic::new(start..entry, "mov".to_string(), "{u}, {u}".to_string(), ops.iter(), vec![instr].iter())?;
+
+                Ok(Match{
+                    tokens: reg.iter().cut(&(start..entry)).map(|x| x.unwrap()).collect(),
+                    mnemonics: vec![mne],
+                    jumps: vec![(start,Rvalue::new_u32(entry as u32),Guard::always())],
+                    configuration: (),
+                })
+            }
+            Some(Some(b'A')) => {
+                let var = read_lvalue(reg, &mut entry, 32)?;
+                let val1 = read_rvalue(reg, &mut entry, 32)?;
+                let val2 = read_rvalue(reg, &mut entry, 32)?;
+                let ops = vec![var.clone().into(),val1.clone(),val2.clone()];
+                let instr = Statement{
+                    assignee: var,
+                    op: Operation::Add(val1,val2)
+                };
+                let mne = Mnemonic::new(start..entry, "add".to_string(), "{u}, {u}, {u}".to_string(), ops.iter(), vec![instr].iter())?;
+
+                Ok(Match{
+                    tokens: reg.iter().cut(&(start..entry)).map(|x| x.unwrap()).collect(),
+                    mnemonics: vec![mne],
+                    jumps: vec![(start,Rvalue::new_u32(entry as u32),Guard::always())],
+                    configuration: (),
+                })
+            }
+            Some(Some(b'C')) => {
+                let var = read_lvalue(reg, &mut entry, 1)?;
+                let val1 = read_rvalue(reg, &mut entry, 32)?;
+                let val2 = read_rvalue(reg, &mut entry, 32)?;
+                let ops = vec![var.clone().into(),val1.clone(),val2.clone()];
+                let instr = Statement{
+                    assignee: var,
+                    op: Operation::LessOrEqualUnsigned(val1,val2)
+                };
+                let mne = Mnemonic::new(start..entry, "leq".to_string(), "{u}, {u}, {u}".to_string(), ops.iter(), vec![instr].iter())?;
+
+                Ok(Match{
+                    tokens: reg.iter().cut(&(start..entry)).map(|x| x.unwrap()).collect(),
+                    mnemonics: vec![mne],
+                    jumps: vec![(start,Rvalue::new_u32(entry as u32),Guard::always())],
+                    configuration: (),
+                })
+            }
+            Some(Some(b'B')) => {
+                let bit = read_rvalue(reg, &mut entry, 1)?;
+                let brtgt = read_address(reg, &mut entry)?;
+                let ops = vec![bit.clone(),Rvalue::new_u32(brtgt as u32)];
+                let mne = Mnemonic::new(start..entry, "br".to_string(), "{u}, {u}".to_string(), ops.iter(), iter::empty())?;
+                let guard = Guard::from_flag(&bit)?;
+
+                Ok(Match{
+                    tokens: reg.iter().cut(&(start..entry)).map(|x| x.unwrap()).collect(),
+                    mnemonics: vec![mne],
+                    jumps: vec![
+                        (start,Rvalue::new_u32(entry as u32),guard.negation()),
+                        (start,Rvalue::new_u32(brtgt as u32),guard)],
+                    configuration: (),
+                })
+            }
+            Some(Some(b'J')) => {
+                let jtgt = read_address(reg, &mut entry)?;
+                let ops = vec![Rvalue::new_u32(jtgt as u32)];
+                let mne = Mnemonic::new(start..entry, "jmp".to_string(), "{u}".to_string(), ops.iter(), iter::empty())?;
+
+                Ok(Match{
+                    tokens: reg.iter().cut(&(start..entry)).map(|x| x.unwrap()).collect(),
+                    mnemonics: vec![mne],
+                    jumps: vec![(start,Rvalue::new_u32(jtgt as u32),Guard::always())],
+                    configuration: (),
+                })
+            }
+            Some(Some(b'R')) => {
+                let mne = Mnemonic::new(start..entry, "ret".to_string(), "".to_string(), iter::empty(), iter::empty())?;
+
+                Ok(Match{
+                    tokens: reg.iter().cut(&(start..entry)).map(|x| x.unwrap()).collect(),
+                    mnemonics: vec![mne],
+                    jumps: vec![],
+                    configuration: (),
+                })
+            }
+            Some(Some(o)) => {
+                Err(format!("Unknown opcode '{}' at {}",o,start).into())
+            }
+            Some(None) => {
+                Err(format!("Undefined cell at {}",start).into())
+            }
+            None => {
+                Err(format!("Premature end while decoding opcode {}",start).into())
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1237,5 +1415,14 @@ mod tests {
         assert_eq!(res.mnemonics[0].area, Bound::new(0, 2));
         assert_eq!(res.mnemonics[0].instructions.len(), 0);
         assert_eq!(res.jumps.len(), 0);
+    }
+
+    #[test]
+    fn test_arch() {
+        use neo::Function;
+
+        let data = OpaqueLayer::wrap(b"Mi1MiiAiiiAi1iAii1Ai11CiiiCi1iCii1Ci11Bi0R".to_vec());
+        let reg = Region::new("".to_string(), data);
+        let _ = Function::new::<TestArch>((), 0, &reg, None).unwrap();
     }
 }

--- a/core/src/function.rs
+++ b/core/src/function.rs
@@ -722,57 +722,13 @@ impl Function {
     pub fn statements<'b>(&'b self) -> Box<Iterator<Item=&'b Statement> + 'b> {
         Box::new(self.basic_blocks().map(|bb| bb.statements()).flat_map(|ss| ss))
     }
-}
-    ///// Returns the functions basic block graph in graphivz's DOT format. Useful for debugging.
-//    pub fn to_dot(&self) -> String {
-//        let mut ret = "digraph G {".to_string();
-//
-//        for v in self.cflow_graph.node_indices() {
-//            match self.cflow_graph.node_weight(v) {
-//                Some(&ControlFlowTarget::Resolved(ref bb)) => {
-//                    ret = format!(
-//                        "{}\n{} [label=<<table border=\"0\"><tr><td>{}:{}</td></tr>",
-//                        ret,
-//                        v.0,
-//                        bb.area.start,
-//                        bb.area.end
-//                    );
-//
-//                    for mne in bb.mnemonics.iter() {
-//                        ret = format!("{}<tr><td align=\"left\">{}</td></tr>", ret, mne.opcode);
-//                        for i in mne.instructions.iter() {
-//                            ret = format!(
-//                                "{}<tr><td align=\"left\">&nbsp;&nbsp;&nbsp;&nbsp;{}</td></tr>",
-//                                ret,
-//                                i
-//                            );
-//                        }
-//                    }
-//
-//                    ret = format!("{}</table>>,shape=record];", ret);
-//                }
-//                Some(&ControlFlowTarget::Unresolved(ref c)) => {
-//                    ret = format!("{}\n{} [label=\"{:?}\",shape=circle];", ret, v.0, c);
-//                }
-//                _ => {
-//                    ret = format!("{}\n{} [label=\"?\",shape=circle];", ret, v.0);
-//                }
-//            }
-//        }
-//
-////        for e in self.cflow_graph.edges() {
-////            ret = format!(
-////                "{}\n{} -> {} [label=\"{}\"];",
-////                ret,
-////                self.cflow_graph.source(e).0,
-////                self.cflow_graph.target(e).0,
-////                self.cflow_graph.edge_label(e).unwrap()
-////            );
-////        }
-//
-//        format!("{}\n}}", ret)
-//    }
 
+    /// Returns the functions basic block graph in graphivz's DOT format. Useful for debugging.
+    pub fn to_dot(&self) -> String {
+        use petgraph::dot::Dot;
+        format!("{:?}", Dot::new(&self.cflow_graph))
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/core/src/function.rs
+++ b/core/src/function.rs
@@ -28,25 +28,26 @@
 //! on the front-end.
 
 
-use {Architecture, BasicBlock, Guard, Mnemonic, Operation, Region, Result, Rvalue, Statement};
+use {Architecture, BasicBlock, Fun, Guard, Mnemonic, Operation, Region, Result, Rvalue, Statement};
 
-use panopticon_graph_algos::{AdjacencyList, EdgeListGraphTrait, GraphTrait, MutableGraphTrait, VertexListGraphTrait};
-use panopticon_graph_algos::adjacency_list::{AdjacencyListEdgeDescriptor, AdjacencyListVertexDescriptor, VertexLabelIterator};
-use panopticon_graph_algos::search::{TraversalOrder, TreeIterator};
+use petgraph::Graph;
+use petgraph::graph::{NodeIndex, EdgeIndex};
+use petgraph::prelude::*;
 use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use uuid::Uuid;
 
 /// An iterator over every BasicBlock in a Function
 pub struct BasicBlockIterator<'a> {
-    iter: VertexLabelIterator<'a, ControlFlowRef, ControlFlowTarget>
+    iter: Box<Iterator<Item = &'a ControlFlowTarget> + 'a>
 }
 
 impl<'a> BasicBlockIterator<'a> {
     /// Create a new statement iterator from `mnemonics`
     pub fn new(cfg: &'a ControlFlowGraph) -> Self {
+        let iter = Box::new(cfg.node_indices().filter_map(move |idx| cfg.node_weight(idx)));
         BasicBlockIterator {
-            iter: cfg.vertex_labels(),
+            iter
         }
     }
 }
@@ -76,11 +77,11 @@ pub enum ControlFlowTarget {
 }
 
 /// Graph of basic blocks and jumps
-pub type ControlFlowGraph = AdjacencyList<ControlFlowTarget, Guard>;
+pub type ControlFlowGraph = Graph<ControlFlowTarget, Guard>;
 /// Stable reference to a node in the `ControlFlowGraph`
-pub type ControlFlowRef = AdjacencyListVertexDescriptor;
+pub type ControlFlowRef = NodeIndex<u32>;
 /// Stable reference to an edge in the `ControlFlowGraph`
-pub type ControlFlowEdge = AdjacencyListEdgeDescriptor;
+pub type ControlFlowEdge = EdgeIndex<u32>;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 /// The kind of function this is, to distinguish plt stubs from regular functions.
@@ -122,12 +123,51 @@ enum MnemonicOrError {
     Error(u64, Cow<'static, str>),
 }
 
+impl Fun for Function {
+    fn aliases(&self) -> &[String] {
+        Function::aliases(self)
+    }
+    fn kind(&self) -> &FunctionKind {
+        Function::kind(self)
+    }
+    fn add_alias(&mut self, name: String) {
+        Function::add_alias(self, name)
+    }
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn uuid(&self) -> &Uuid {
+        &*self.uuid()
+    }
+    fn set_uuid(&mut self, uuid: Uuid) {
+        self.uuid = uuid;
+    }
+    fn start(&self) -> u64 {
+        Function::start(self)
+    }
+    fn collect_call_addresses(&self) -> Vec<u64> {
+        Function::collect_call_addresses(self)
+    }
+    fn collect_calls(&self) -> Vec<Rvalue> {
+        Function::collect_calls(self)
+    }
+    fn statements<'a>(&'a self) -> Box<Iterator<Item=&'a Statement> + 'a> {
+        Function::statements(self)
+    }
+    fn set_plt(&mut self, import: &str, address: u64) {
+        Function::set_plt(self, import, address)
+    }
+    fn new<A: Architecture>(start: u64, region: &Region, name: Option<String>, init: A::Configuration) -> Result<Function> {
+        Function::new::<A>(start, region, name, init)
+    }
+}
+
 impl Function {
     /// Create an undefined Function. This function has undefined behavior. Creating an undefined Function always succeeds, and is usually a bad idea. Don't do it unless you know what you're doing.
     pub fn undefined(start: u64, uuid: Option<Uuid>, region: &Region, name: Option<String>) -> Function {
-        let mut cflow_graph = AdjacencyList::new();
+        let mut cflow_graph = ControlFlowGraph::new();
         let entry_point = ControlFlowTarget::Unresolved(Rvalue::new_u64(start));
-        let entry_point = cflow_graph.add_vertex(entry_point);
+        let entry_point = cflow_graph.add_node(entry_point);
         Function {
             name: name.unwrap_or(format!("func_{:#x}", start)),
             aliases: Vec::new(),
@@ -144,8 +184,8 @@ impl Function {
     fn disassemble<A: Architecture>(start: u64, cflow_graph: &mut ControlFlowGraph, size: &mut usize, name: &str, uuid: &Uuid, region: &Region, init: A::Configuration) -> Result<ControlFlowRef> {
         let (mut mnemonics, mut by_source, mut by_destination) = Self::index_cflow_graph(cflow_graph, start);
 
-        let mut todo = cflow_graph.vertex_labels().filter_map(|lb| {
-            if let &ControlFlowTarget::Unresolved(Rvalue::Constant{ value,.. }) = lb {
+        let mut todo = cflow_graph.node_weights_mut().filter_map(|lb| {
+            if let &mut ControlFlowTarget::Unresolved(Rvalue::Constant { value, .. }) = lb {
                 Some(value)
             } else {
                 None
@@ -221,11 +261,11 @@ impl Function {
             }
         }
 
-        let cfg = Self::assemble_cflow_graph(mnemonics, by_source, by_destination, start);
+        let cfg = Function::assemble_cflow_graph(mnemonics, by_source, by_destination, start);
         let ep = cfg
-            .vertices()
+            .node_indices()
             .find(
-                |&x| match cfg.vertex_label(x) {
+                |&x| match cfg.node_weight(x) {
                     Some(&ControlFlowTarget::Resolved(ref bb)) => bb.area.start == start && bb.area.end > start,
                     _ => false,
                 }
@@ -249,13 +289,13 @@ impl Function {
 
     /// Create and start disassembling a new function with `name`, inside memory `region`, starting at entry point `start`, with a random UUID.
     pub fn new<A: Architecture>(start: u64, region: &Region, name: Option<String>, init: A::Configuration) -> Result<Function> {
-        let mut cflow_graph = AdjacencyList::new();
+        let mut cflow_graph = ControlFlowGraph::new();
         let entry_point = ControlFlowTarget::Unresolved(Rvalue::new_u64(start));
-        cflow_graph.add_vertex(entry_point);
+        cflow_graph.add_node(entry_point);
         let mut size = 0;
         let name = name.unwrap_or(format!("func_{:#x}", start));
         let uuid = Uuid::new_v4();
-        let entry_point = Self::disassemble::<A>(start, &mut cflow_graph, &mut size, &name, &uuid, region, init)?;
+        let entry_point = Function::disassemble::<A>(start, &mut cflow_graph, &mut size, &name, &uuid, region, init)?;
         Ok(Function {
             name,
             aliases: Vec::new(),
@@ -356,7 +396,7 @@ impl Function {
 
     /// Returns a reference to the BasicBlock entry point of this function.
     pub fn entry_point(&self) -> &BasicBlock {
-        match self.cflow_graph.vertex_label(self.entry_point).unwrap() {
+        match self.cflow_graph.node_weight(self.entry_point).unwrap() {
             &ControlFlowTarget::Resolved(ref bb) => bb,
             _ => panic!("Function {} has an unresolved entry point - this is a bug, dumping the cfg: {:?}", self.name, self.cflow_graph)
         }
@@ -364,7 +404,7 @@ impl Function {
 
     /// Returns a mutable reference to the BasicBlock entry point of this function.
     pub fn entry_point_mut(&mut self) -> &mut BasicBlock {
-        match self.cflow_graph.vertex_label_mut(self.entry_point).unwrap() {
+        match self.cflow_graph.node_weight_mut(self.entry_point).unwrap() {
             &mut ControlFlowTarget::Resolved(ref mut bb) => bb,
             _ => panic!("Function {} has an unresolved entry point - this is a bug!", self.name) // can't dump cfg here because borrowed mutable ;)
         }
@@ -383,6 +423,7 @@ impl Function {
         true
     }
 
+
     fn index_cflow_graph(
         g: &ControlFlowGraph,
         entry: u64,
@@ -393,9 +434,9 @@ impl Function {
 
         by_destination.insert(entry, vec![(Rvalue::Undefined, Guard::always())]);
 
-        for cft in g.vertex_labels() {
-            match cft {
-                &ControlFlowTarget::Resolved(ref bb) => {
+        for cft in g.node_indices() {
+            match g.node_weight(cft) {
+                Some(&ControlFlowTarget::Resolved(ref bb)) => {
                     let mut prev_mne = None;
 
                     for mne in &bb.mnemonics {
@@ -408,17 +449,17 @@ impl Function {
                         prev_mne = Some(mne.area.start);
                     }
                 }
-                &ControlFlowTarget::Failed(ref pos, ref msg) => {
+                Some(&ControlFlowTarget::Failed(ref pos, ref msg)) => {
                     mnemonics.entry(*pos).or_insert(Vec::new()).push(MnemonicOrError::Error(*pos, msg.clone()));
                 }
-                &ControlFlowTarget::Unresolved(_) => {}
+                _ => {}
             }
         }
 
-        for e in g.edges() {
-            let gu = g.edge_label(e).unwrap().clone();
-            let src = g.vertex_label(g.source(e));
-            let tgt = g.vertex_label(g.target(e));
+        for e in g.edge_references() {
+            let gu = g.edge_weight(e.id()).unwrap().clone();
+            let src = g.node_weight(e.source());
+            let tgt = g.node_weight(e.target());
 
             match (src, tgt) {
                 // Resolved -> Resolved
@@ -539,7 +580,7 @@ impl Function {
                         let bb = BasicBlock::from_vec(bblock.clone());
 
                         bblock.clear();
-                        ret.add_vertex(ControlFlowTarget::Resolved(bb));
+                        ret.add_node(ControlFlowTarget::Resolved(bb));
                     }
                 }
             }
@@ -550,7 +591,7 @@ impl Function {
                         bblock.push(mne);
                     }
                     MnemonicOrError::Error(pos, msg) => {
-                        ret.add_vertex(ControlFlowTarget::Failed(pos, msg));
+                        ret.add_node(ControlFlowTarget::Failed(pos, msg));
                     }
                 }
             }
@@ -558,16 +599,15 @@ impl Function {
 
         // last basic block
         if !bblock.is_empty() {
-            ret.add_vertex(ControlFlowTarget::Resolved(BasicBlock::from_vec(bblock)));
+            ret.add_node(ControlFlowTarget::Resolved(BasicBlock::from_vec(bblock)));
         }
 
         // connect basic blocks
         for (src_off, tgts) in by_source.iter() {
             for &(ref tgt, ref gu) in tgts {
-
-                let from_bb = ret.vertices()
+                let from_bb = ret.node_indices()
                     .find(
-                        |&t| match ret.vertex_label(t) {
+                        |&t| match ret.node_weight(t) {
                             Some(&ControlFlowTarget::Resolved(ref bb)) => bb.mnemonics.last().map_or(false, |x| x.area.start == *src_off),
                             Some(&ControlFlowTarget::Unresolved(Rvalue::Constant { value: v, .. })) => v == *src_off,
                             Some(&ControlFlowTarget::Unresolved(_)) => false,
@@ -575,9 +615,9 @@ impl Function {
                             None => unreachable!(),
                         }
                     );
-                let to_bb = ret.vertices()
+                let to_bb = ret.node_indices()
                     .find(
-                        |&t| match (tgt, ret.vertex_label(t)) {
+                        |&t| match (tgt, ret.node_weight(t)) {
                             (&Rvalue::Constant { value, .. }, Some(&ControlFlowTarget::Resolved(ref bb))) => bb.area.start == value,
                             (&Rvalue::Constant { value, .. }, Some(&ControlFlowTarget::Failed(pos, _))) => pos == value,
                             (rv, Some(&ControlFlowTarget::Unresolved(ref v))) => *v == *rv,
@@ -588,20 +628,20 @@ impl Function {
 
                 match (from_bb, to_bb) {
                     (Some(from), Some(to)) => {
-                        ret.add_edge(gu.clone(), from, to);
+                        ret.add_edge(from, to, gu.clone());
                     }
                     (None, Some(to)) => {
-                        if let Some(&ControlFlowTarget::Resolved(ref bb)) = ret.vertex_label(to) {
+                        if let Some(&ControlFlowTarget::Resolved(ref bb)) = ret.node_weight(to) {
                             if bb.area.start <= *src_off && bb.area.end > *src_off {
                                 continue;
                             }
                         }
 
-                        let vx = ret.add_vertex(ControlFlowTarget::Unresolved(Rvalue::new_u64(*src_off)));
-                        ret.add_edge(gu.clone(), vx, to);
+                        let vx = ret.add_node(ControlFlowTarget::Unresolved(Rvalue::new_u64(*src_off)));
+                        ret.add_edge(vx, to, gu.clone());
                     }
                     (Some(from), None) => {
-                        if let Some(&ControlFlowTarget::Resolved(ref bb)) = ret.vertex_label(from) {
+                        if let Some(&ControlFlowTarget::Resolved(ref bb)) = ret.node_weight(from) {
                             if let &Rvalue::Constant { value, .. } = tgt {
                                 if bb.area.start <= value && bb.area.end > value {
                                     continue;
@@ -609,8 +649,8 @@ impl Function {
                             }
                         }
 
-                        let vx = ret.add_vertex(ControlFlowTarget::Unresolved(tgt.clone()));
-                        ret.add_edge(gu.clone(), from, vx);
+                        let vx = ret.add_node(ControlFlowTarget::Unresolved(tgt.clone()));
+                        ret.add_edge(from, vx, gu.clone());
                     }
                     _ => {
                         trace!(
@@ -637,7 +677,7 @@ impl Function {
         for bb in self.basic_blocks() {
             for statement in bb.statements() {
                 match statement {
-                    &Statement { op: Operation::Call(Rvalue::Constant{ value, .. }), .. } => ret.push(value),
+                    &Statement { op: Operation::Call(Rvalue::Constant { value, .. }), .. } => ret.push(value),
                     _ => ()
                 }
             }
@@ -664,9 +704,9 @@ impl Function {
     /// Returns the basic block that begins at `a`.
     pub fn find_basic_block_by_start(&self, a: u64) -> Option<ControlFlowRef> {
         self.cflow_graph
-            .vertices()
+            .node_indices()
             .find(
-                |&x| match self.cflow_graph.vertex_label(x) {
+                |&x| match self.cflow_graph.node_weight(x) {
                     Some(&ControlFlowTarget::Resolved(ref bb)) => bb.area.start == a && bb.area.end > a,
                     _ => false,
                 }
@@ -678,71 +718,61 @@ impl Function {
         self.basic_blocks().find(|&bb| bb.area.start <= a && bb.area.end > a)
     }
 
-    /// Returns all nodes in the graph of this function in post order.
-    pub fn postorder(&self) -> Vec<ControlFlowRef> {
-        TreeIterator::new(
-            self.entry_point,
-            TraversalOrder::Postorder,
-            &self.cflow_graph,
-        )
-                .collect()
-    }
-
     /// Return a boxed iterator over every statement in this function
     pub fn statements<'b>(&'b self) -> Box<Iterator<Item=&'b Statement> + 'b> {
         Box::new(self.basic_blocks().map(|bb| bb.statements()).flat_map(|ss| ss))
     }
-
-    /// Returns the functions basic block graph in graphivz's DOT format. Useful for debugging.
-    pub fn to_dot(&self) -> String {
-        let mut ret = "digraph G {".to_string();
-
-        for v in self.cflow_graph.vertices() {
-            match self.cflow_graph.vertex_label(v) {
-                Some(&ControlFlowTarget::Resolved(ref bb)) => {
-                    ret = format!(
-                        "{}\n{} [label=<<table border=\"0\"><tr><td>{}:{}</td></tr>",
-                        ret,
-                        v.0,
-                        bb.area.start,
-                        bb.area.end
-                    );
-
-                    for mne in bb.mnemonics.iter() {
-                        ret = format!("{}<tr><td align=\"left\">{}</td></tr>", ret, mne.opcode);
-                        for i in mne.instructions.iter() {
-                            ret = format!(
-                                "{}<tr><td align=\"left\">&nbsp;&nbsp;&nbsp;&nbsp;{}</td></tr>",
-                                ret,
-                                i
-                            );
-                        }
-                    }
-
-                    ret = format!("{}</table>>,shape=record];", ret);
-                }
-                Some(&ControlFlowTarget::Unresolved(ref c)) => {
-                    ret = format!("{}\n{} [label=\"{:?}\",shape=circle];", ret, v.0, c);
-                }
-                _ => {
-                    ret = format!("{}\n{} [label=\"?\",shape=circle];", ret, v.0);
-                }
-            }
-        }
-
-        for e in self.cflow_graph.edges() {
-            ret = format!(
-                "{}\n{} -> {} [label=\"{}\"];",
-                ret,
-                self.cflow_graph.source(e).0,
-                self.cflow_graph.target(e).0,
-                self.cflow_graph.edge_label(e).unwrap()
-            );
-        }
-
-        format!("{}\n}}", ret)
-    }
 }
+    ///// Returns the functions basic block graph in graphivz's DOT format. Useful for debugging.
+//    pub fn to_dot(&self) -> String {
+//        let mut ret = "digraph G {".to_string();
+//
+//        for v in self.cflow_graph.node_indices() {
+//            match self.cflow_graph.node_weight(v) {
+//                Some(&ControlFlowTarget::Resolved(ref bb)) => {
+//                    ret = format!(
+//                        "{}\n{} [label=<<table border=\"0\"><tr><td>{}:{}</td></tr>",
+//                        ret,
+//                        v.0,
+//                        bb.area.start,
+//                        bb.area.end
+//                    );
+//
+//                    for mne in bb.mnemonics.iter() {
+//                        ret = format!("{}<tr><td align=\"left\">{}</td></tr>", ret, mne.opcode);
+//                        for i in mne.instructions.iter() {
+//                            ret = format!(
+//                                "{}<tr><td align=\"left\">&nbsp;&nbsp;&nbsp;&nbsp;{}</td></tr>",
+//                                ret,
+//                                i
+//                            );
+//                        }
+//                    }
+//
+//                    ret = format!("{}</table>>,shape=record];", ret);
+//                }
+//                Some(&ControlFlowTarget::Unresolved(ref c)) => {
+//                    ret = format!("{}\n{} [label=\"{:?}\",shape=circle];", ret, v.0, c);
+//                }
+//                _ => {
+//                    ret = format!("{}\n{} [label=\"?\",shape=circle];", ret, v.0);
+//                }
+//            }
+//        }
+//
+////        for e in self.cflow_graph.edges() {
+////            ret = format!(
+////                "{}\n{} -> {} [label=\"{}\"];",
+////                ret,
+////                self.cflow_graph.source(e).0,
+////                self.cflow_graph.target(e).0,
+////                self.cflow_graph.edge_label(e).unwrap()
+////            );
+////        }
+//
+//        format!("{}\n}}", ret)
+//    }
+
 
 #[cfg(test)]
 mod tests {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -72,8 +72,8 @@
 //! applying functions to `Cell` array where the result is not equal in size to the
 //! input (for example uncompressing parts of the executable image).
 
-#![recursion_limit="100"]
-#![warn(missing_docs)]
+#![recursion_limit = "1024"]
+//#![warn(missing_docs)]
 
 #[macro_use]
 extern crate log;
@@ -84,7 +84,8 @@ extern crate panopticon_graph_algos;
 extern crate uuid;
 extern crate byteorder;
 extern crate goblin;
-#[macro_use] extern crate quickcheck;
+#[cfg(not(test))]
+extern crate quickcheck;
 extern crate serde;
 #[macro_use] extern crate serde_derive;
 extern crate serde_cbor;
@@ -94,6 +95,8 @@ extern crate petgraph;
 
 #[cfg(test)]
 extern crate env_logger;
+#[cfg(test)]
+#[macro_use] extern crate quickcheck;
 
 // core
 pub mod disassembler;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -92,6 +92,7 @@ extern crate serde_cbor;
 #[macro_use] extern crate error_chain;
 extern crate leb128;
 extern crate petgraph;
+extern crate smallvec;
 
 #[cfg(test)]
 extern crate env_logger;
@@ -100,7 +101,7 @@ extern crate env_logger;
 
 // core
 pub mod disassembler;
-pub use disassembler::{Architecture, Disassembler, Match, State};
+pub use disassembler::{Architecture, Disassembler, Match, State, TestArch};
 
 #[macro_use]
 pub mod il;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -99,6 +99,26 @@ extern crate env_logger;
 #[cfg(test)]
 #[macro_use] extern crate quickcheck;
 
+pub trait Fun: Sized {
+    fn aliases(&self) -> &[String];
+    fn kind(&self) -> &FunctionKind;
+    fn add_alias(&mut self, String);
+    fn name(&self) -> &str;
+    fn uuid(&self) -> &uuid::Uuid;
+    fn set_uuid(&mut self, uuid::Uuid);
+    fn start(&self) -> u64;
+    fn collect_call_addresses(&self) -> Vec<u64>;
+    fn collect_calls(&self) -> Vec<Rvalue>;
+    fn statements<'a>(&'a self) -> Box<Iterator<Item=&'a Statement> + 'a>;
+    fn set_plt(&mut self, import: &str, address: u64);
+    fn new<A: Architecture>(start: u64, region: &Region, name: Option<String>, init: A::Configuration) -> Result<Self>;
+    fn with_uuid<A: Architecture>(start: u64, uuid: &uuid::Uuid, region: &Region, name: Option<String>, init: A::Configuration) -> Result<Self> {
+        let mut f = Self::new::<A>(start, region, name, init)?;
+        f.set_uuid(uuid.clone());
+        Ok(f)
+    }
+}
+
 // core
 pub mod disassembler;
 pub use disassembler::{Architecture, Disassembler, Match, State, TestArch};

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -84,10 +84,13 @@ extern crate panopticon_graph_algos;
 extern crate uuid;
 extern crate byteorder;
 extern crate goblin;
-extern crate quickcheck;
+#[macro_use] extern crate quickcheck;
 extern crate serde;
 #[macro_use] extern crate serde_derive;
 extern crate serde_cbor;
+#[macro_use] extern crate error_chain;
+extern crate leb128;
+extern crate petgraph;
 
 #[cfg(test)]
 extern crate env_logger;
@@ -126,3 +129,5 @@ pub use result::{Error, Result};
 // file formats
 pub mod loader;
 pub use loader::{Machine, load};
+
+pub mod neo;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -80,7 +80,6 @@ extern crate log;
 
 extern crate num;
 extern crate flate2;
-extern crate panopticon_graph_algos;
 extern crate uuid;
 extern crate byteorder;
 extern crate goblin;

--- a/core/src/neo/bitcode.rs
+++ b/core/src/neo/bitcode.rs
@@ -1,5 +1,5 @@
 use std::io::{Write,Cursor,Read};
-use std::ops::Range;
+use std::ops::{Range};
 use leb128;
 use uuid::Uuid;
 use neo::il::{Statement,Endianess,CallTarget,Operation};
@@ -1107,10 +1107,21 @@ impl Bitcode {
             bitcode: self,
         }
     }
+
+    pub fn iter_range<'a>(&'a self, rgn: Range<usize>) -> BitcodeIter<'a> {
+        BitcodeIter{
+            cursor: Cursor::new(&self.data[rgn]),
+            bitcode: self,
+        }
+    }
+
+    pub fn num_bytes(&self) -> usize {
+        self.data.len()
+    }
 }
 
 pub struct BitcodeIter<'a> {
-    cursor: Cursor<&'a Vec<u8>>,
+    cursor: Cursor<&'a [u8]>,
     bitcode: &'a Bitcode,
 }
 

--- a/core/src/neo/bitcode.rs
+++ b/core/src/neo/bitcode.rs
@@ -1,0 +1,1146 @@
+use std::io::{Write,Cursor,Read};
+use std::ops::Range;
+use leb128;
+use uuid::Uuid;
+use neo::il::{Statement,Endianess,CallTarget,Operation};
+use neo::value::{Constant,Variable,Value};
+use neo::{Str,Result};
+
+#[derive(Clone,Debug)]
+pub struct Bitcode {
+    data: Vec<u8>,
+    strings: Vec<Str>,
+}
+// const: <len, pow2><leb128 value>
+// var: <name, leb128 str idx>, <subscript, leb128 + 1>, <offset, leb128>, <len, pow2><leb128 value>
+
+//  1\2  c   v   u
+//   c|000 001 010
+//   v|011 100 101
+//   u|110 111 xxx
+//
+// add  00000--- <a> <b> <res>
+// sub  00001--- <a> <b> <res>
+// mul  00010--- <a> <b> <res>
+// divu 00011--- <a> <b> <res>
+// divs 00100--- <a> <b> <res>
+// shl  00101--- <a> <b> <res>
+// shru 00110--- <a> <b> <res>
+// shrs 00111--- <a> <b> <res>
+// mod  01000--- <a> <b> <res>
+// and  01001--- <a> <b> <res>
+// or   01010--- <a> <b> <res>
+// xor  01011--- <a> <b> <res>
+// eq   01100--- <a> <b> <res>
+// leu  01101--- <a> <b> <res>
+// les  01110--- <a> <b> <res>
+// ltu  01111--- <a> <b> <res>
+// lts  10000--- <a> <b> <res>
+//
+// c: 0, v: 1
+// little: 0, big: 1
+// zext   1000100- <size, leb128> <a>
+// sext   1000101- <size, leb128> <a>
+// mov    1000110- <a>
+// movu   10001110
+// init   10001111 <name, leb128> <size, leb128>
+// sel    100100-- <size, leb128> <start> <a>
+// load   100101e- <region, leb128> <size, leb128> <a>
+// phi2   10011000 <a, var> <b, var>
+// phi3   10011001 <a, var> <b, var> <c, var>
+// call   10011010 <stub, leb128>
+// call   10011011 <uuid, leb128>
+// icall  1001110- <a>
+// ucall  10011110
+//        10011111
+// store  1010e--- <region, leb128> <size, leb128> <addr> <val>
+// ret    10110000
+//        10110001
+// loadu  1011001e <region, leb128> <size, leb128>
+
+macro_rules! encoding_rule {
+    ( $val:tt [ c , c ] => $a:expr, $b:expr, $res:expr, $data:expr, $strtbl:expr ) => {{
+        let val = $val;
+        let a = $a;
+        let b = $b;
+        let res = $res;
+        let data = $data;
+        let strtbl = $strtbl;
+
+        data.write(&[val])?;
+        Self::encode_constant(a,data)?;
+        Self::encode_constant(b,data)?;
+        Self::encode_variable(res,data,strtbl)?;
+    }};
+    ( $val:tt [ c , v ] => $a:expr, $b:expr, $res:expr, $data:expr, $strtbl:expr ) => {{
+        let val = $val;
+        let a = $a;
+        let b = $b;
+        let res = $res;
+        let data = $data;
+        let strtbl = $strtbl;
+
+        data.write(&[val])?;
+        Self::encode_constant(a,data)?;
+        Self::encode_variable(b,data,strtbl)?;
+        Self::encode_variable(res,data,strtbl)?;
+    }};
+    ( $val:tt [ c , u ] => $a:expr, $res:expr, $data:expr, $strtbl:expr ) => {{
+        let val = $val;
+        let a = $a;
+        let res = $res;
+        let data = $data;
+        let strtbl = $strtbl;
+
+        data.write(&[val])?;
+        Self::encode_constant(a,data)?;
+        Self::encode_variable(res,data,strtbl)?;
+    }};
+    ( $val:tt [ v , c ] => $a:expr, $b:expr, $res:expr, $data:expr, $strtbl:expr ) => {{
+        let val = $val;
+        let a = $a;
+        let b = $b;
+        let res = $res;
+        let data = $data;
+        let strtbl = $strtbl;
+
+        data.write(&[val])?;
+        Self::encode_variable(a,data,strtbl)?;
+        Self::encode_constant(b,data)?;
+        Self::encode_variable(res,data,strtbl)?;
+    }};
+    ( $val:tt [ v , v ] => $a:expr, $b:expr, $res:expr, $data:expr, $strtbl:expr ) => {{
+        let val = $val;
+        let a = $a;
+        let b = $b;
+        let res = $res;
+        let data = $data;
+        let strtbl = $strtbl;
+
+        data.write(&[val])?;
+        Self::encode_variable(a,data,strtbl)?;
+        Self::encode_variable(b,data,strtbl)?;
+        Self::encode_variable(res,data,strtbl)?;
+    }};
+    ( $val:tt [ v , u ] => $a:expr, $res:expr, $data:expr, $strtbl:expr ) => {{
+        let val = $val;
+        let a = $a;
+        let res = $res;
+        let data = $data;
+        let strtbl = $strtbl;
+
+        data.write(&[val])?;
+        Self::encode_variable(a,data,strtbl)?;
+        Self::encode_variable(res,data,strtbl)?;
+    }};
+    ( $val:tt [ u , c ] => $b:expr, $res:expr, $data:expr, $strtbl:expr ) => {{
+        let val = $val;
+        let b = $b;
+        let res = $res;
+        let data = $data;
+        let strtbl = $strtbl;
+
+        data.write(&[val])?;
+        Self::encode_constant(b,data)?;
+        Self::encode_variable(res,data,strtbl)?;
+    }};
+    ( $val:tt [ u , v ] => $b:expr, $res:expr, $data:expr, $strtbl:expr ) => {{
+        let val = $val;
+        let b = $b;
+        let res = $res;
+        let data = $data;
+        let strtbl = $strtbl;
+
+        data.write(&[val])?;
+        Self::encode_variable(b,data,strtbl)?;
+        Self::encode_variable(res,data,strtbl)?;
+    }};
+}
+
+impl Default for Bitcode {
+    fn default() -> Bitcode {
+        Bitcode{
+            strings: Vec::new(),
+            data: Vec::new(),
+        }
+    }
+}
+
+impl Bitcode {
+    pub fn append<I: IntoIterator<Item=Statement> + Sized>(&mut self, i: I) -> Result<Range<usize>> {
+        let mut buf = Cursor::new(Vec::new());
+        let start = self.data.len();
+
+        for stmt in i {
+            Self::encode_statement(stmt,&mut buf,&mut self.strings)?;
+        }
+
+        self.data.extend(buf.into_inner().into_iter());
+        Ok(start..self.data.len())
+    }
+
+    pub fn new(v: Vec<Statement>) -> Result<Bitcode> {
+        let mut strtbl = Vec::<Str>::new();
+        let mut buf = Cursor::new(Vec::new());
+
+        for stmt in v {
+            Self::encode_statement(stmt,&mut buf,&mut strtbl)?;
+        }
+
+        Ok(Bitcode{ data: buf.into_inner(), strings: strtbl })
+    }
+
+    fn encode_statement<W: Write>(stmt: Statement, data: &mut W, strtbl: &mut Vec<Str>) -> Result<()> {
+        use neo::il::Operation::*;
+        use neo::value::Value::*;
+
+        match stmt {
+            // Add: 0b00000---
+            Statement::Expression{ op: Add(Constant(a),Constant(b)), result } => encoding_rule!( 0b00000_000 [c,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: Add(Constant(a),Variable(b)), result } => encoding_rule!( 0b00000_001 [c,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: Add(Constant(a),Undefined), result } => encoding_rule!( 0b00000_010 [c,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: Add(Variable(a),Constant(b)), result } => encoding_rule!( 0b00000_011 [v,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: Add(Variable(a),Variable(b)), result } => encoding_rule!( 0b00000_100 [v,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: Add(Variable(a),Undefined), result } => encoding_rule!( 0b00000_101 [v,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: Add(Undefined,Constant(b)), result } => encoding_rule!( 0b00000_110 [u,c] => b, result, data, strtbl ),
+            Statement::Expression{ op: Add(Undefined,Variable(b)), result } => encoding_rule!( 0b00000_111 [u,v] => b, result, data, strtbl ),
+            Statement::Expression{ op: Add(Undefined,Undefined), result } => {
+                Self::encode_statement(Statement::Expression{ op: Move(Undefined), result: result },data,strtbl)?;
+            }
+
+            // Subtract: 0b00001---
+            Statement::Expression{ op: Subtract(Constant(a),Constant(b)), result } => encoding_rule!( 0b00001_000 [c,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: Subtract(Constant(a),Variable(b)), result } => encoding_rule!( 0b00001_001 [c,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: Subtract(Constant(a),Undefined), result } => encoding_rule!( 0b00001_010 [c,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: Subtract(Variable(a),Constant(b)), result } => encoding_rule!( 0b00001_011 [v,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: Subtract(Variable(a),Variable(b)), result } => encoding_rule!( 0b00001_100 [v,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: Subtract(Variable(a),Undefined), result } => encoding_rule!( 0b00001_101 [v,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: Subtract(Undefined,Constant(b)), result } => encoding_rule!( 0b00001_110 [u,c] => b, result, data, strtbl ),
+            Statement::Expression{ op: Subtract(Undefined,Variable(b)), result } => encoding_rule!( 0b00001_111 [u,v] => b, result, data, strtbl ),
+            Statement::Expression{ op: Subtract(Undefined,Undefined), result } => {
+                Self::encode_statement(Statement::Expression{ op: Move(Undefined), result: result },data,strtbl)?;
+            }
+
+            // Multiply: 0b00010---
+            Statement::Expression{ op: Multiply(Constant(a),Constant(b)), result } => encoding_rule!( 0b00010_000 [c,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: Multiply(Constant(a),Variable(b)), result } => encoding_rule!( 0b00010_001 [c,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: Multiply(Constant(a),Undefined), result } => encoding_rule!( 0b00010_010 [c,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: Multiply(Variable(a),Constant(b)), result } => encoding_rule!( 0b00010_011 [v,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: Multiply(Variable(a),Variable(b)), result } => encoding_rule!( 0b00010_100 [v,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: Multiply(Variable(a),Undefined), result } => encoding_rule!( 0b00010_101 [v,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: Multiply(Undefined,Constant(b)), result } => encoding_rule!( 0b00010_110 [u,c] => b, result, data, strtbl ),
+            Statement::Expression{ op: Multiply(Undefined,Variable(b)), result } => encoding_rule!( 0b00010_111 [u,v] => b, result, data, strtbl ),
+            Statement::Expression{ op: Multiply(Undefined,Undefined), result } => {
+                Self::encode_statement(Statement::Expression{ op: Move(Undefined), result: result },data,strtbl)?;
+            }
+
+            // DivideUnsigned: 0b00011---
+            Statement::Expression{ op: DivideUnsigned(Constant(a),Constant(b)), result } => encoding_rule!( 0b00011_000 [c,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: DivideUnsigned(Constant(a),Variable(b)), result } => encoding_rule!( 0b00011_001 [c,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: DivideUnsigned(Constant(a),Undefined), result } => encoding_rule!( 0b00011_010 [c,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: DivideUnsigned(Variable(a),Constant(b)), result } => encoding_rule!( 0b00011_011 [v,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: DivideUnsigned(Variable(a),Variable(b)), result } => encoding_rule!( 0b00011_100 [v,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: DivideUnsigned(Variable(a),Undefined), result } => encoding_rule!( 0b00011_101 [v,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: DivideUnsigned(Undefined,Constant(b)), result } => encoding_rule!( 0b00011_110 [u,c] => b, result, data, strtbl ),
+            Statement::Expression{ op: DivideUnsigned(Undefined,Variable(b)), result } => encoding_rule!( 0b00011_111 [u,v] => b, result, data, strtbl ),
+            Statement::Expression{ op: DivideUnsigned(Undefined,Undefined), result } => {
+                Self::encode_statement(Statement::Expression{ op: Move(Undefined), result: result },data,strtbl)?;
+            }
+
+            // DivideSigned: 0b00100---
+            Statement::Expression{ op: DivideSigned(Constant(a),Constant(b)), result } => encoding_rule!( 0b00100_000 [c,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: DivideSigned(Constant(a),Variable(b)), result } => encoding_rule!( 0b00100_001 [c,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: DivideSigned(Constant(a),Undefined), result } => encoding_rule!( 0b00100_010 [c,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: DivideSigned(Variable(a),Constant(b)), result } => encoding_rule!( 0b00100_011 [v,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: DivideSigned(Variable(a),Variable(b)), result } => encoding_rule!( 0b00100_100 [v,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: DivideSigned(Variable(a),Undefined), result } => encoding_rule!( 0b00100_101 [v,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: DivideSigned(Undefined,Constant(b)), result } => encoding_rule!( 0b00100_110 [u,c] => b, result, data, strtbl ),
+            Statement::Expression{ op: DivideSigned(Undefined,Variable(b)), result } => encoding_rule!( 0b00100_111 [u,v] => b, result, data, strtbl ),
+            Statement::Expression{ op: DivideSigned(Undefined,Undefined), result } => {
+                Self::encode_statement(Statement::Expression{ op: Move(Undefined), result: result },data,strtbl)?;
+            }
+
+            // ShiftLeft: 0b00101---
+            Statement::Expression{ op: ShiftLeft(Constant(a),Constant(b)), result } => encoding_rule!( 0b00101_000 [c,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: ShiftLeft(Constant(a),Variable(b)), result } => encoding_rule!( 0b00101_001 [c,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: ShiftLeft(Constant(a),Undefined), result } => encoding_rule!( 0b00101_010 [c,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: ShiftLeft(Variable(a),Constant(b)), result } => encoding_rule!( 0b00101_011 [v,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: ShiftLeft(Variable(a),Variable(b)), result } => encoding_rule!( 0b00101_100 [v,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: ShiftLeft(Variable(a),Undefined), result } => encoding_rule!( 0b00101_101 [v,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: ShiftLeft(Undefined,Constant(b)), result } => encoding_rule!( 0b00101_110 [u,c] => b, result, data, strtbl ),
+            Statement::Expression{ op: ShiftLeft(Undefined,Variable(b)), result } => encoding_rule!( 0b00101_111 [u,v] => b, result, data, strtbl ),
+            Statement::Expression{ op: ShiftLeft(Undefined,Undefined), result } => {
+                Self::encode_statement(Statement::Expression{ op: Move(Undefined), result: result },data,strtbl)?;
+            }
+
+            // ShiftRightUnsigned: 0b00110---
+            Statement::Expression{ op: ShiftRightUnsigned(Constant(a),Constant(b)), result } => encoding_rule!( 0b00110_000 [c,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: ShiftRightUnsigned(Constant(a),Variable(b)), result } => encoding_rule!( 0b00110_001 [c,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: ShiftRightUnsigned(Constant(a),Undefined), result } => encoding_rule!( 0b00110_010 [c,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: ShiftRightUnsigned(Variable(a),Constant(b)), result } => encoding_rule!( 0b00110_011 [v,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: ShiftRightUnsigned(Variable(a),Variable(b)), result } => encoding_rule!( 0b00110_100 [v,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: ShiftRightUnsigned(Variable(a),Undefined), result } => encoding_rule!( 0b00110_101 [v,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: ShiftRightUnsigned(Undefined,Constant(b)), result } => encoding_rule!( 0b00110_110 [u,c] => b, result, data, strtbl ),
+            Statement::Expression{ op: ShiftRightUnsigned(Undefined,Variable(b)), result } => encoding_rule!( 0b00110_111 [u,v] => b, result, data, strtbl ),
+            Statement::Expression{ op: ShiftRightUnsigned(Undefined,Undefined), result } => {
+                Self::encode_statement(Statement::Expression{ op: Move(Undefined), result: result },data,strtbl)?;
+            }
+
+            // ShiftRightSigned: 0b00111---
+            Statement::Expression{ op: ShiftRightSigned(Constant(a),Constant(b)), result } => encoding_rule!( 0b00111_000 [c,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: ShiftRightSigned(Constant(a),Variable(b)), result } => encoding_rule!( 0b00111_001 [c,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: ShiftRightSigned(Constant(a),Undefined), result } => encoding_rule!( 0b00111_010 [c,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: ShiftRightSigned(Variable(a),Constant(b)), result } => encoding_rule!( 0b00111_011 [v,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: ShiftRightSigned(Variable(a),Variable(b)), result } => encoding_rule!( 0b00111_100 [v,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: ShiftRightSigned(Variable(a),Undefined), result } => encoding_rule!( 0b00111_101 [v,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: ShiftRightSigned(Undefined,Constant(b)), result } => encoding_rule!( 0b00111_110 [u,c] => b, result, data, strtbl ),
+            Statement::Expression{ op: ShiftRightSigned(Undefined,Variable(b)), result } => encoding_rule!( 0b00111_111 [u,v] => b, result, data, strtbl ),
+            Statement::Expression{ op: ShiftRightSigned(Undefined,Undefined), result } => {
+                Self::encode_statement(Statement::Expression{ op: Move(Undefined), result: result },data,strtbl)?;
+            }
+
+            // Modulo: 0b01000---
+            Statement::Expression{ op: Modulo(Constant(a),Constant(b)), result } => encoding_rule!( 0b01000_000 [c,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: Modulo(Constant(a),Variable(b)), result } => encoding_rule!( 0b01000_001 [c,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: Modulo(Constant(a),Undefined), result } => encoding_rule!( 0b01000_010 [c,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: Modulo(Variable(a),Constant(b)), result } => encoding_rule!( 0b01000_011 [v,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: Modulo(Variable(a),Variable(b)), result } => encoding_rule!( 0b01000_100 [v,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: Modulo(Variable(a),Undefined), result } => encoding_rule!( 0b01000_101 [v,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: Modulo(Undefined,Constant(b)), result } => encoding_rule!( 0b01000_110 [u,c] => b, result, data, strtbl ),
+            Statement::Expression{ op: Modulo(Undefined,Variable(b)), result } => encoding_rule!( 0b01000_111 [u,v] => b, result, data, strtbl ),
+            Statement::Expression{ op: Modulo(Undefined,Undefined), result } => {
+                Self::encode_statement(Statement::Expression{ op: Move(Undefined), result: result },data,strtbl)?;
+            }
+
+            // And: 0b01001---
+            Statement::Expression{ op: And(Constant(a),Constant(b)), result } => encoding_rule!( 0b01001_000 [c,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: And(Constant(a),Variable(b)), result } => encoding_rule!( 0b01001_001 [c,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: And(Constant(a),Undefined), result } => encoding_rule!( 0b01001_010 [c,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: And(Variable(a),Constant(b)), result } => encoding_rule!( 0b01001_011 [v,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: And(Variable(a),Variable(b)), result } => encoding_rule!( 0b01001_100 [v,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: And(Variable(a),Undefined), result } => encoding_rule!( 0b01001_101 [v,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: And(Undefined,Constant(b)), result } => encoding_rule!( 0b01001_110 [u,c] => b, result, data, strtbl ),
+            Statement::Expression{ op: And(Undefined,Variable(b)), result } => encoding_rule!( 0b01001_111 [u,v] => b, result, data, strtbl ),
+            Statement::Expression{ op: And(Undefined,Undefined), result } => {
+                Self::encode_statement(Statement::Expression{ op: Move(Undefined), result: result },data,strtbl)?;
+            }
+
+            // InclusiveOr: 0b01010---
+            Statement::Expression{ op: InclusiveOr(Constant(a),Constant(b)), result } => encoding_rule!( 0b01010_000 [c,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: InclusiveOr(Constant(a),Variable(b)), result } => encoding_rule!( 0b01010_001 [c,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: InclusiveOr(Constant(a),Undefined), result } => encoding_rule!( 0b01010_010 [c,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: InclusiveOr(Variable(a),Constant(b)), result } => encoding_rule!( 0b01010_011 [v,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: InclusiveOr(Variable(a),Variable(b)), result } => encoding_rule!( 0b01010_100 [v,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: InclusiveOr(Variable(a),Undefined), result } => encoding_rule!( 0b01010_101 [v,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: InclusiveOr(Undefined,Constant(b)), result } => encoding_rule!( 0b01010_110 [u,c] => b, result, data, strtbl ),
+            Statement::Expression{ op: InclusiveOr(Undefined,Variable(b)), result } => encoding_rule!( 0b01010_111 [u,v] => b, result, data, strtbl ),
+            Statement::Expression{ op: InclusiveOr(Undefined,Undefined), result } => {
+                Self::encode_statement(Statement::Expression{ op: Move(Undefined), result: result },data,strtbl)?;
+            }
+
+            // ExclusiveOr: 0b01011---
+            Statement::Expression{ op: ExclusiveOr(Constant(a),Constant(b)), result } => encoding_rule!( 0b01011_000 [c,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: ExclusiveOr(Constant(a),Variable(b)), result } => encoding_rule!( 0b01011_001 [c,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: ExclusiveOr(Constant(a),Undefined), result } => encoding_rule!( 0b01011_010 [c,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: ExclusiveOr(Variable(a),Constant(b)), result } => encoding_rule!( 0b01011_011 [v,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: ExclusiveOr(Variable(a),Variable(b)), result } => encoding_rule!( 0b01011_100 [v,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: ExclusiveOr(Variable(a),Undefined), result } => encoding_rule!( 0b01011_101 [v,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: ExclusiveOr(Undefined,Constant(b)), result } => encoding_rule!( 0b01011_110 [u,c] => b, result, data, strtbl ),
+            Statement::Expression{ op: ExclusiveOr(Undefined,Variable(b)), result } => encoding_rule!( 0b01011_111 [u,v] => b, result, data, strtbl ),
+            Statement::Expression{ op: ExclusiveOr(Undefined,Undefined), result } => {
+                Self::encode_statement(Statement::Expression{ op: Move(Undefined), result: result },data,strtbl)?;
+            }
+
+            // Equal: 0b01100---
+            Statement::Expression{ op: Equal(Constant(a),Constant(b)), result } => encoding_rule!( 0b01100_000 [c,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: Equal(Constant(a),Variable(b)), result } => encoding_rule!( 0b01100_001 [c,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: Equal(Constant(a),Undefined), result } => encoding_rule!( 0b01100_010 [c,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: Equal(Variable(a),Constant(b)), result } => encoding_rule!( 0b01100_011 [v,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: Equal(Variable(a),Variable(b)), result } => encoding_rule!( 0b01100_100 [v,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: Equal(Variable(a),Undefined), result } => encoding_rule!( 0b01100_101 [v,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: Equal(Undefined,Constant(b)), result } => encoding_rule!( 0b01100_110 [u,c] => b, result, data, strtbl ),
+            Statement::Expression{ op: Equal(Undefined,Variable(b)), result } => encoding_rule!( 0b01100_111 [u,v] => b, result, data, strtbl ),
+            Statement::Expression{ op: Equal(Undefined,Undefined), result } => {
+                Self::encode_statement(Statement::Expression{ op: Move(Undefined), result: result },data,strtbl)?;
+            }
+
+            // LessOrEqualUnsigned: 0b01101---
+            Statement::Expression{ op: LessOrEqualUnsigned(Constant(a),Constant(b)), result } => encoding_rule!( 0b01101_000 [c,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: LessOrEqualUnsigned(Constant(a),Variable(b)), result } => encoding_rule!( 0b01101_001 [c,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: LessOrEqualUnsigned(Constant(a),Undefined), result } => encoding_rule!( 0b01101_010 [c,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: LessOrEqualUnsigned(Variable(a),Constant(b)), result } => encoding_rule!( 0b01101_011 [v,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: LessOrEqualUnsigned(Variable(a),Variable(b)), result } => encoding_rule!( 0b01101_100 [v,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: LessOrEqualUnsigned(Variable(a),Undefined), result } => encoding_rule!( 0b01101_101 [v,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: LessOrEqualUnsigned(Undefined,Constant(b)), result } => encoding_rule!( 0b01101_110 [u,c] => b, result, data, strtbl ),
+            Statement::Expression{ op: LessOrEqualUnsigned(Undefined,Variable(b)), result } => encoding_rule!( 0b01101_111 [u,v] => b, result, data, strtbl ),
+            Statement::Expression{ op: LessOrEqualUnsigned(Undefined,Undefined), result } => {
+                Self::encode_statement(Statement::Expression{ op: Move(Undefined), result: result },data,strtbl)?;
+            }
+
+            // LessOrEqualSigned: 0b01110---
+            Statement::Expression{ op: LessOrEqualSigned(Constant(a),Constant(b)), result } => encoding_rule!( 0b01110_000 [c,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: LessOrEqualSigned(Constant(a),Variable(b)), result } => encoding_rule!( 0b01110_001 [c,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: LessOrEqualSigned(Constant(a),Undefined), result } => encoding_rule!( 0b01110_010 [c,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: LessOrEqualSigned(Variable(a),Constant(b)), result } => encoding_rule!( 0b01110_011 [v,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: LessOrEqualSigned(Variable(a),Variable(b)), result } => encoding_rule!( 0b01110_100 [v,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: LessOrEqualSigned(Variable(a),Undefined), result } => encoding_rule!( 0b01110_101 [v,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: LessOrEqualSigned(Undefined,Constant(b)), result } => encoding_rule!( 0b01110_110 [u,c] => b, result, data, strtbl ),
+            Statement::Expression{ op: LessOrEqualSigned(Undefined,Variable(b)), result } => encoding_rule!( 0b01110_111 [u,v] => b, result, data, strtbl ),
+            Statement::Expression{ op: LessOrEqualSigned(Undefined,Undefined), result } => {
+                Self::encode_statement(Statement::Expression{ op: Move(Undefined), result: result },data,strtbl)?;
+            }
+
+            // LessUnsigned: 0b01111---
+            Statement::Expression{ op: LessUnsigned(Constant(a),Constant(b)), result } => encoding_rule!( 0b01111_000 [c,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: LessUnsigned(Constant(a),Variable(b)), result } => encoding_rule!( 0b01111_001 [c,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: LessUnsigned(Constant(a),Undefined), result } => encoding_rule!( 0b01111_010 [c,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: LessUnsigned(Variable(a),Constant(b)), result } => encoding_rule!( 0b01111_011 [v,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: LessUnsigned(Variable(a),Variable(b)), result } => encoding_rule!( 0b01111_100 [v,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: LessUnsigned(Variable(a),Undefined), result } => encoding_rule!( 0b01111_101 [v,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: LessUnsigned(Undefined,Constant(b)), result } => encoding_rule!( 0b01111_110 [u,c] => b, result, data, strtbl ),
+            Statement::Expression{ op: LessUnsigned(Undefined,Variable(b)), result } => encoding_rule!( 0b01111_111 [u,v] => b, result, data, strtbl ),
+            Statement::Expression{ op: LessUnsigned(Undefined,Undefined), result } => {
+                Self::encode_statement(Statement::Expression{ op: Move(Undefined), result: result },data,strtbl)?;
+            }
+
+            // LessSigned: 0b10000---
+            Statement::Expression{ op: LessSigned(Constant(a),Constant(b)), result } => encoding_rule!( 0b10000_000 [c,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: LessSigned(Constant(a),Variable(b)), result } => encoding_rule!( 0b10000_001 [c,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: LessSigned(Constant(a),Undefined), result } => encoding_rule!( 0b10000_010 [c,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: LessSigned(Variable(a),Constant(b)), result } => encoding_rule!( 0b10000_011 [v,c] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: LessSigned(Variable(a),Variable(b)), result } => encoding_rule!( 0b10000_100 [v,v] => a, b, result, data, strtbl ),
+            Statement::Expression{ op: LessSigned(Variable(a),Undefined), result } => encoding_rule!( 0b10000_101 [v,u] => a, result, data, strtbl ),
+            Statement::Expression{ op: LessSigned(Undefined,Constant(b)), result } => encoding_rule!( 0b10000_110 [u,c] => b, result, data, strtbl ),
+            Statement::Expression{ op: LessSigned(Undefined,Variable(b)), result } => encoding_rule!( 0b10000_111 [u,v] => b, result, data, strtbl ),
+            Statement::Expression{ op: LessSigned(Undefined,Undefined), result } => {
+                Self::encode_statement(Statement::Expression{ op: Move(Undefined), result: result },data,strtbl)?;
+            }
+
+            // ZeroExtend: 0b1000100- <size, leb128> <a>
+            Statement::Expression{ op: ZeroExtend(sz,Constant(a)), result } => {
+                data.write(&[0b10001000])?;
+                leb128::write::unsigned(data,sz as u64)?;
+                Self::encode_constant(a,data)?;
+                Self::encode_variable(result,data,strtbl)?;
+            }
+            Statement::Expression{ op: ZeroExtend(sz,Variable(a)), result } => {
+                data.write(&[0b10001001])?;
+                leb128::write::unsigned(data,sz as u64)?;
+                Self::encode_variable(a,data,strtbl)?;
+                Self::encode_variable(result,data,strtbl)?;
+            }
+            Statement::Expression{ op: ZeroExtend(_,Undefined), result } => {
+                Self::encode_statement(Statement::Expression{ op: Move(Undefined), result: result },data,strtbl)?;
+            }
+
+            // SignExtend: 0b1000101- <size, leb128> <a>
+            Statement::Expression{ op: SignExtend(sz,Constant(a)), result } => {
+                data.write(&[0b10001010])?;
+                leb128::write::unsigned(data,sz as u64)?;
+                Self::encode_constant(a,data)?;
+                Self::encode_variable(result,data,strtbl)?;
+            }
+            Statement::Expression{ op: SignExtend(sz,Variable(a)), result } => {
+                data.write(&[0b10001011])?;
+                leb128::write::unsigned(data,sz as u64)?;
+                Self::encode_variable(a,data,strtbl)?;
+                Self::encode_variable(result,data,strtbl)?;
+            }
+            Statement::Expression{ op: SignExtend(_,Undefined), result } => {
+                Self::encode_statement(Statement::Expression{ op: Move(Undefined), result: result },data,strtbl)?;
+            }
+
+            // Move: 0b1000110- <a>
+            Statement::Expression{ op: Move(Constant(a)), result } => {
+                data.write(&[0b10001100])?;
+                Self::encode_constant(a,data)?;
+                Self::encode_variable(result,data,strtbl)?;
+            }
+            Statement::Expression{ op: Move(Variable(a)), result } => {
+                data.write(&[0b10001101])?;
+                Self::encode_variable(a,data,strtbl)?;
+                Self::encode_variable(result,data,strtbl)?;
+            }
+
+            // Move Undefined: 0b10001110
+            Statement::Expression{ op: Move(Undefined), result } => {
+                data.write(&[0b10001110])?;
+                Self::encode_variable(result,data,strtbl)?;
+            }
+
+            // Initialize: 0b10001111 <name, leb128> <size, leb128>
+            Statement::Expression{ op: Initialize(name,sz), result } => {
+                data.write(&[0b10001111])?;
+                leb128::write::unsigned(data,Self::encode_str(name,strtbl))?;
+                leb128::write::unsigned(data,sz as u64)?;
+                Self::encode_variable(result,data,strtbl)?;
+            }
+
+            // Select: 0b100100-- <size, leb128> <start> <a>
+            Statement::Expression{ op: Select(sz,Constant(start),Constant(src)), result } => {
+                data.write(&[0b10010000])?;
+                leb128::write::unsigned(data,sz as u64)?;
+                Self::encode_constant(start,data)?;
+                Self::encode_constant(src,data)?;
+                Self::encode_variable(result,data,strtbl)?;
+            }
+            Statement::Expression{ op: Select(sz,Constant(start),Variable(src)), result } => {
+                data.write(&[0b10010001])?;
+                leb128::write::unsigned(data,sz as u64)?;
+                Self::encode_constant(start,data)?;
+                Self::encode_variable(src,data,strtbl)?;
+                Self::encode_variable(result,data,strtbl)?;
+            }
+            Statement::Expression{ op: Select(sz,Variable(start),Constant(src)), result } => {
+                data.write(&[0b10010010])?;
+                leb128::write::unsigned(data,sz as u64)?;
+                Self::encode_variable(start,data,strtbl)?;
+                Self::encode_constant(src,data)?;
+                Self::encode_variable(result,data,strtbl)?;
+            }
+            Statement::Expression{ op: Select(sz,Variable(start),Variable(src)), result } => {
+                data.write(&[0b10010011])?;
+                leb128::write::unsigned(data,sz as u64)?;
+                Self::encode_variable(start,data,strtbl)?;
+                Self::encode_variable(src,data,strtbl)?;
+                Self::encode_variable(result,data,strtbl)?;
+            }
+            Statement::Expression{ op: Select(_,_,Undefined), result } => {
+                Self::encode_statement(Statement::Expression{ op: Move(Undefined), result: result },data,strtbl)?;
+            }
+            Statement::Expression{ op: Select(_,Undefined,_), result } => {
+                Self::encode_statement(Statement::Expression{ op: Move(Undefined), result: result },data,strtbl)?;
+            }
+
+            // Load: 0b100101e- <region, leb128> <size, leb128> <a>
+            Statement::Expression{ op: Load(region,Endianess::Little,bytes,Constant(addr)), result } => {
+                data.write(&[0b10010100])?;
+                leb128::write::unsigned(data,Self::encode_str(region,strtbl))?;
+                leb128::write::unsigned(data,bytes as u64)?;
+                Self::encode_constant(addr,data)?;
+                Self::encode_variable(result,data,strtbl)?;
+            }
+            Statement::Expression{ op: Load(region,Endianess::Big,bytes,Constant(addr)), result } => {
+                data.write(&[0b10010110])?;
+                leb128::write::unsigned(data,Self::encode_str(region,strtbl))?;
+                leb128::write::unsigned(data,bytes as u64)?;
+                Self::encode_constant(addr,data)?;
+                Self::encode_variable(result,data,strtbl)?;
+            }
+            Statement::Expression{ op: Load(region,Endianess::Little,bytes,Variable(addr)), result } => {
+                data.write(&[0b10010101])?;
+                leb128::write::unsigned(data,Self::encode_str(region,strtbl))?;
+                leb128::write::unsigned(data,bytes as u64)?;
+                Self::encode_variable(addr,data,strtbl)?;
+                Self::encode_variable(result,data,strtbl)?;
+            }
+            Statement::Expression{ op: Load(region,Endianess::Big,bytes,Variable(addr)), result } => {
+                data.write(&[0b10010111])?;
+                leb128::write::unsigned(data,Self::encode_str(region,strtbl))?;
+                leb128::write::unsigned(data,bytes as u64)?;
+                Self::encode_variable(addr,data,strtbl)?;
+                Self::encode_variable(result,data,strtbl)?;
+            }
+
+            // Phi2: 0b10011000 <a> <b>
+            Statement::Expression{ op: Phi(Variable(a),Variable(b),Undefined), result } |
+            Statement::Expression{ op: Phi(Variable(a),Undefined,Variable(b)), result } |
+            Statement::Expression{ op: Phi(Undefined,Variable(a),Variable(b)), result } => {
+                data.write(&[0b10011000])?;
+                Self::encode_variable(a,data,strtbl)?;
+                Self::encode_variable(b,data,strtbl)?;
+                Self::encode_variable(result,data,strtbl)?;
+            }
+
+            // Phi3: 0b10011001 <a> <b> <c>
+            Statement::Expression{ op: Phi(Variable(a),Variable(b),Variable(c)), result } => {
+                data.write(&[0b10011001])?;
+                Self::encode_variable(a,data,strtbl)?;
+                Self::encode_variable(b,data,strtbl)?;
+                Self::encode_variable(c,data,strtbl)?;
+                Self::encode_variable(result,data,strtbl)?;
+            }
+
+            Statement::Expression{ op: Phi(_,_,_),.. } => {
+                return Err(format!("Internal error: invalid Phi expression {:?}",stmt).into());
+            }
+
+            // Call: 0b10011010 <stub, leb128>
+            Statement::Call{ function: CallTarget::External(name) } => {
+                data.write(&[0b10011010])?;
+                leb128::write::unsigned(data,Self::encode_str(name,strtbl))?;
+            }
+
+            // Call: 0b10011011 <uuid, leb128>
+            Statement::Call{ function: CallTarget::Function(uuid) } => {
+                data.write(&[0b10011011])?;
+                leb128::write::unsigned(data,Self::encode_str(uuid.to_string().into(),strtbl))?;
+            }
+
+            // IndirectCall: 0b1001110- <a>
+            Statement::IndirectCall{ target: Constant(tgt) } => {
+                data.write(&[0b10011100])?;
+                Self::encode_constant(tgt,data)?;
+            }
+            Statement::IndirectCall{ target: Variable(tgt) } => {
+                data.write(&[0b10011101])?;
+                Self::encode_variable(tgt,data,strtbl)?;
+            }
+
+            // IndirectCall Undefined: 0b10011110
+            Statement::IndirectCall{ target: Undefined } => {
+                data.write(&[0b10011110])?;
+            }
+
+            // Store: 0b1010e--- <region, leb128> <size, leb128> <addr> <val>
+            Statement::Store{ region, bytes, endianess, address: Constant(addr), value: Constant(value) } => {
+                data.write(&[0b10100000 | if endianess == Endianess::Little { 0 } else { 0b1000 }])?;
+                leb128::write::unsigned(data,Self::encode_str(region,strtbl))?;
+                leb128::write::unsigned(data,bytes as u64)?;
+                Self::encode_constant(addr,data)?;
+                Self::encode_constant(value,data)?;
+            }
+            Statement::Store{ region, bytes, endianess, address: Constant(addr), value: Variable(value) } => {
+                data.write(&[0b10100001 | if endianess == Endianess::Little { 0 } else { 0b1000 }])?;
+                leb128::write::unsigned(data,Self::encode_str(region,strtbl))?;
+                leb128::write::unsigned(data,bytes as u64)?;
+                Self::encode_constant(addr,data)?;
+                Self::encode_variable(value,data,strtbl)?;
+            }
+            Statement::Store{ region, bytes, endianess, address: Constant(addr), value: Undefined } => {
+                data.write(&[0b10100010 | if endianess == Endianess::Little { 0 } else { 0b1000 }])?;
+                leb128::write::unsigned(data,Self::encode_str(region,strtbl))?;
+                leb128::write::unsigned(data,bytes as u64)?;
+                Self::encode_constant(addr,data)?;
+            }
+            Statement::Store{ region, bytes, endianess, address: Variable(addr), value: Constant(value) } => {
+                data.write(&[0b10100011 | if endianess == Endianess::Little { 0 } else { 0b1000 }])?;
+                leb128::write::unsigned(data,Self::encode_str(region,strtbl))?;
+                leb128::write::unsigned(data,bytes as u64)?;
+                Self::encode_variable(addr,data,strtbl)?;
+                Self::encode_constant(value,data)?;
+            }
+            Statement::Store{ region, bytes, endianess, address: Variable(addr), value: Variable(value) } => {
+                data.write(&[0b10100100 | if endianess == Endianess::Little { 0 } else { 0b1000 }])?;
+                leb128::write::unsigned(data,Self::encode_str(region,strtbl))?;
+                leb128::write::unsigned(data,bytes as u64)?;
+                Self::encode_variable(addr,data,strtbl)?;
+                Self::encode_variable(value,data,strtbl)?;
+            }
+            Statement::Store{ region, bytes, endianess, address: Variable(addr), value: Undefined } => {
+                data.write(&[0b10100101 | if endianess == Endianess::Little { 0 } else { 0b1000 }])?;
+                leb128::write::unsigned(data,Self::encode_str(region,strtbl))?;
+                leb128::write::unsigned(data,bytes as u64)?;
+                Self::encode_variable(addr,data,strtbl)?;
+            }
+            Statement::Store{ region, bytes, endianess, address: Undefined, value: Constant(value) } => {
+                data.write(&[0b10100110 | if endianess == Endianess::Little { 0 } else { 0b1000 }])?;
+                leb128::write::unsigned(data,Self::encode_str(region,strtbl))?;
+                leb128::write::unsigned(data,bytes as u64)?;
+                Self::encode_constant(value,data)?;
+            }
+            Statement::Store{ region, bytes, endianess, address: Undefined, value: Variable(value) } => {
+                data.write(&[0b10100111 | if endianess == Endianess::Little { 0 } else { 0b1000 }])?;
+                leb128::write::unsigned(data,Self::encode_str(region,strtbl))?;
+                leb128::write::unsigned(data,bytes as u64)?;
+                Self::encode_variable(value,data,strtbl)?;
+            }
+            Statement::Store{ address: Undefined, value: Undefined,.. } => { /* NOP */ }
+
+            // Return: 0b10110000
+            Statement::Return => {
+                data.write(&[0b10110000])?;
+            }
+
+            // Load Undefined: 0b1011 001e <region, leb128> <size, leb128>
+            Statement::Expression{ op: Load(region,endianess,bytes,Undefined), result } => {
+                data.write(&[0b1011_0010 | if endianess == Endianess::Little { 0 } else { 0b1 }])?;
+                leb128::write::unsigned(data,Self::encode_str(region,strtbl))?;
+                leb128::write::unsigned(data,bytes as u64)?;
+                Self::encode_variable(result,data,strtbl)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    // const: <len, pow2><leb128 value>
+    fn encode_constant<W: Write>(c: Constant, data: &mut W) -> Result<()> {
+        let Constant{ value, bits } = c;
+        leb128::write::unsigned(data,bits as u64)?;
+        leb128::write::unsigned(data,value)?;
+        Ok(())
+    }
+
+    // var: <name, leb128 str idx>, <subscript, leb128 + 1>, <len, pow2>
+    fn encode_variable<W: Write>(c: Variable, data: &mut W, strtbl: &mut Vec<Str>) -> Result<()> {
+        let Variable{ name, subscript, bits } = c;
+        leb128::write::unsigned(data,Self::encode_str(name,strtbl))?;
+        leb128::write::unsigned(data,if let Some(subscript) = subscript { subscript as u64 + 1 } else { 0 })?;
+        leb128::write::unsigned(data,bits as u64)?;
+        Ok(())
+    }
+
+    fn encode_str(s: Str, strtbl: &mut Vec<Str>) -> u64 {
+        if let Some(pos) = strtbl.iter().position(|x| *x == s) {
+            pos as u64
+        } else {
+            strtbl.push(s);
+            strtbl.len() as u64 - 1
+        }
+    }
+
+    fn decode_statement<R: Read>(&self, data: &mut R) -> Result<Statement> {
+        let mut opcode = [0u8; 1];
+        data.read_exact(&mut opcode)?;
+
+        match opcode[0] {
+            0b00000_000...0b00001_000 => {
+                let (a,b) = self.decode_arguments(opcode[0] & 0b111,data)?;
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{ op: Operation::Add(a,b), result: res };
+
+                Ok(stmt)
+            }
+            0b00001_000...0b00010_000 => {
+                let (a,b) = self.decode_arguments(opcode[0] & 0b111,data)?;
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{ op: Operation::Subtract(a,b), result: res };
+
+                Ok(stmt)
+            }
+            0b00010_000...0b00011_000 => {
+                let (a,b) = self.decode_arguments(opcode[0] & 0b111,data)?;
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{ op: Operation::Multiply(a,b), result: res };
+
+                Ok(stmt)
+            }
+            0b00011_000...0b00100_000 => {
+                let (a,b) = self.decode_arguments(opcode[0] & 0b111,data)?;
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{ op: Operation::DivideUnsigned(a,b), result: res };
+
+                Ok(stmt)
+            }
+            0b00100_000...0b00101_000 => {
+                let (a,b) = self.decode_arguments(opcode[0] & 0b111,data)?;
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{ op: Operation::DivideSigned(a,b), result: res };
+
+                Ok(stmt)
+            }
+            0b00101_000...0b00110_000 => {
+                let (a,b) = self.decode_arguments(opcode[0] & 0b111,data)?;
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{ op: Operation::ShiftLeft(a,b), result: res };
+
+                Ok(stmt)
+            }
+            0b00110_000...0b00111_000 => {
+                let (a,b) = self.decode_arguments(opcode[0] & 0b111,data)?;
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{ op: Operation::ShiftRightUnsigned(a,b), result: res };
+
+                Ok(stmt)
+            }
+            0b00111_000...0b01000_000 => {
+                let (a,b) = self.decode_arguments(opcode[0] & 0b111,data)?;
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{ op: Operation::ShiftRightSigned(a,b), result: res };
+
+                Ok(stmt)
+            }
+            0b01000_000...0b01001_000 => {
+                let (a,b) = self.decode_arguments(opcode[0] & 0b111,data)?;
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{ op: Operation::Modulo(a,b), result: res };
+
+                Ok(stmt)
+            }
+            0b01001_000...0b01010_000 => {
+                let (a,b) = self.decode_arguments(opcode[0] & 0b111,data)?;
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{ op: Operation::And(a,b), result: res };
+
+                Ok(stmt)
+            }
+            0b01010_000...0b01011_000 => {
+                let (a,b) = self.decode_arguments(opcode[0] & 0b111,data)?;
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{ op: Operation::InclusiveOr(a,b), result: res };
+
+                Ok(stmt)
+            }
+            0b01011_000...0b01100_000 => {
+                let (a,b) = self.decode_arguments(opcode[0] & 0b111,data)?;
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{ op: Operation::ExclusiveOr(a,b), result: res };
+
+                Ok(stmt)
+            }
+            0b01100_000...0b01101_000 => {
+                let (a,b) = self.decode_arguments(opcode[0] & 0b111,data)?;
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{ op: Operation::Equal(a,b), result: res };
+
+                Ok(stmt)
+            }
+            0b01101_000...0b01110_000 => {
+                let (a,b) = self.decode_arguments(opcode[0] & 0b111,data)?;
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{ op: Operation::LessOrEqualUnsigned(a,b), result: res };
+
+                Ok(stmt)
+            }
+            0b01110_000...0b01111_000 => {
+                let (a,b) = self.decode_arguments(opcode[0] & 0b111,data)?;
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{ op: Operation::LessOrEqualSigned(a,b), result: res };
+
+                Ok(stmt)
+            }
+            0b01111_000...0b10000_000 => {
+                let (a,b) = self.decode_arguments(opcode[0] & 0b111,data)?;
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{ op: Operation::LessUnsigned(a,b), result: res };
+
+                Ok(stmt)
+            }
+            0b10000_000...0b10000_111 => {
+                let (a,b) = self.decode_arguments(opcode[0] & 0b111,data)?;
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{ op: Operation::LessSigned(a,b), result: res };
+
+                Ok(stmt)
+            }
+
+            // zext  1000 100- <size, leb128> <a>
+            0b1000_1000 | 0b1000_1001 => {
+                let sz = leb128::read::unsigned(data)? as usize;
+                let a = if opcode[0] & 1 == 0 {
+                    Value::Constant(self.decode_constant(data)?)
+                } else {
+                    Value::Variable(self.decode_variable(data)?)
+                };
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{ op: Operation::ZeroExtend(sz,a), result: res };
+
+                Ok(stmt)
+            }
+
+            // sext  1000 101- <size, leb128> <a>
+            0b1000_1010 | 0b1000_1011 => {
+                let sz = leb128::read::unsigned(data)? as usize;
+                let a = if opcode[0] & 1 == 0 {
+                    Value::Constant(self.decode_constant(data)?)
+                } else {
+                    Value::Variable(self.decode_variable(data)?)
+                };
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{ op: Operation::SignExtend(sz,a), result: res };
+
+                Ok(stmt)
+            }
+
+            // mov   1000 110- <a>
+            0b1000_1100 | 0b1000_1101 => {
+                let a = if opcode[0] & 1 == 0 {
+                    Value::Constant(self.decode_constant(data)?)
+                } else {
+                    Value::Variable(self.decode_variable(data)?)
+                };
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{ op: Operation::Move(a), result: res };
+
+                Ok(stmt)
+            }
+
+            // movu  1000 1110
+            0b1000_1110 => {
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{ op: Operation::Move(Value::Undefined), result: res };
+
+                Ok(stmt)
+            }
+
+            // init  1000 1111 <name, leb128> <size, leb128>
+            0b1000_1111 => {
+                let name = leb128::read::unsigned(data)? as usize;
+                let sz = leb128::read::unsigned(data)? as usize;
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{
+                    op: Operation::Initialize(self.strings[name].clone(),sz),
+                    result: res
+                };
+
+                Ok(stmt)
+            }
+
+            // sel   1001 00-- <size, leb128> <start> <a>
+            0b1001_0000...0b1001_0011 => {
+                let sz = leb128::read::unsigned(data)? as usize;
+                let start = if opcode[0] & 0b10 == 0 {
+                    Value::Constant(self.decode_constant(data)?)
+                } else {
+                    Value::Variable(self.decode_variable(data)?)
+                };
+                let val = if opcode[0] & 0b1 == 0 {
+                    Value::Constant(self.decode_constant(data)?)
+                } else {
+                    Value::Variable(self.decode_variable(data)?)
+                };
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{ op: Operation::Select(sz,start,val), result: res };
+
+                Ok(stmt)
+            }
+
+            // load  1001 01e- <region, leb128> <size, leb128> <a>
+            0b1001_0100...0b1001_0111 => {
+                let reg = leb128::read::unsigned(data)? as usize;
+                let sz = leb128::read::unsigned(data)? as usize;
+                let val = if opcode[0] & 0b1 == 0 {
+                    Value::Constant(self.decode_constant(data)?)
+                } else {
+                    Value::Variable(self.decode_variable(data)?)
+                };
+                let endianess = if opcode[0] & 0b10 == 0 {
+                    Endianess::Little
+                } else {
+                    Endianess::Big
+                };
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{
+                    op: Operation::Load(self.strings[reg].clone(),endianess,sz,val),
+                    result: res
+                };
+
+                Ok(stmt)
+            }
+
+            // phi2  1001 1000 <a, var> <b, var>
+            0b1001_1000 => {
+                let a = Value::Variable(self.decode_variable(data)?);
+                let b = Value::Variable(self.decode_variable(data)?);
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{
+                    op: Operation::Phi(a,b,Value::Undefined),
+                    result: res
+                };
+
+                Ok(stmt)
+            }
+
+            // phi3  1001 1001 <a, var> <b, var> <c, var>
+            0b1001_1001 => {
+                let a = Value::Variable(self.decode_variable(data)?);
+                let b = Value::Variable(self.decode_variable(data)?);
+                let c = Value::Variable(self.decode_variable(data)?);
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{
+                    op: Operation::Phi(a,b,c),
+                    result: res
+                };
+
+                Ok(stmt)
+            }
+
+            // call  1001 1010 <stub, leb128>
+            // call  1001 1011 <uuid, leb128>
+            0b1001_1010 | 0b1001_1011 => {
+                let s = leb128::read::unsigned(data)? as usize;
+                let stmt = Statement::Call{
+                    function: if opcode[0] & 1 == 0 {
+                        CallTarget::External(self.strings[s].clone())
+                    } else {
+                        let s = &self.strings[s];
+                        let uu = Uuid::parse_str(s)
+                            .map_err(|_| format!("Internal error: invalid uuid '{}'",s))?;
+                        CallTarget::Function(uu)
+                    }
+                };
+
+                Ok(stmt)
+            }
+
+            // icall 1001 110- <a>
+            0b1001_1100...0b1001_1101 => {
+                let val = if opcode[0] & 0b1 == 0 {
+                    Value::Constant(self.decode_constant(data)?)
+                } else {
+                    Value::Variable(self.decode_variable(data)?)
+                };
+                let stmt = Statement::IndirectCall{ target: val };
+
+                Ok(stmt)
+            }
+
+            0b1001_1110 => {
+                let stmt = Statement::IndirectCall{ target: Value::Undefined };
+
+                Ok(stmt)
+            }
+
+            // store 1010 e--- <region, leb128> <size, leb128> <addr> <val>
+            0b1010_0000...0b1010_1111 => {
+                let reg = leb128::read::unsigned(data)? as usize;
+                let sz = leb128::read::unsigned(data)? as usize;
+                let (addr,val) = self.decode_arguments(opcode[0] & 0b111,data)?;
+                let endianess = if opcode[0] & 0b1000 == 0 {
+                    Endianess::Little
+                } else {
+                    Endianess::Big
+                };
+                let stmt = Statement::Store{
+                    region: self.strings[reg].clone(),
+                    bytes: sz,
+                    endianess: endianess,
+                    address: addr,
+                    value: val,
+                };
+
+                Ok(stmt)
+            }
+
+            // ret   1011 0000
+            0b1011_0000 => {
+                let stmt = Statement::Return;
+
+                Ok(stmt)
+            }
+
+            // loadu: 0b1011001e <region, leb128> <size, leb128>
+            0b1011_0010 | 0b1011_0011 => {
+                let reg = leb128::read::unsigned(data)? as usize;
+                let sz = leb128::read::unsigned(data)? as usize;
+                let endianess = if opcode[0] & 1 == 0 {
+                    Endianess::Little
+                } else {
+                    Endianess::Big
+                };
+                let res = self.decode_variable(data)?;
+                let stmt = Statement::Expression{
+                    op: Operation::Load(self.strings[reg].clone(),endianess,sz,Value::Undefined),
+                    result: res
+                };
+
+                Ok(stmt)
+            }
+
+            _ => Err(format!("Internal error: invalid bitcode {:b}",opcode[0]).into()),
+        }
+    }
+
+    //  1\2  c   v   u
+    //   c|000 001 010
+    //   v|011 100 101
+    //   u|110 111 xxx
+    fn decode_arguments<R: Read>(&self, code: u8, data: &mut R) -> Result<(Value,Value)> {
+        match code {
+            0b000 => {
+                let a = self.decode_constant(data)?;
+                let b = self.decode_constant(data)?;
+                Ok((Value::Constant(a),Value::Constant(b)))
+            }
+            0b001 => {
+                let a = self.decode_constant(data)?;
+                let b = self.decode_variable(data)?;
+                Ok((Value::Constant(a),Value::Variable(b)))
+            }
+            0b010 => {
+                let a = self.decode_constant(data)?;
+                Ok((Value::Constant(a),Value::Undefined))
+            }
+            0b011 => {
+                let a = self.decode_variable(data)?;
+                let b = self.decode_constant(data)?;
+                Ok((Value::Variable(a),Value::Constant(b)))
+            }
+            0b100 => {
+                let a = self.decode_variable(data)?;
+                let b = self.decode_variable(data)?;
+                Ok((Value::Variable(a),Value::Variable(b)))
+            }
+            0b101 => {
+                let a = self.decode_variable(data)?;
+                Ok((Value::Variable(a),Value::Undefined))
+            }
+            0b110 => {
+                let a = self.decode_constant(data)?;
+                Ok((Value::Undefined,Value::Constant(a)))
+            }
+            0b111 => {
+                let a = self.decode_variable(data)?;
+                Ok((Value::Undefined,Value::Variable(a)))
+            }
+            _ => Err(format!("internal error: impossible argument code {:b}",code).into())
+        }
+    }
+
+    // const: <len, pow2><leb128 value>
+    fn decode_constant<R: Read>(&self, data: &mut R) -> Result<Constant> {
+        let bits = leb128::read::unsigned(data)?;
+        let value = leb128::read::unsigned(data)?;
+
+        Ok(Constant{ bits: bits as usize, value: value })
+    }
+
+    // var: <name, leb128 str idx>, <subscript, leb128 + 1>, <len, pow2>
+    fn decode_variable<R: Read>(&self, data: &mut R) -> Result<Variable> {
+        let name = leb128::read::unsigned(data)?;
+        let subscript = leb128::read::unsigned(data)?;
+        let bits = leb128::read::unsigned(data)?;
+        let var = Variable{
+            name: self.strings[name as usize].clone(),
+            subscript: if subscript == 0 { None } else { Some(subscript as usize - 1)  },
+            bits: bits as usize,
+        };
+
+
+        Ok(var)
+    }
+
+    pub fn iter<'a>(&'a self) -> BitcodeIter<'a> {
+        BitcodeIter{
+            cursor: Cursor::new(&self.data),
+            bitcode: self,
+        }
+    }
+}
+
+pub struct BitcodeIter<'a> {
+    cursor: Cursor<&'a Vec<u8>>,
+    bitcode: &'a Bitcode,
+}
+
+impl<'a> Iterator for BitcodeIter<'a> {
+    type Item = Statement;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.bitcode.decode_statement(&mut self.cursor).ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    quickcheck! {
+        fn round_trip(v: Vec<Statement>) -> bool {
+            debug!("in: {:?}",v);
+            match Bitcode::new(v.clone()) {
+                Ok(bt) => {
+                    debug!("{:?}",bt);
+                    let w = bt.iter().collect::<Vec<_>>();
+                    debug!("decoded: {:?}",w);
+                    v == w
+                }
+                Err(s) => {
+                    debug!("err: {}",s);
+                    false
+                }
+            }
+        }
+    }
+}

--- a/core/src/neo/bitcode.rs
+++ b/core/src/neo/bitcode.rs
@@ -190,6 +190,13 @@ impl Bitcode {
         Ok(Bitcode{ data: buf.into_inner(), strings: strtbl })
     }
 
+    pub fn with_capacity(bytes: usize, strs: usize) -> Bitcode {
+        Bitcode{
+            strings: Vec::with_capacity(strs),
+            data: Vec::with_capacity(bytes),
+        }
+    }
+
     fn encode_statement<W: Write>(stmt: Statement, data: &mut W, strtbl: &mut Vec<Str>) -> Result<()> {
         use neo::il::Operation::*;
         use neo::value::Value::*;
@@ -1117,6 +1124,10 @@ impl Bitcode {
 
     pub fn num_bytes(&self) -> usize {
         self.data.len()
+    }
+
+    pub fn num_strings(&self) -> usize {
+        self.strings.len()
     }
 }
 

--- a/core/src/neo/function.rs
+++ b/core/src/neo/function.rs
@@ -1,0 +1,1098 @@
+use std::ops::Range;
+use std::cell::RefCell;
+use uuid::Uuid;
+use petgraph::Graph;
+use petgraph::graph::NodeIndex;
+use petgraph::visit::{Walker,DfsPostOrder};
+use {Architecture,Guard,Region,MnemonicFormatToken,Rvalue,Lvalue};
+use neo::{Str,Result,Statement,Bitcode,Value,BitcodeIter,Constant,Operation,Variable,Endianess,CallTarget};
+
+mod core {
+    pub use ::mnemonic::Mnemonic;
+    pub use ::il::Operation;
+    pub use ::il::Statement;
+    pub use ::il::Endianess;
+    pub use ::program::CallTarget;
+}
+
+use std::collections::{HashSet,HashMap};
+use std::fmt::Debug;
+
+#[derive(Debug)]
+pub struct BasicBlock {
+    mnemonics: Range<MnemonicIndex>,
+    node: NodeIndex,
+    area: Range<u64>,
+}
+
+#[derive(Debug)]
+pub struct Mnemonic {
+    area: Range<u64>,
+    opcode: Str,
+    operands: Vec<Value>,
+    format_string: Vec<MnemonicFormatToken>,
+    statements: Range<usize>,
+}
+
+#[derive(Clone,Copy,Debug)]
+pub struct BasicBlockIndex {
+    index: usize
+}
+
+impl BasicBlockIndex {
+    pub fn new(i: usize) -> BasicBlockIndex { BasicBlockIndex{ index: i } }
+    pub fn index(&self) -> usize { self.index }
+}
+
+#[derive(Clone,Copy,Debug)]
+pub struct MnemonicIndex {
+    index: usize
+}
+
+impl MnemonicIndex {
+    pub fn new(i: usize) -> MnemonicIndex { MnemonicIndex{ index: i } }
+    pub fn index(&self) -> usize { self.index }
+}
+
+#[derive(Debug)]
+enum CfgNode {
+    BasicBlock(BasicBlockIndex),
+    Value(Value),
+}
+
+#[derive(Debug)]
+pub struct Function {
+    pub name: Str,
+    uuid: Uuid,
+    // sort by rev. post order
+    bitcode: Bitcode,
+    // sort by rev. post order
+    basic_blocks: Vec<BasicBlock>,
+    // sort by area.start
+    mnemonics: Vec<Mnemonic>,
+    // sorted by bb idx
+    cflow_graph: Graph<CfgNode,Guard>,
+}
+
+impl Function {
+	// disassembly
+    pub fn new<A: Architecture>(init: A::Configuration, start: u64, region: &Region, name: Option<Str>) -> Result<Function>
+        where A: Debug, A::Configuration: Debug {
+        let (mnemonics, by_source, by_destination) = disassemble::<A>(init,start,region)?;
+        assemble_function(start, mnemonics, by_source, by_destination)
+    }
+
+    pub fn extend(&mut self,region: &Region) -> Result<bool> { unimplemented!() }
+
+    // getter
+    pub fn entry_point(&self) -> BasicBlockIndex { unimplemented!() }
+    pub fn mnemonics(&self) -> &[Mnemonic] { unimplemented!() }
+    pub fn mnemonics_for_basic_block(&self, idx: BasicBlockIndex) -> &[Mnemonic] { unimplemented!() }
+    pub fn basic_blocks(&self) -> &[BasicBlock] { unimplemented!() }
+    pub fn uuid(&self) -> &Uuid { unimplemented!() }
+
+    // iters
+    pub fn statements(&self) -> BitcodeIter { unimplemented!() }
+    pub fn statements_for_block(&self, idx: BasicBlockIndex) -> BitcodeIter { unimplemented!() }
+    pub fn statements_for_mnemonic(&self, idx: MnemonicIndex) -> BitcodeIter { unimplemented!() }
+
+    // aux
+    pub fn first_address(&self) -> u64 { unimplemented!() }
+    pub fn has_unresolved_jumps(&self) -> bool { unimplemented!() }
+    pub fn resolve_jump(&self,_: Value,_: u64) -> Result<bool> { unimplemented!() }
+
+    // insert
+    pub fn insert_statement(stmt: Statement, mnemonic: MnemonicIndex,
+        basic_block: BasicBlockIndex, index: usize) -> Result<()> { unimplemented!() }
+    pub fn insert_pseudo_mnemonic(stmts: &[Statement], opcode: Str,
+        basic_block: BasicBlock, index: usize) -> Result<()> { unimplemented!() }
+}
+
+fn disassemble<A: Architecture>(init: A::Configuration, start: u64, region: &Region)
+-> Result<(Vec<core::Mnemonic>,HashMap<u64,Vec<(Value,Guard)>>,HashMap<u64,Vec<(Value,Guard)>>)>
+where A: Debug, A::Configuration: Debug {
+    let mut todo = HashSet::<u64>::new();
+    let mut mnemonics = Vec::<core::Mnemonic>::new();
+    let mut by_source = HashMap::<u64,Vec<(Value,Guard)>>::new();
+    let mut by_destination = HashMap::<u64,Vec<(Value,Guard)>>::new();
+
+    todo.insert(start);
+
+    while let Some(addr) = todo.iter().next().cloned() {
+        assert!(todo.remove(&addr));
+
+        match mnemonics.binary_search_by_key(&addr,|x| x.area.start) {
+            // Already disassembled here
+            Ok(pos) => {
+                let mne = &mnemonics[pos];
+
+                if mne.area.start != addr {
+                    error!("{:#x}: Jump inside mnemonic {} at {:#x}",addr,mne.opcode,mne.area.start);
+                }
+            }
+            // New mnemonic
+            Err(pos) => {
+                let maybe_match = A::decode(region,addr,&init);
+
+                match maybe_match {
+                    Ok(match_st) => {
+                        // Matched mnemonics
+                        if match_st.mnemonics.is_empty() {
+                            error!("{:#x}: Unrecognized instruction",addr);
+                        } else {
+                            for mne in match_st.mnemonics {
+                                debug!(
+                                    "{:x}: {} ({:?})",
+                                    mne.area.start,
+                                    mne.opcode,
+                                    match_st.tokens
+                                    );
+                                mnemonics.insert(pos,mne);
+                            }
+                        }
+
+                        // New control transfers
+                        for (origin, tgt, gu) in match_st.jumps {
+                            debug!("jump to {:?}", tgt);
+                            match tgt {
+                                Rvalue::Constant { value, size } => {
+                                    by_source.entry(origin).or_insert(Vec::new()).push((Value::val(value,size)?, gu.clone()));
+                                    by_destination.entry(value).or_insert(Vec::new()).push((Value::val(origin,64)?, gu));
+                                    todo.insert(value);
+                                }
+                                Rvalue::Variable{ name, size,.. } => {
+                                    by_source.entry(origin).or_insert(Vec::new()).push((Value::var(name,size,None)?, gu));
+                                }
+                                Rvalue::Undefined => {
+                                    by_source.entry(origin).or_insert(Vec::new()).push((Value::undef(), gu));
+                                }
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        error!("{:#x} Failed to disassemble: {}",addr, e);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok((mnemonics,by_source,by_destination))
+}
+
+fn assemble_function(entry: u64, mut mnemonics: Vec<core::Mnemonic>,
+                     by_source: HashMap<u64,Vec<(Value,Guard)>>,
+                     by_destination: HashMap<u64,Vec<(Value,Guard)>>) -> Result<Function> {
+
+    let mut basic_blocks = Vec::<BasicBlock>::new();
+    let mut idx = 0;
+
+    mnemonics.sort_by_key(|x| x.area.start);
+
+    // Split mnemonics into basic blocks
+    while idx < mnemonics.len() {
+        if mnemonics.len() - idx > 1 {
+            let next_bb = mnemonics
+                .as_slice()[idx..].windows(2)
+                .position(|x| is_basic_block_boundary(&x[0],&x[1],entry,&by_source,&by_destination))
+                .map(|x| x + 1 + idx)
+                .unwrap_or(mnemonics.len());
+            let bb = BasicBlock{
+                mnemonics: MnemonicIndex::new(idx)..MnemonicIndex::new(next_bb),
+                area: mnemonics[idx].area.start..mnemonics[next_bb - 1].area.end,
+                node: NodeIndex::new(0),
+            };
+
+            basic_blocks.push(bb);
+            idx = next_bb;
+        } else {
+            let bb = BasicBlock{
+                mnemonics: MnemonicIndex::new(idx)..MnemonicIndex::new(mnemonics.len()),
+                area: mnemonics[idx].area.start..mnemonics[idx].area.end,
+                node: NodeIndex::new(0),
+            };
+
+            basic_blocks.push(bb);
+            break;
+        }
+    }
+
+    // Build control flow graph
+    let mut cfg = Graph::<CfgNode,Guard>::with_capacity(basic_blocks.len(),3*basic_blocks.len() / 2);
+
+    for (i,bb) in basic_blocks.iter_mut().enumerate() {
+        bb.node = cfg.add_node(CfgNode::BasicBlock(BasicBlockIndex::new(i)));
+    }
+
+    for (i,bb) in basic_blocks.iter().enumerate() {
+        if let Some(ct) = by_source.get(&bb.area.start) {
+            for &(ref val,ref guard) in ct.iter() {
+                match val {
+                    &Value::Constant(Constant{ value,.. }) if bb.area.start <= value && bb.area.end > value => {}
+                    &Value::Constant(Constant{ value,.. }) => {
+                        if let Ok(pos) = basic_blocks.binary_search_by_key(&value,|bb| bb.area.start) {
+                            cfg.update_edge(bb.node,basic_blocks[pos].node,guard.clone());
+                        } else {
+                            let n = cfg.add_node(CfgNode::Value(val.clone()));
+                            cfg.update_edge(bb.node,n,guard.clone());
+                        }
+                    }
+                    val => {
+                        let n = cfg.add_node(CfgNode::Value(val.clone()));
+                        cfg.update_edge(bb.node,n,guard.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    let entry_idx = basic_blocks
+        .iter().position(|x| x.area.start == entry)
+        .ok_or("Internal error: no basic block at the entry point")?;
+
+    // Generate bitcode
+    let postorder = DfsPostOrder::new(&cfg,basic_blocks[entry_idx].node).iter(&cfg).collect::<Vec<_>>();
+    let mut bitcode = Bitcode::default();
+    let mut statement_ranges = vec![0..0; mnemonics.len()];
+
+    for &n in postorder.iter() {
+        if let Some(&CfgNode::BasicBlock(idx)) = cfg.node_weight(n) {
+            let bb = &basic_blocks[idx.index()];
+            let sl = bb.mnemonics.start.index()..bb.mnemonics.end.index();
+            for (off,mne) in mnemonics.as_slice()[sl].iter().enumerate() {
+                let rgn = bitcode.append(mne.instructions.iter().map(|s| to_statement(s)))?;
+
+                statement_ranges[bb.mnemonics.start.index() + off] = rgn;
+            }
+        }
+    }
+
+    let func = Function{
+        name: "".into(),
+        uuid: Uuid::new_v4(),
+        bitcode: bitcode,
+        basic_blocks: basic_blocks,
+        mnemonics: mnemonics.into_iter().enumerate().map(|(idx,mne)| {
+            Mnemonic{
+                area: mne.area.start..mne.area.end,
+                opcode: mne.opcode.into(),
+                operands: mne.operands.iter().map(|x| x.clone().into()).collect(),
+                format_string: mne.format_string,
+                statements: statement_ranges[idx].clone(),
+            }
+        }).collect(),
+        cflow_graph: cfg,
+    };
+
+    Ok(func)
+}
+
+fn is_basic_block_boundary(a: &core::Mnemonic, b: &core::Mnemonic, entry: u64,
+                           by_source: &HashMap<u64,Vec<(Value,Guard)>>,
+                           by_destination: &HashMap<u64,Vec<(Value,Guard)>>) -> bool {
+    true
+}
+
+fn to_statement(stmt: &core::Statement) -> Statement {
+    match stmt {
+        &core::Statement{ op: core::Operation::Add(ref a,ref b), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+            Statement::Expression{ op: Operation::Add(a.clone().into(),b.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
+        }
+        &core::Statement{ op: core::Operation::Subtract(ref a,ref b), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+            Statement::Expression{ op: Operation::Subtract(a.clone().into(),b.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
+        }
+        &core::Statement{ op: core::Operation::Multiply(ref a,ref b), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+            Statement::Expression{ op: Operation::Multiply(a.clone().into(),b.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
+        }
+        &core::Statement{ op: core::Operation::DivideUnsigned(ref a,ref b), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+            Statement::Expression{ op: Operation::DivideUnsigned(a.clone().into(),b.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
+        }
+        &core::Statement{ op: core::Operation::DivideSigned(ref a,ref b), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+            Statement::Expression{ op: Operation::DivideSigned(a.clone().into(),b.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
+        }
+        &core::Statement{ op: core::Operation::Modulo(ref a,ref b), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+            Statement::Expression{ op: Operation::Modulo(a.clone().into(),b.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
+        }
+        &core::Statement{ op: core::Operation::ShiftLeft(ref a,ref b), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+            Statement::Expression{ op: Operation::ShiftLeft(a.clone().into(),b.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
+        }
+        &core::Statement{ op: core::Operation::ShiftRightUnsigned(ref a,ref b), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+            Statement::Expression{ op: Operation::ShiftRightUnsigned(a.clone().into(),b.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
+        }
+        &core::Statement{ op: core::Operation::ShiftRightSigned(ref a,ref b), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+            Statement::Expression{ op: Operation::ShiftRightSigned(a.clone().into(),b.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
+        }
+        &core::Statement{ op: core::Operation::InclusiveOr(ref a,ref b), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+            Statement::Expression{ op: Operation::InclusiveOr(a.clone().into(),b.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
+        }
+        &core::Statement{ op: core::Operation::And(ref a,ref b), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+            Statement::Expression{ op: Operation::And(a.clone().into(),b.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
+        }
+        &core::Statement{ op: core::Operation::ExclusiveOr(ref a,ref b), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+            Statement::Expression{ op: Operation::ExclusiveOr(a.clone().into(),b.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
+        }
+        &core::Statement{ op: core::Operation::Equal(ref a,ref b), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+            Statement::Expression{ op: Operation::Equal(a.clone().into(),b.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
+        }
+        &core::Statement{ op: core::Operation::LessOrEqualUnsigned(ref a,ref b), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+            Statement::Expression{ op: Operation::LessOrEqualUnsigned(a.clone().into(),b.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
+        }
+        &core::Statement{ op: core::Operation::LessOrEqualSigned(ref a,ref b), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+            Statement::Expression{ op: Operation::LessOrEqualSigned(a.clone().into(),b.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
+        }
+        &core::Statement{ op: core::Operation::LessUnsigned(ref a,ref b), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+            Statement::Expression{ op: Operation::LessUnsigned(a.clone().into(),b.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
+        }
+        &core::Statement{ op: core::Operation::LessSigned(ref a,ref b), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+            Statement::Expression{ op: Operation::LessSigned(a.clone().into(),b.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
+        }
+        &core::Statement{ op: core::Operation::SignExtend(sz,ref a), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+            Statement::Expression{ op: Operation::SignExtend(sz,a.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
+        }
+        &core::Statement{ op: core::Operation::ZeroExtend(sz,ref a), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+            Statement::Expression{ op: Operation::ZeroExtend(sz,a.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
+        }
+        &core::Statement{ op: core::Operation::Move(ref a), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+            Statement::Expression{ op: Operation::Move(a.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
+        }
+       &core::Statement{ op: core::Operation::Initialize(ref s,ref a), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+            Statement::Expression{ op: Operation::Initialize(s.clone(),a.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
+        }
+       &core::Statement{ op: core::Operation::Select(sz,ref a,ref b), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+            Statement::Expression{ op: Operation::Select(sz,a.clone().into(),b.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
+        }
+       &core::Statement{ op: core::Operation::Load(ref s,core::Endianess::Little,b,ref a), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+            Statement::Expression{ op: Operation::Load(s.clone(),Endianess::Little,b,a.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
+        }
+       &core::Statement{ op: core::Operation::Load(ref s,core::Endianess::Big,b,ref a), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+            Statement::Expression{ op: Operation::Load(s.clone(),Endianess::Big,b,a.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
+        }
+       &core::Statement{ op: core::Operation::Store(ref s,core::Endianess::Little,by,ref a,ref b),.. } => {
+            Statement::Store{
+                region: s.clone(),
+                endianess: Endianess::Little,
+                bytes: by,
+                address: a.clone().into(),
+                value: b.clone().into(),
+            }
+        }
+       &core::Statement{ op: core::Operation::Store(ref s,core::Endianess::Big,by,ref a,ref b),.. } => {
+            Statement::Store{
+                region: s.clone(),
+                endianess: Endianess::Big,
+                bytes: by,
+                address: a.clone().into(),
+                value: b.clone().into(),
+            }
+        }
+
+    //Phi(Vec<V>),
+       &core::Statement{ op: core::Operation::Call(ref a),.. } => {
+           Statement::IndirectCall{
+               target: a.clone().into(),
+           }
+       }
+
+
+        _ => unimplemented!("{:?}",stmt)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use {Architecture, BasicBlock, Bound, Disassembler, Guard, Match, Mnemonic, OpaqueLayer, Region, Result, Rvalue, State};
+    use panopticon_graph_algos::{AdjacencyMatrixGraphTrait, EdgeListGraphTrait, VertexListGraphTrait};
+    use panopticon_graph_algos::{GraphTrait, MutableGraphTrait};
+    use std::borrow::Cow;
+    use std::sync::Arc;
+
+    #[derive(Clone,Debug)]
+    enum TestArchShort {}
+    impl Architecture for TestArchShort {
+        type Token = u8;
+        type Configuration = Arc<Disassembler<TestArchShort>>;
+
+        fn prepare(_: &Region, _: &Self::Configuration) -> Result<Vec<(&'static str, u64, &'static str)>> {
+            unimplemented!()
+        }
+
+        fn decode(reg: &Region, addr: u64, cfg: &Self::Configuration) -> Result<Match<Self>> {
+            if let Some(s) = cfg.next_match(&mut reg.iter().seek(addr), addr, cfg.clone()) {
+                Ok(s.into())
+            } else {
+                Err("No match".into())
+            }
+        }
+    }
+
+    #[derive(Clone,Debug)]
+    enum TestArchWide {}
+    impl Architecture for TestArchWide {
+        type Token = u16;
+        type Configuration = Arc<Disassembler<TestArchWide>>;
+
+        fn prepare(_: &Region, _: &Self::Configuration) -> Result<Vec<(&'static str, u64, &'static str)>> {
+            unimplemented!()
+        }
+
+        fn decode(reg: &Region, addr: u64, cfg: &Self::Configuration) -> Result<Match<Self>> {
+            if let Some(s) = cfg.next_match(&mut reg.iter().seek(addr), addr, cfg.clone()) {
+                Ok(s.into())
+            } else {
+                Err("No match".into())
+            }
+        }
+    }
+/*
+    #[test]
+    fn new() {
+        let f = Function::new("test".to_string(), "ram".to_string());
+
+        assert_eq!(f.name, "test".to_string());
+        assert_eq!(f.cflow_graph.num_vertices(), 0);
+        assert_eq!(f.cflow_graph.num_edges(), 0);
+        assert_eq!(f.entry_point, None);
+    }
+
+    #[test]
+    fn index_resolved() {
+        let mut cfg = ControlFlowGraph::new();
+
+        let bb0 = BasicBlock::from_vec(
+            vec![
+                Mnemonic::dummy(0..1),
+                Mnemonic::dummy(1..2),
+                Mnemonic::dummy(2..5),
+                Mnemonic::dummy(5..6),
+            ]
+        );
+        let bb1 = BasicBlock::from_vec(
+            vec![
+                Mnemonic::dummy(10..11),
+                Mnemonic::dummy(11..12),
+                Mnemonic::dummy(12..15),
+                Mnemonic::dummy(15..16),
+            ]
+        );
+        let bb2 = BasicBlock::from_vec(vec![Mnemonic::dummy(6..10)]);
+
+        let vx0 = cfg.add_vertex(ControlFlowTarget::Resolved(bb0));
+        let vx1 = cfg.add_vertex(ControlFlowTarget::Resolved(bb1));
+        let vx2 = cfg.add_vertex(ControlFlowTarget::Resolved(bb2));
+
+        cfg.add_edge(Guard::always(), vx0, vx1);
+        cfg.add_edge(Guard::always(), vx1, vx1);
+        cfg.add_edge(Guard::always(), vx1, vx2);
+        cfg.add_edge(Guard::always(), vx2, vx0);
+
+        let (mnes, src, dest) = Function::index_cflow_graph(cfg, None);
+
+        assert_eq!(mnes.len(), 9);
+        assert_eq!(src.values().fold(0, |acc, x| acc + x.len()), 10);
+        assert_eq!(dest.values().fold(0, |acc, x| acc + x.len()), 10);
+
+        let cfg_re = Function::assemble_cflow_graph(mnes, src, dest, 0);
+
+        assert_eq!(cfg_re.num_vertices(), 3);
+        assert_eq!(cfg_re.num_edges(), 4);
+
+        for vx in cfg_re.vertices() {
+            if let Some(&ControlFlowTarget::Resolved(ref bb)) = cfg_re.vertex_label(vx) {
+                assert!((bb.area.start == 0 && bb.area.end == 6) || (bb.area.start == 10 && bb.area.end == 16) || (bb.area.start == 6 && bb.area.end == 10));
+            } else {
+                unreachable!();
+            }
+        }
+
+        for e in cfg_re.edges() {
+            if let Some(&ControlFlowTarget::Resolved(ref from)) = cfg_re.vertex_label(cfg_re.source(e)) {
+                if let Some(&ControlFlowTarget::Resolved(ref to)) = cfg_re.vertex_label(cfg_re.target(e)) {
+                    assert!(
+                        (from.area.start == 0 && to.area.start == 10) || (from.area.start == 10 && to.area.start == 10) ||
+                        (from.area.start == 10 && to.area.start == 6) || (from.area.start == 6 && to.area.start == 0)
+                    );
+                } else {
+                    unreachable!();
+                }
+            } else {
+                unreachable!();
+            }
+        }
+    }
+
+    #[test]
+    fn index_unresolved() {
+        let mut cfg = ControlFlowGraph::new();
+
+        let bb0 = BasicBlock::from_vec(vec![Mnemonic::dummy(0..1)]);
+        let bb1 = BasicBlock::from_vec(vec![Mnemonic::dummy(10..11)]);
+
+        let vx0 = cfg.add_vertex(ControlFlowTarget::Resolved(bb0));
+        let vx1 = cfg.add_vertex(ControlFlowTarget::Resolved(bb1));
+        let vx2 = cfg.add_vertex(ControlFlowTarget::Unresolved(Rvalue::new_u32(42)));
+        let vx3 = cfg.add_vertex(ControlFlowTarget::Unresolved(Rvalue::new_u32(23)));
+        let vx4 = cfg.add_vertex(
+            ControlFlowTarget::Unresolved(
+                Rvalue::Variable {
+                    name: Cow::Borrowed("a"),
+                    size: 8,
+                    offset: 0,
+                    subscript: None,
+                }
+            )
+        );
+
+        cfg.add_edge(Guard::always(), vx0, vx1);
+        cfg.add_edge(Guard::always(), vx2, vx1);
+        cfg.add_edge(Guard::always(), vx3, vx0);
+        cfg.add_edge(Guard::always(), vx4, vx3);
+
+        let (mnes, src, dest) = Function::index_cflow_graph(cfg, None);
+
+        assert_eq!(mnes.len(), 2);
+        assert_eq!(src.values().fold(0, |acc, x| acc + x.len()), 3);
+        assert_eq!(dest.values().fold(0, |acc, x| acc + x.len()), 3);
+
+        let cfg_re = Function::assemble_cflow_graph(mnes, src, dest, 0);
+
+        assert_eq!(cfg_re.num_vertices(), 4);
+        assert_eq!(cfg_re.num_edges(), 3);
+
+        for vx in cfg_re.vertices() {
+            match cfg_re.vertex_label(vx) {
+                Some(&ControlFlowTarget::Resolved(ref bb)) => {
+                    assert!((bb.area.start == 0 && bb.area.end == 1) || (bb.area.start == 10 && bb.area.end == 11));
+                }
+                Some(&ControlFlowTarget::Unresolved(Rvalue::Constant { value: ref c, size: 64 })) => {
+                    assert!(*c == 42 || *c == 23);
+                }
+                _ => {
+                    unreachable!();
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn add_single() {
+        let main = new_disassembler!(TestArchShort =>
+            [ 0 ] = |st: &mut State<TestArchShort>| {
+                st.mnemonic(1,"A","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                true
+            }
+		);
+        let data = OpaqueLayer::wrap(vec![0]);
+        let reg = Region::new("".to_string(), data);
+        let func = Function::disassemble::<TestArchShort>(None, main, &reg, 0);
+
+        assert_eq!(func.cflow_graph.num_vertices(), 1);
+        assert_eq!(func.cflow_graph.num_edges(), 0);
+
+        if let Some(vx) = func.cflow_graph.vertices().next() {
+            if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cflow_graph.vertex_label(vx) {
+                assert_eq!(bb.mnemonics.len(), 1);
+                assert_eq!(bb.mnemonics[0].opcode, "A".to_string());
+                assert_eq!(bb.mnemonics[0].area, Bound::new(0, 1));
+                assert_eq!(bb.area, Bound::new(0, 1));
+            } else {
+                unreachable!();
+            }
+        } else {
+            unreachable!();
+        }
+
+        assert_eq!(func.entry_point, func.cflow_graph.vertices().next());
+        assert_eq!(func.name, "func_0".to_string());
+    }
+
+    #[test]
+    fn continuous() {
+        let main = new_disassembler!(TestArchShort =>
+            [ 0 ] = |st: &mut State<TestArchShort>| {
+                let next = st.address;
+                st.mnemonic(1,"test0","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u64(next + 1),Guard::always()).unwrap();
+                true
+            },
+            [ 1 ] = |st: &mut State<TestArchShort>| {
+                let next = st.address;
+                st.mnemonic(1,"test1","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u64(next + 1),Guard::always()).unwrap();
+                true
+            },
+            [ 2 ] = |st: &mut State<TestArchShort>| {
+                let next = st.address;
+                st.mnemonic(1,"test2","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u64(next + 1),Guard::always()).unwrap();
+                true
+            },
+            [ 3 ] = |st: &mut State<TestArchShort>| {
+                let next = st.address;
+                st.mnemonic(1,"test3","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u64(next + 1),Guard::always()).unwrap();
+                true
+            },
+            [ 4 ] = |st: &mut State<TestArchShort>| {
+                let next = st.address;
+                st.mnemonic(1,"test4","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u64(next + 1),Guard::always()).unwrap();
+                true
+            },
+            [ 5 ] = |st: &mut State<TestArchShort>| {
+                let next = st.address;
+                st.mnemonic(1,"test5","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u64(next + 1),Guard::always()).unwrap();
+                true
+            }
+        );
+
+        let data = OpaqueLayer::wrap(vec![0, 1, 2, 3, 4, 5]);
+        let reg = Region::new("".to_string(), data);
+        let func = Function::disassemble::<TestArchShort>(None, main, &reg, 0);
+
+        assert_eq!(func.cflow_graph.num_vertices(), 2);
+        assert_eq!(func.cflow_graph.num_edges(), 1);
+
+        let mut bb_vx = None;
+        let mut ures_vx = None;
+
+        for vx in func.cflow_graph.vertices() {
+            if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cflow_graph.vertex_label(vx) {
+                assert_eq!(bb.mnemonics.len(), 6);
+                assert_eq!(bb.mnemonics[0].opcode, "test0".to_string());
+                assert_eq!(bb.mnemonics[0].area, Bound::new(0, 1));
+                assert_eq!(bb.mnemonics[1].opcode, "test1".to_string());
+                assert_eq!(bb.mnemonics[1].area, Bound::new(1, 2));
+                assert_eq!(bb.mnemonics[2].opcode, "test2".to_string());
+                assert_eq!(bb.mnemonics[2].area, Bound::new(2, 3));
+                assert_eq!(bb.mnemonics[3].opcode, "test3".to_string());
+                assert_eq!(bb.mnemonics[3].area, Bound::new(3, 4));
+                assert_eq!(bb.mnemonics[4].opcode, "test4".to_string());
+                assert_eq!(bb.mnemonics[4].area, Bound::new(4, 5));
+                assert_eq!(bb.mnemonics[5].opcode, "test5".to_string());
+                assert_eq!(bb.mnemonics[5].area, Bound::new(5, 6));
+                assert_eq!(bb.area, Bound::new(0, 6));
+                bb_vx = Some(vx);
+            } else if let Some(&ControlFlowTarget::Failed(c, _)) = func.cflow_graph.vertex_label(vx) {
+                assert_eq!(c, 6);
+                ures_vx = Some(vx);
+            } else {
+                unreachable!();
+            }
+        }
+
+        assert!(ures_vx.is_some() && bb_vx.is_some());
+        assert_eq!(func.entry_point, bb_vx);
+        assert_eq!(func.name, "func_0".to_string());
+        assert!(func.cflow_graph.edge(bb_vx.unwrap(), ures_vx.unwrap()).is_some());
+    }
+
+    #[test]
+    fn branch() {
+        let main = new_disassembler!(TestArchShort =>
+            [ 0 ] = |st: &mut State<TestArchShort>| {
+                st.mnemonic(1,"test0","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(1),Guard::always()).unwrap();
+                st.jump(Rvalue::new_u32(2),Guard::always()).unwrap();
+                true
+            },
+            [ 1 ] = |st: &mut State<TestArchShort>| {
+                st.mnemonic(1,"test1","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(3),Guard::always()).unwrap();
+                true
+            },
+            [ 2 ] = |st: &mut State<TestArchShort>| {
+                st.mnemonic(1,"test2","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(1),Guard::always()).unwrap();
+                true
+            }
+        );
+
+        let data = OpaqueLayer::wrap(vec![0, 1, 2]);
+        let reg = Region::new("".to_string(), data);
+        let func = Function::disassemble::<TestArchShort>(None, main, &reg, 0);
+
+        assert_eq!(func.cflow_graph.num_vertices(), 4);
+        assert_eq!(func.cflow_graph.num_edges(), 4);
+
+        let mut bb0_vx = None;
+        let mut bb1_vx = None;
+        let mut bb2_vx = None;
+        let mut ures_vx = None;
+
+        for vx in func.cflow_graph.vertices() {
+            if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cflow_graph.vertex_label(vx) {
+                if bb.area.start == 0 {
+                    assert_eq!(bb.mnemonics.len(), 1);
+                    assert_eq!(bb.mnemonics[0].opcode, "test0".to_string());
+                    assert_eq!(bb.mnemonics[0].area, Bound::new(0, 1));
+                    assert_eq!(bb.area, Bound::new(0, 1));
+                    bb0_vx = Some(vx);
+                } else if bb.area.start == 1 {
+                    assert_eq!(bb.mnemonics.len(), 1);
+                    assert_eq!(bb.mnemonics[0].opcode, "test1".to_string());
+                    assert_eq!(bb.mnemonics[0].area, Bound::new(1, 2));
+                    assert_eq!(bb.area, Bound::new(1, 2));
+                    bb1_vx = Some(vx);
+                } else if bb.area.start == 2 {
+                    assert_eq!(bb.mnemonics.len(), 1);
+                    assert_eq!(bb.mnemonics[0].opcode, "test2".to_string());
+                    assert_eq!(bb.mnemonics[0].area, Bound::new(2, 3));
+                    assert_eq!(bb.area, Bound::new(2, 3));
+                    bb2_vx = Some(vx);
+                } else {
+                    unreachable!();
+                }
+            } else if let Some(&ControlFlowTarget::Failed(c, _)) = func.cflow_graph.vertex_label(vx) {
+                assert_eq!(c, 3);
+                ures_vx = Some(vx);
+            } else {
+                unreachable!();
+            }
+        }
+
+        assert!(ures_vx.is_some() && bb0_vx.is_some() && bb1_vx.is_some() && bb2_vx.is_some());
+        assert_eq!(func.entry_point, bb0_vx);
+        assert_eq!(func.name, "func_0".to_string());
+        assert!(func.cflow_graph.edge(bb0_vx.unwrap(), bb1_vx.unwrap()).is_some());
+        assert!(func.cflow_graph.edge(bb0_vx.unwrap(), bb2_vx.unwrap()).is_some());
+        assert!(func.cflow_graph.edge(bb1_vx.unwrap(), ures_vx.unwrap()).is_some());
+        assert!(func.cflow_graph.edge(bb2_vx.unwrap(), bb1_vx.unwrap()).is_some());
+    }
+
+    #[test]
+    fn function_loop() {
+        let main = new_disassembler!(TestArchShort =>
+            [ 0 ] = |st: &mut State<TestArchShort>| {
+                st.mnemonic(1,"test0","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(1),Guard::always()).unwrap();
+                true
+            },
+            [ 1 ] = |st: &mut State<TestArchShort>| {
+                st.mnemonic(1,"test1","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(2),Guard::always()).unwrap();
+                true
+            },
+            [ 2 ] = |st: &mut State<TestArchShort>| {
+                st.mnemonic(1,"test2","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(0),Guard::always()).unwrap();
+                true
+            }
+        );
+
+        let data = OpaqueLayer::wrap(vec![0, 1, 2]);
+        let reg = Region::new("".to_string(), data);
+        let func = Function::disassemble::<TestArchShort>(None, main, &reg, 0);
+
+        assert_eq!(func.cflow_graph.num_vertices(), 1);
+        assert_eq!(func.cflow_graph.num_edges(), 1);
+
+        let vx = func.cflow_graph.vertices().next().unwrap();
+        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cflow_graph.vertex_label(vx) {
+            if bb.area.start == 0 {
+                assert_eq!(bb.mnemonics.len(), 3);
+                assert_eq!(bb.mnemonics[0].opcode, "test0".to_string());
+                assert_eq!(bb.mnemonics[0].area, Bound::new(0, 1));
+                assert_eq!(bb.mnemonics[1].opcode, "test1".to_string());
+                assert_eq!(bb.mnemonics[1].area, Bound::new(1, 2));
+                assert_eq!(bb.mnemonics[2].opcode, "test2".to_string());
+                assert_eq!(bb.mnemonics[2].area, Bound::new(2, 3));
+                assert_eq!(bb.area, Bound::new(0, 3));
+            } else {
+                unreachable!();
+            }
+        }
+
+        assert_eq!(func.name, "func_0".to_string());
+        assert_eq!(func.entry_point, Some(vx));
+        assert!(func.cflow_graph.edge(vx, vx).is_some());
+    }
+
+    #[test]
+    fn empty() {
+        let main = new_disassembler!(TestArchShort =>
+            [ 0 ] = |st: &mut State<TestArchShort>| {
+                st.mnemonic(1,"test0","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(1),Guard::always()).unwrap();
+                true
+            },
+            [ 1 ] = |st: &mut State<TestArchShort>| {
+                st.mnemonic(1,"test1","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(2),Guard::always()).unwrap();
+                true
+            },
+            [ 2 ] = |st: &mut State<TestArchShort>| {
+                st.mnemonic(1,"test2","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(0),Guard::always()).unwrap();
+                true
+            }
+        );
+
+        let data = OpaqueLayer::wrap(vec![]);
+        let reg = Region::new("".to_string(), data);
+        let func = Function::disassemble::<TestArchShort>(None, main, &reg, 0);
+
+        assert_eq!(func.cflow_graph.num_vertices(), 1);
+        assert_eq!(func.cflow_graph.num_edges(), 0);
+        assert_eq!(func.name, "func_0".to_string());
+        assert_eq!(func.entry_point, None);
+
+        let vx = func.cflow_graph.vertices().next().unwrap();
+        if let Some(&ControlFlowTarget::Failed(v, _)) = func.cflow_graph.vertex_label(vx) {
+            assert_eq!(v, 0);
+        }
+    }
+
+    #[test]
+    fn entry_split() {
+        let bb = BasicBlock::from_vec(vec![Mnemonic::dummy(0..1), Mnemonic::dummy(1..2)]);
+        let mut fun = Function::new("test_func".to_string(), "ram".to_string());
+        let vx0 = fun.cflow_graph.add_vertex(ControlFlowTarget::Resolved(bb));
+        let vx1 = fun.cflow_graph.add_vertex(ControlFlowTarget::Unresolved(Rvalue::new_u32(2)));
+
+        fun.entry_point = Some(vx0);
+        fun.cflow_graph.add_edge(Guard::always(), vx0, vx1);
+
+        let main = new_disassembler!(TestArchShort =>
+            [ 0 ] = |st: &mut State<TestArchShort>| {
+                st.mnemonic(1,"test0","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(1),Guard::always()).unwrap();
+                true
+            },
+            [ 1 ] = |st: &mut State<TestArchShort>| {
+                st.mnemonic(1,"test1","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(2),Guard::always()).unwrap();
+                true
+            },
+            [ 2 ] = |st: &mut State<TestArchShort>| {
+                st.mnemonic(1,"test2","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(1),Guard::always()).unwrap();
+                true
+            }
+        );
+
+        let data = OpaqueLayer::wrap(vec![0, 1, 2]);
+        let reg = Region::new("".to_string(), data);
+        let func = Function::disassemble::<TestArchShort>(Some(fun), main, &reg, 2);
+
+        assert_eq!(func.cflow_graph.num_vertices(), 3);
+        assert_eq!(func.cflow_graph.num_edges(), 3);
+        assert_eq!(func.name, "test_func".to_string());
+
+        let mut bb0_vx = None;
+        let mut bb1_vx = None;
+        let mut bb2_vx = None;
+
+        for vx in func.cflow_graph.vertices() {
+            if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cflow_graph.vertex_label(vx) {
+                if bb.area.start == 0 {
+                    assert_eq!(bb.mnemonics.len(), 1);
+                    assert_eq!(bb.mnemonics[0].opcode, "dummy".to_string());
+                    assert_eq!(bb.mnemonics[0].area, Bound::new(0, 1));
+                    assert_eq!(bb.area, Bound::new(0, 1));
+                    bb0_vx = Some(vx);
+                } else if bb.area.start == 1 {
+                    assert_eq!(bb.mnemonics.len(), 1);
+                    assert_eq!(bb.mnemonics[0].opcode, "dummy".to_string());
+                    assert_eq!(bb.mnemonics[0].area, Bound::new(1, 2));
+                    assert_eq!(bb.area, Bound::new(1, 2));
+                    bb1_vx = Some(vx);
+                } else if bb.area.start == 2 {
+                    assert_eq!(bb.mnemonics.len(), 1);
+                    assert_eq!(bb.mnemonics[0].opcode, "test2".to_string());
+                    assert_eq!(bb.mnemonics[0].area, Bound::new(2, 3));
+                    assert_eq!(bb.area, Bound::new(2, 3));
+                    bb2_vx = Some(vx);
+                } else {
+                    unreachable!();
+                }
+            } else {
+                unreachable!();
+            }
+        }
+
+        assert!(bb0_vx.is_some() && bb1_vx.is_some() && bb2_vx.is_some());
+        assert_eq!(func.entry_point, bb0_vx);
+        assert!(func.cflow_graph.edge(bb0_vx.unwrap(), bb1_vx.unwrap()).is_some());
+        assert!(func.cflow_graph.edge(bb1_vx.unwrap(), bb2_vx.unwrap()).is_some());
+        assert!(func.cflow_graph.edge(bb2_vx.unwrap(), bb1_vx.unwrap()).is_some());
+    }
+
+    #[test]
+    fn wide_token() {
+        let def = OpaqueLayer::wrap(vec![0x11, 0x22, 0x33, 0x44, 0x55, 0x44]);
+        let reg = Region::new("".to_string(), def);
+        let dec = new_disassembler!(TestArchWide =>
+            [0x2211] = |s: &mut State<TestArchWide>|
+            {
+                let a = s.address;
+                s.mnemonic(2,"A","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                s.jump(Rvalue::new_u64(a + 2),Guard::always()).unwrap();
+                true
+            },
+
+            [0x4433] = |s: &mut State<TestArchWide>|
+            {
+                let a = s.address;
+                s.mnemonic(2,"B","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                s.jump(Rvalue::new_u64(a + 2),Guard::always()).unwrap();
+                s.jump(Rvalue::new_u64(a + 4),Guard::always()).unwrap();
+                true
+            },
+
+            [0x4455] = |s: &mut State<TestArchWide>|
+            {
+                s.mnemonic(2, "C","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                true
+            }
+        );
+
+        let func = Function::disassemble::<TestArchWide>(None, dec, &reg, 0);
+
+        assert_eq!(func.cflow_graph.num_vertices(), 3);
+        assert_eq!(func.cflow_graph.num_edges(), 2);
+
+        let mut bb0_vx = None;
+        let mut bb1_vx = None;
+
+        for vx in func.cflow_graph.vertices() {
+            match func.cflow_graph.vertex_label(vx) {
+                Some(&ControlFlowTarget::Resolved(ref bb)) => {
+                    if bb.area.start == 0 {
+                        assert_eq!(bb.mnemonics.len(), 2);
+                        assert_eq!(bb.area, Bound::new(0, 4));
+                        bb0_vx = Some(vx);
+                    } else if bb.area.start == 4 {
+                        assert_eq!(bb.mnemonics.len(), 1);
+                        assert_eq!(bb.area, Bound::new(4, 6));
+                        bb1_vx = Some(vx);
+                    } else {
+                        unreachable!();
+                    }
+                }
+                Some(&ControlFlowTarget::Failed(6, _)) => {}
+                _ => unreachable!(),
+            }
+        }
+
+        assert!(bb0_vx.is_some() && bb1_vx.is_some());
+        assert_eq!(func.entry_point, bb0_vx);
+    }
+
+    #[test]
+    fn issue_51_treat_entry_point_as_incoming_edge() {
+        let main = new_disassembler!(TestArchShort =>
+            [ 0 ] = |st: &mut State<TestArchShort>| {
+                st.mnemonic(1,"test0","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(1),Guard::always()).unwrap();
+                true
+            },
+            [ 1 ] = |st: &mut State<TestArchShort>| {
+                st.mnemonic(1,"test1","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(2),Guard::always()).unwrap();
+                true
+            },
+            [ 2 ] = |st: &mut State<TestArchShort>| {
+                st.mnemonic(1,"test2","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(0),Guard::always()).unwrap();
+                true
+            }
+        );
+
+        let data = OpaqueLayer::wrap(vec![0, 1, 2]);
+        let reg = Region::new("".to_string(), data);
+        let func = Function::disassemble::<TestArchShort>(None, main, &reg, 1);
+
+        assert_eq!(func.cflow_graph.num_vertices(), 2);
+        assert_eq!(func.cflow_graph.num_edges(), 2);
+
+        let mut bb0_vx = None;
+        let mut bb1_vx = None;
+
+        for vx in func.cflow_graph.vertices() {
+            if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cflow_graph.vertex_label(vx) {
+                if bb.area.start == 0 {
+                    assert_eq!(bb.mnemonics.len(), 1);
+                    assert_eq!(bb.area, Bound::new(0, 1));
+                    bb0_vx = Some(vx);
+                } else if bb.area.start == 1 {
+                    assert_eq!(bb.mnemonics.len(), 2);
+                    assert_eq!(bb.area, Bound::new(1, 3));
+                    bb1_vx = Some(vx);
+                } else {
+                    unreachable!();
+                }
+            } else {
+                unreachable!();
+            }
+        }
+
+        assert!(bb0_vx.is_some() && bb1_vx.is_some());
+        assert_eq!(func.entry_point, bb1_vx);
+        assert!(func.cflow_graph.edge(bb0_vx.unwrap(), bb1_vx.unwrap()).is_some());
+        assert!(func.cflow_graph.edge(bb1_vx.unwrap(), bb0_vx.unwrap()).is_some());
+    }
+
+    #[test]
+    fn issue_232_overlap_with_entry_point() {
+        let main = new_disassembler!(TestArchShort =>
+            [ 0, 1 ] = |st: &mut State<TestArchShort>| {
+                st.mnemonic(2,"test01","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(2),Guard::always()).unwrap();
+                true
+            },
+            [ 1 ] = |st: &mut State<TestArchShort>| {
+                st.mnemonic(1,"test1","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(2),Guard::always()).unwrap();
+                true
+            },
+            [ 2 ] = |st: &mut State<TestArchShort>| {
+                st.mnemonic(1,"test2","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u32(0),Guard::always()).unwrap();
+                true
+            }
+        );
+
+        let data = OpaqueLayer::wrap(vec![0, 1, 2]);
+        let reg = Region::new("".to_string(), data);
+        let func = Function::disassemble::<TestArchShort>(None, main, &reg, 1);
+
+        assert_eq!(func.cflow_graph.num_vertices(), 3);
+        assert_eq!(func.cflow_graph.num_edges(), 3);
+
+        let mut bb01_vx = None;
+        let mut bb1_vx = None;
+        let mut bb2_vx = None;
+
+        for vx in func.cflow_graph.vertices() {
+            if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cflow_graph.vertex_label(vx) {
+                if bb.area.start == 0 {
+                    assert_eq!(bb.mnemonics.len(), 1);
+                    assert_eq!(bb.area, Bound::new(0, 2));
+                    bb01_vx = Some(vx);
+                } else if bb.area.start == 1 {
+                    assert_eq!(bb.mnemonics.len(), 1);
+                    assert_eq!(bb.area, Bound::new(1, 2));
+                    bb1_vx = Some(vx);
+                } else if bb.area.start == 2 {
+                    assert_eq!(bb.mnemonics.len(), 1);
+                    assert_eq!(bb.area, Bound::new(2, 3));
+                    bb2_vx = Some(vx);
+                } else {
+                    unreachable!();
+                }
+            } else {
+                unreachable!();
+            }
+        }
+
+        assert!(bb01_vx.is_some());
+        assert!(bb1_vx.is_some());
+        assert!(bb2_vx.is_some());
+        assert_eq!(func.entry_point, bb1_vx);
+        assert!(func.cflow_graph.edge(bb01_vx.unwrap(), bb2_vx.unwrap()).is_some());
+        assert!(func.cflow_graph.edge(bb1_vx.unwrap(), bb2_vx.unwrap()).is_some());
+        assert!(func.cflow_graph.edge(bb2_vx.unwrap(), bb01_vx.unwrap()).is_some());
+    }*/
+}

--- a/core/src/neo/function.rs
+++ b/core/src/neo/function.rs
@@ -1,11 +1,11 @@
 use std::ops::Range;
-use std::cell::RefCell;
+use std::iter::FromIterator;
 use uuid::Uuid;
 use petgraph::Graph;
-use petgraph::graph::NodeIndex;
+use petgraph::graph::{NodeIndices,NodeIndex};
 use petgraph::visit::{Walker,DfsPostOrder};
 use {Architecture,Guard,Region,MnemonicFormatToken,Rvalue,Lvalue};
-use neo::{Str,Result,Statement,Bitcode,Value,BitcodeIter,Constant,Operation,Variable,Endianess,CallTarget};
+use neo::{Str,Result,Statement,Bitcode,Value,BitcodeIter,Constant,Operation,Variable,Endianess};
 
 mod core {
     pub use ::mnemonic::Mnemonic;
@@ -20,21 +20,93 @@ use std::fmt::Debug;
 
 #[derive(Debug)]
 pub struct BasicBlock {
-    mnemonics: Range<MnemonicIndex>,
-    node: NodeIndex,
-    area: Range<u64>,
+    pub mnemonics: Range<MnemonicIndex>,
+    pub node: NodeIndex,
+    pub area: Range<u64>,
 }
 
-#[derive(Debug)]
+impl BasicBlock {
+    pub fn area(&self) -> Range<u64> { self.area.clone() }
+}
+
+#[derive(Clone,Debug)]
 pub struct Mnemonic {
-    area: Range<u64>,
-    opcode: Str,
-    operands: Vec<Value>,
-    format_string: Vec<MnemonicFormatToken>,
-    statements: Range<usize>,
+    pub area: Range<u64>,
+    pub opcode: Str,
+    pub operands: Vec<Rvalue>,
+    pub format_string: Vec<MnemonicFormatToken>,
+    pub statements: Range<usize>,
 }
 
-#[derive(Clone,Copy,Debug)]
+/// Internal to `Mnemonic`
+#[derive(Clone,Debug)]
+pub enum Argument {
+    /// Internal to `Mnemonic`
+    Literal(char),
+    /// Internal to `Mnemonic`
+    Value {
+        /// Internal to `Mnemonic`
+        has_sign: bool,
+        /// Internal to `Mnemonic`
+        value: Value,
+    },
+    /// Internal to `Mnemonic`
+    Pointer {
+        /// Internal to `Mnemonic`
+        is_code: bool,
+        /// Internal to `Mnemonic`
+        region: Str,
+        /// Internal to `Mnemonic`
+        address: Value,
+    },
+}
+
+/*macro_rules! arg {
+    ( { u : $val:expr } $cdr:tt ) => {
+        Argument::Value{
+            has_sign: false,
+            value: ($val).into(),
+        }
+    }
+    ( { s : $val:expr } $cdr:tt ) => {
+        Argument::Value{
+            has_sign: true,
+            value: ($val).into(),
+        }
+    }
+    ( { p : $val:expr : $bank:expr } $cdr:tt ) => {
+        Argument::Pointer{
+            is_code: false,
+            region: ($bank).into(),
+            address: ($val).into(),
+        }
+    }
+    ( { c : $val:expr : $bank:expr } $cdr:tt ) => {
+        Argument::Pointer{
+            is_code: false,
+            region: ($bank).into(),
+            address: ($val).into(),
+        }
+    }
+    ( ) => {}
+}
+
+arg!({ u : Variable::new("test",1,None) } "sss");
+arg!({ s : Variable::new("test",1,None) } "sss");
+
+impl Argument {
+    /// format := '{' type '}'
+    /// type := 'u' ':' value | # unsigned
+    ///         's' ':' value | # signed
+    ///         'p' ':' value ':' bank |  # data pointer
+    ///         'c' ':' value ':' bank |  # code pointer
+    /// value := digit+ | xdigit+ | # constant
+    ///          alpha alphanum* | # variable
+    /// bank := alpha alphanum*
+     pub fn parse(mut j: Chars) -> Result<Vec<Argument>> {
+        named!(main, tag!("{"*/
+
+#[derive(Clone,Copy,Debug,PartialOrd,Ord,PartialEq,Eq)]
 pub struct BasicBlockIndex {
     index: usize
 }
@@ -44,7 +116,35 @@ impl BasicBlockIndex {
     pub fn index(&self) -> usize { self.index }
 }
 
-#[derive(Clone,Copy,Debug)]
+pub struct BasicBlockIterator<'a> {
+    function: &'a Function,
+    index: usize,
+    max: usize,
+}
+
+impl<'a> Iterator for BasicBlockIterator<'a> {
+    type Item = (BasicBlockIndex,&'a BasicBlock);
+
+    fn next(&mut self) -> Option<(BasicBlockIndex,&'a BasicBlock)> {
+        if self.index <= self.max {
+            let idx = BasicBlockIndex::new(self.index);
+            let bb = &self.function.basic_blocks[self.index];
+
+            self.index += 1;
+            Some((idx,bb))
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a> ExactSizeIterator for BasicBlockIterator<'a> {
+    fn len(&self) -> usize {
+        self.max - self.index + 1
+    }
+}
+
+#[derive(Clone,Copy,Debug,PartialOrd,Ord,PartialEq,Eq)]
 pub struct MnemonicIndex {
     index: usize
 }
@@ -54,8 +154,106 @@ impl MnemonicIndex {
     pub fn index(&self) -> usize { self.index }
 }
 
+pub struct MnemonicIterator<'a> {
+    function: &'a Function,
+    index: usize,
+    max: usize,
+}
+
+impl<'a> Iterator for MnemonicIterator<'a> {
+    type Item = (MnemonicIndex,&'a Mnemonic);
+
+    fn next(&mut self) -> Option<(MnemonicIndex,&'a Mnemonic)> {
+        if self.index <= self.max {
+            let idx = MnemonicIndex::new(self.index);
+            let mne = &self.function.mnemonics[self.index];
+
+            self.index += 1;
+            Some((idx,mne))
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a> ExactSizeIterator for MnemonicIterator<'a> {
+    fn len(&self) -> usize {
+        self.max - self.index + 1
+    }
+}
+
+pub trait IntoStatementRange {
+    fn into_statement_range(self, func: &Function) -> Range<usize>;
+}
+
+impl<T: IntoStatementRange> IntoStatementRange for Option<T> {
+    fn into_statement_range(self, func: &Function) -> Range<usize> {
+        match self {
+            Some(t) => t.into_statement_range(func),
+            None => 0..func.bitcode.num_bytes()
+        }
+    }
+}
+
+impl IntoStatementRange for Range<usize> {
+    fn into_statement_range(self, _: &Function) -> Range<usize> {
+        self
+    }
+}
+
+impl IntoStatementRange for BasicBlockIndex {
+    fn into_statement_range(self, func: &Function) -> Range<usize> {
+        let bb = &func.basic_blocks[self.index()];
+        bb.into_statement_range(func)
+    }
+}
+
+impl IntoStatementRange for MnemonicIndex {
+    fn into_statement_range(self, func: &Function) -> Range<usize> {
+        let mne = &func.mnemonics[self.index()];
+        mne.into_statement_range(func)
+    }
+}
+
+impl<'a> IntoStatementRange for &'a Mnemonic {
+    fn into_statement_range(self, _: &Function) -> Range<usize> {
+        self.statements.clone()
+    }
+}
+
+impl<'a> IntoStatementRange for &'a BasicBlock {
+    fn into_statement_range(self, func: &Function) -> Range<usize> {
+        let start = func.mnemonics[self.mnemonics.start.index()].statements.start;
+        let end = func.mnemonics[self.mnemonics.end.index() - 1].statements.end;
+
+        start..end
+    }
+}
+
+pub struct IndirectJumps<'a> {
+    pub graph: &'a Graph<CfgNode,Guard>,
+    pub iterator: NodeIndices<u32>,
+}
+
+impl<'a> Iterator for IndirectJumps<'a> {
+    type Item = Variable;
+
+    fn next(&mut self) -> Option<Variable> {
+        while let Some(idx) = self.iterator.next() {
+            match self.graph.node_weight(idx) {
+                Some(&CfgNode::Value(Value::Variable(ref v))) => {
+                    return Some(v.clone());
+                }
+                _ => {}
+            }
+        }
+
+        None
+    }
+}
+
 #[derive(Debug)]
-enum CfgNode {
+pub enum CfgNode {
     BasicBlock(BasicBlockIndex),
     Value(Value),
 }
@@ -72,34 +270,159 @@ pub struct Function {
     mnemonics: Vec<Mnemonic>,
     // sorted by bb idx
     cflow_graph: Graph<CfgNode,Guard>,
+    entry_point: BasicBlockIndex,
 }
 
 impl Function {
 	// disassembly
     pub fn new<A: Architecture>(init: A::Configuration, start: u64, region: &Region, name: Option<Str>) -> Result<Function>
-        where A: Debug, A::Configuration: Debug {
-        let (mnemonics, by_source, by_destination) = disassemble::<A>(init,start,region)?;
-        assemble_function(start, mnemonics, by_source, by_destination)
+    where A: Debug, A::Configuration: Debug {
+        let mut mnemonics = Vec::new();
+        let mut by_source = HashMap::new();
+        let mut by_destination = HashMap::new();
+        let mut func = Function{
+            name: name.unwrap_or("(none)".into()),
+            uuid: Uuid::new_v4(),
+            bitcode: Bitcode::default(),
+            basic_blocks: Vec::new(),
+            mnemonics: Vec::new(),
+            cflow_graph: Graph::new(),
+            entry_point: BasicBlockIndex::new(0),
+        };
+
+        disassemble::<A>(init,vec![start],region, &mut mnemonics, &mut by_source, &mut by_destination)?;
+        assemble_function(&mut func, start, mnemonics, by_source, by_destination)?;
+
+        Ok(func)
     }
 
-    pub fn extend(&mut self,region: &Region) -> Result<bool> { unimplemented!() }
+    pub fn extend<A: Architecture>(&mut self, init: A::Configuration, region: &Region) -> Result<()>
+    where A: Debug, A::Configuration: Debug {
+        use petgraph::visit::EdgeRef;
+
+        let mut mnemonics = self.mnemonics.iter().map(|mne| {
+            let stmts = self.bitcode.iter_range(mne.statements.clone()).collect::<Vec<_>>();
+            (mne.clone(),stmts)
+        }).collect::<Vec<_>>();
+        let mut by_source = HashMap::new();
+        let mut by_destination = HashMap::new();
+        let mut starts = Vec::new();
+
+        for e in self.cflow_graph.edge_references() {
+            let src = match self.cflow_graph.node_weight(e.source()) {
+                Some(&CfgNode::BasicBlock(bb_idx)) => {
+                    let bb = &self.basic_blocks[bb_idx.index()];
+                    let mne = &self.mnemonics[bb.mnemonics.end.index() - 1];
+                    mne.area.start
+                }
+                _ => unreachable!()
+            };
+            let dst = match self.cflow_graph.node_weight(e.target()) {
+                Some(&CfgNode::BasicBlock(bb_idx)) => {
+                    let bb = &self.basic_blocks[bb_idx.index()];
+                    let mne = &self.mnemonics[bb.mnemonics.start.index()];
+                    Value::val(mne.area.start,64)?
+                }
+                Some(&CfgNode::Value(ref val)) => {
+                    val.clone()
+                }
+                None => unreachable!()
+            };
+
+            by_source.entry(src).or_insert_with(|| Vec::new()).push((dst.clone(),e.weight().clone()));
+
+            if let Value::Constant(Constant{ value,.. }) = dst {
+                by_destination.entry(value).or_insert_with(|| Vec::new()).push((Value::val(src,64)?,e.weight().clone()));
+                starts.push(value);
+            }
+        }
+
+        let entry = self.entry_address();
+        disassemble::<A>(init,starts, region, &mut mnemonics, &mut by_source, &mut by_destination)?;
+        assemble_function(self,entry,mnemonics,by_source,by_destination)
+    }
 
     // getter
-    pub fn entry_point(&self) -> BasicBlockIndex { unimplemented!() }
-    pub fn mnemonics(&self) -> &[Mnemonic] { unimplemented!() }
-    pub fn mnemonics_for_basic_block(&self, idx: BasicBlockIndex) -> &[Mnemonic] { unimplemented!() }
-    pub fn basic_blocks(&self) -> &[BasicBlock] { unimplemented!() }
-    pub fn uuid(&self) -> &Uuid { unimplemented!() }
+    pub fn entry_point(&self) -> BasicBlockIndex { self.entry_point }
+
+    pub fn mnemonics<'a, O: Into<Option<BasicBlockIndex>>>(&'a self, basic_block: O) -> MnemonicIterator<'a> {
+        match basic_block.into() {
+            Some(BasicBlockIndex{ index }) => {
+                let &BasicBlock{ ref mnemonics,.. } = &self.basic_blocks[index];
+                MnemonicIterator{
+                    function: self,
+                    index: mnemonics.start.index,
+                    max: mnemonics.end.index - 1
+                }
+            }
+            None => {
+                MnemonicIterator{
+                    function: self,
+                    index: 0,
+                    max: self.mnemonics.len() - 1
+                }
+            }
+        }
+    }
+
+    pub fn basic_blocks<'a>(&'a self) -> BasicBlockIterator<'a> {
+        BasicBlockIterator{
+            function: self,
+            index: 0,
+            max: self.basic_blocks.len() - 1
+        }
+    }
+
+    pub fn cflow_graph<'a>(&'a self) -> &'a Graph<CfgNode,Guard> {
+        &self.cflow_graph
+    }
+
+    pub fn basic_block<'a>(&'a self, idx: BasicBlockIndex) -> &'a BasicBlock {
+        &self.basic_blocks[idx.index]
+    }
+
+    pub fn mnemonic<'a>(&'a self, idx: MnemonicIndex) -> &'a Mnemonic {
+        &self.mnemonics[idx.index]
+    }
 
     // iters
-    pub fn statements(&self) -> BitcodeIter { unimplemented!() }
-    pub fn statements_for_block(&self, idx: BasicBlockIndex) -> BitcodeIter { unimplemented!() }
-    pub fn statements_for_mnemonic(&self, idx: MnemonicIndex) -> BitcodeIter { unimplemented!() }
+    pub fn statements<Idx: IntoStatementRange + Sized>(&self, rgn: Idx) -> BitcodeIter {
+        let rgn = rgn.into_statement_range(self);
+        self.bitcode.iter_range(rgn)
+    }
 
     // aux
-    pub fn first_address(&self) -> u64 { unimplemented!() }
-    pub fn has_unresolved_jumps(&self) -> bool { unimplemented!() }
-    pub fn resolve_jump(&self,_: Value,_: u64) -> Result<bool> { unimplemented!() }
+    pub fn first_address(&self) -> u64 {
+        self.basic_blocks[0].area().start
+    }
+
+    pub fn entry_address(&self) -> u64 {
+        let e = self.entry_point().index();
+        self.basic_blocks[e].area().start
+    }
+
+    pub fn indirect_jumps<'a>(&'a self) -> IndirectJumps<'a> {
+        IndirectJumps{
+            graph: &self.cflow_graph,
+            iterator: self.cflow_graph.node_indices()
+        }
+    }
+
+    pub fn resolve_indirect_jump(&mut self, var: Variable, val: Constant) -> bool {
+        let var = Value::Variable(var);
+
+        for n in self.cflow_graph.node_indices() {
+            match self.cflow_graph.node_weight_mut(n) {
+                Some(&mut CfgNode::Value(ref mut value)) if *value == var => {
+                    *value = Value::Constant(val);
+                    return true;
+                }
+                _ => {}
+            }
+        }
+
+        false
+    }
 
     // insert
     pub fn insert_statement(stmt: Statement, mnemonic: MnemonicIndex,
@@ -108,23 +431,20 @@ impl Function {
         basic_block: BasicBlock, index: usize) -> Result<()> { unimplemented!() }
 }
 
-fn disassemble<A: Architecture>(init: A::Configuration, start: u64, region: &Region)
--> Result<(Vec<core::Mnemonic>,HashMap<u64,Vec<(Value,Guard)>>,HashMap<u64,Vec<(Value,Guard)>>)>
+fn disassemble<A: Architecture>(init: A::Configuration, starts: Vec<u64>, region: &Region,
+                                mnemonics: &mut Vec<(Mnemonic,Vec<Statement>)>,
+                                by_source: &mut HashMap<u64,Vec<(Value,Guard)>>,
+                                by_destination: &mut HashMap<u64,Vec<(Value,Guard)>>) -> Result<()>
 where A: Debug, A::Configuration: Debug {
-    let mut todo = HashSet::<u64>::new();
-    let mut mnemonics = Vec::<core::Mnemonic>::new();
-    let mut by_source = HashMap::<u64,Vec<(Value,Guard)>>::new();
-    let mut by_destination = HashMap::<u64,Vec<(Value,Guard)>>::new();
-
-    todo.insert(start);
+    let mut todo = HashSet::<u64>::from_iter(starts.into_iter());
 
     while let Some(addr) = todo.iter().next().cloned() {
         assert!(todo.remove(&addr));
 
-        match mnemonics.binary_search_by_key(&addr,|x| x.area.start) {
+        match mnemonics.binary_search_by_key(&addr,|&(ref x,_)| x.area.start) {
             // Already disassembled here
             Ok(pos) => {
-                let mne = &mnemonics[pos];
+                let mne = &mnemonics[pos].0;
 
                 if mne.area.start != addr {
                     error!("{:#x}: Jump inside mnemonic {} at {:#x}",addr,mne.opcode,mne.area.start);
@@ -147,7 +467,15 @@ where A: Debug, A::Configuration: Debug {
                                     mne.opcode,
                                     match_st.tokens
                                     );
-                                mnemonics.insert(pos,mne);
+                                let this_mne = Mnemonic{
+                                    area: mne.area.start..mne.area.end,
+                                    opcode: mne.opcode.into(),
+                                    operands: mne.operands.iter().map(|x| x.clone().into()).collect(),
+                                    format_string: mne.format_string,
+                                    statements: 0..0,
+                                };
+                                let stmts = mne.instructions.iter().map(|s| to_statement(s)).collect::<Vec<_>>();
+                                mnemonics.insert(pos,(this_mne,stmts));
                             }
                         }
 
@@ -177,29 +505,27 @@ where A: Debug, A::Configuration: Debug {
         }
     }
 
-    Ok((mnemonics,by_source,by_destination))
+    Ok(())
 }
 
-fn assemble_function(entry: u64, mut mnemonics: Vec<core::Mnemonic>,
+fn assemble_function(function: &mut Function, entry: u64, mut mnemonics: Vec<(Mnemonic,Vec<Statement>)>,
                      by_source: HashMap<u64,Vec<(Value,Guard)>>,
-                     by_destination: HashMap<u64,Vec<(Value,Guard)>>) -> Result<Function> {
+                     by_destination: HashMap<u64,Vec<(Value,Guard)>>) -> Result<()> {
 
     let mut basic_blocks = Vec::<BasicBlock>::new();
     let mut idx = 0;
 
-    mnemonics.sort_by_key(|x| x.area.start);
-
-    // Split mnemonics into basic blocks
+    // Partition mnemonics into basic blocks
     while idx < mnemonics.len() {
         if mnemonics.len() - idx > 1 {
             let next_bb = mnemonics
                 .as_slice()[idx..].windows(2)
-                .position(|x| is_basic_block_boundary(&x[0],&x[1],entry,&by_source,&by_destination))
+                .position(|x| is_basic_block_boundary(&x[0].0,&x[1].0,entry,&by_source,&by_destination))
                 .map(|x| x + 1 + idx)
                 .unwrap_or(mnemonics.len());
             let bb = BasicBlock{
                 mnemonics: MnemonicIndex::new(idx)..MnemonicIndex::new(next_bb),
-                area: mnemonics[idx].area.start..mnemonics[next_bb - 1].area.end,
+                area: mnemonics[idx].0.area.start..mnemonics[next_bb - 1].0.area.end,
                 node: NodeIndex::new(0),
             };
 
@@ -208,7 +534,7 @@ fn assemble_function(entry: u64, mut mnemonics: Vec<core::Mnemonic>,
         } else {
             let bb = BasicBlock{
                 mnemonics: MnemonicIndex::new(idx)..MnemonicIndex::new(mnemonics.len()),
-                area: mnemonics[idx].area.start..mnemonics[idx].area.end,
+                area: mnemonics[idx].0.area.start..mnemonics[idx].0.area.end,
                 node: NodeIndex::new(0),
             };
 
@@ -224,11 +550,11 @@ fn assemble_function(entry: u64, mut mnemonics: Vec<core::Mnemonic>,
         bb.node = cfg.add_node(CfgNode::BasicBlock(BasicBlockIndex::new(i)));
     }
 
-    for (i,bb) in basic_blocks.iter().enumerate() {
-        if let Some(ct) = by_source.get(&bb.area.start) {
+    for bb in basic_blocks.iter() {
+        let last_mne = &mnemonics[bb.mnemonics.end.index() - 1].0;
+        if let Some(ct) = by_source.get(&last_mne.area.start) {
             for &(ref val,ref guard) in ct.iter() {
                 match val {
-                    &Value::Constant(Constant{ value,.. }) if bb.area.start <= value && bb.area.end > value => {}
                     &Value::Constant(Constant{ value,.. }) => {
                         if let Ok(pos) = basic_blocks.binary_search_by_key(&value,|bb| bb.area.start) {
                             cfg.update_edge(bb.node,basic_blocks[pos].node,guard.clone());
@@ -259,38 +585,59 @@ fn assemble_function(entry: u64, mut mnemonics: Vec<core::Mnemonic>,
         if let Some(&CfgNode::BasicBlock(idx)) = cfg.node_weight(n) {
             let bb = &basic_blocks[idx.index()];
             let sl = bb.mnemonics.start.index()..bb.mnemonics.end.index();
-            for (off,mne) in mnemonics.as_slice()[sl].iter().enumerate() {
-                let rgn = bitcode.append(mne.instructions.iter().map(|s| to_statement(s)))?;
+            for (off,&mut (_,ref mut instr)) in mnemonics.as_mut_slice()[sl].iter_mut().enumerate() {
+                let rgn = bitcode.append(instr.drain(..))?;
 
                 statement_ranges[bb.mnemonics.start.index() + off] = rgn;
             }
         }
     }
 
-    let func = Function{
-        name: "".into(),
-        uuid: Uuid::new_v4(),
-        bitcode: bitcode,
-        basic_blocks: basic_blocks,
-        mnemonics: mnemonics.into_iter().enumerate().map(|(idx,mne)| {
-            Mnemonic{
-                area: mne.area.start..mne.area.end,
-                opcode: mne.opcode.into(),
-                operands: mne.operands.iter().map(|x| x.clone().into()).collect(),
-                format_string: mne.format_string,
-                statements: statement_ranges[idx].clone(),
-            }
-        }).collect(),
-        cflow_graph: cfg,
-    };
+    function.name = format!("func_{:x}",entry).into();
+    function.bitcode = bitcode;
+    function.basic_blocks = basic_blocks;
+    function.mnemonics = mnemonics.into_iter().enumerate().map(|(idx,(mut mne,_))| {
+        mne.statements = statement_ranges[idx].clone();
+        mne
+    }).collect();
+    function.cflow_graph = cfg;
+    function.entry_point = BasicBlockIndex::new(entry_idx);
 
-    Ok(func)
+    Ok(())
 }
 
-fn is_basic_block_boundary(a: &core::Mnemonic, b: &core::Mnemonic, entry: u64,
+fn is_basic_block_boundary(a: &Mnemonic, b: &Mnemonic, entry: u64,
                            by_source: &HashMap<u64,Vec<(Value,Guard)>>,
                            by_destination: &HashMap<u64,Vec<(Value,Guard)>>) -> bool {
-    true
+    // if next mnemonics aren't adjacent
+    let mut new_bb = a.area.end != b.area.start;
+
+    // or any following jumps aren't to adjacent mnemonics
+    new_bb |= by_source
+        .get(&a.area.start)
+        .unwrap_or(&Vec::new())
+        .iter()
+        .any(|&(ref opt_dest, _)| {
+            if let &Value::Constant(Constant{ value, .. }) = opt_dest { value != b.area.start } else { false }
+        });
+
+    // or any jumps pointing to the next that aren't from here
+    new_bb |= by_destination
+        .get(&b.area.start)
+        .unwrap_or(&Vec::new())
+        .iter()
+        .any(
+            |&(ref opt_src, _)| if let &Value::Constant(Constant{ value, .. }) = opt_src {
+                value != a.area.start
+            } else {
+                false
+            }
+            );
+
+    // or the entry point does not point here
+    new_bb |= b.area.start == entry;
+
+    new_bb
 }
 
 fn to_statement(stmt: &core::Statement) -> Statement {
@@ -355,19 +702,19 @@ fn to_statement(stmt: &core::Statement) -> Statement {
         &core::Statement{ op: core::Operation::Move(ref a), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
             Statement::Expression{ op: Operation::Move(a.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
         }
-       &core::Statement{ op: core::Operation::Initialize(ref s,ref a), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+        &core::Statement{ op: core::Operation::Initialize(ref s,ref a), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
             Statement::Expression{ op: Operation::Initialize(s.clone(),a.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
         }
-       &core::Statement{ op: core::Operation::Select(sz,ref a,ref b), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+        &core::Statement{ op: core::Operation::Select(sz,ref a,ref b), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
             Statement::Expression{ op: Operation::Select(sz,a.clone().into(),b.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
         }
-       &core::Statement{ op: core::Operation::Load(ref s,core::Endianess::Little,b,ref a), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+        &core::Statement{ op: core::Operation::Load(ref s,core::Endianess::Little,b,ref a), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
             Statement::Expression{ op: Operation::Load(s.clone(),Endianess::Little,b,a.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
         }
-       &core::Statement{ op: core::Operation::Load(ref s,core::Endianess::Big,b,ref a), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
+        &core::Statement{ op: core::Operation::Load(ref s,core::Endianess::Big,b,ref a), assignee: Lvalue::Variable{ ref name, ref subscript, size } } => {
             Statement::Expression{ op: Operation::Load(s.clone(),Endianess::Big,b,a.clone().into()), result: Variable::new(name.clone(),size,subscript.clone()).unwrap() }
         }
-       &core::Statement{ op: core::Operation::Store(ref s,core::Endianess::Little,by,ref a,ref b),.. } => {
+        &core::Statement{ op: core::Operation::Store(ref s,core::Endianess::Little,by,ref a,ref b),.. } => {
             Statement::Store{
                 region: s.clone(),
                 endianess: Endianess::Little,
@@ -376,7 +723,7 @@ fn to_statement(stmt: &core::Statement) -> Statement {
                 value: b.clone().into(),
             }
         }
-       &core::Statement{ op: core::Operation::Store(ref s,core::Endianess::Big,by,ref a,ref b),.. } => {
+        &core::Statement{ op: core::Operation::Store(ref s,core::Endianess::Big,by,ref a,ref b),.. } => {
             Statement::Store{
                 region: s.clone(),
                 endianess: Endianess::Big,
@@ -386,12 +733,12 @@ fn to_statement(stmt: &core::Statement) -> Statement {
             }
         }
 
-    //Phi(Vec<V>),
-       &core::Statement{ op: core::Operation::Call(ref a),.. } => {
-           Statement::IndirectCall{
-               target: a.clone().into(),
-           }
-       }
+        //Phi(Vec<V>),
+        &core::Statement{ op: core::Operation::Call(ref a),.. } => {
+            Statement::IndirectCall{
+                target: a.clone().into(),
+            }
+        }
 
 
         _ => unimplemented!("{:?}",stmt)
@@ -401,11 +748,9 @@ fn to_statement(stmt: &core::Statement) -> Statement {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use {Architecture, BasicBlock, Bound, Disassembler, Guard, Match, Mnemonic, OpaqueLayer, Region, Result, Rvalue, State};
-    use panopticon_graph_algos::{AdjacencyMatrixGraphTrait, EdgeListGraphTrait, VertexListGraphTrait};
-    use panopticon_graph_algos::{GraphTrait, MutableGraphTrait};
-    use std::borrow::Cow;
+    use {Architecture, Disassembler, Guard, Match, OpaqueLayer, Region, Result, Rvalue, State};
     use std::sync::Arc;
+    use env_logger;
 
     #[derive(Clone,Debug)]
     enum TestArchShort {}
@@ -444,138 +789,9 @@ mod tests {
             }
         }
     }
-/*
-    #[test]
-    fn new() {
-        let f = Function::new("test".to_string(), "ram".to_string());
-
-        assert_eq!(f.name, "test".to_string());
-        assert_eq!(f.cflow_graph.num_vertices(), 0);
-        assert_eq!(f.cflow_graph.num_edges(), 0);
-        assert_eq!(f.entry_point, None);
-    }
 
     #[test]
-    fn index_resolved() {
-        let mut cfg = ControlFlowGraph::new();
-
-        let bb0 = BasicBlock::from_vec(
-            vec![
-                Mnemonic::dummy(0..1),
-                Mnemonic::dummy(1..2),
-                Mnemonic::dummy(2..5),
-                Mnemonic::dummy(5..6),
-            ]
-        );
-        let bb1 = BasicBlock::from_vec(
-            vec![
-                Mnemonic::dummy(10..11),
-                Mnemonic::dummy(11..12),
-                Mnemonic::dummy(12..15),
-                Mnemonic::dummy(15..16),
-            ]
-        );
-        let bb2 = BasicBlock::from_vec(vec![Mnemonic::dummy(6..10)]);
-
-        let vx0 = cfg.add_vertex(ControlFlowTarget::Resolved(bb0));
-        let vx1 = cfg.add_vertex(ControlFlowTarget::Resolved(bb1));
-        let vx2 = cfg.add_vertex(ControlFlowTarget::Resolved(bb2));
-
-        cfg.add_edge(Guard::always(), vx0, vx1);
-        cfg.add_edge(Guard::always(), vx1, vx1);
-        cfg.add_edge(Guard::always(), vx1, vx2);
-        cfg.add_edge(Guard::always(), vx2, vx0);
-
-        let (mnes, src, dest) = Function::index_cflow_graph(cfg, None);
-
-        assert_eq!(mnes.len(), 9);
-        assert_eq!(src.values().fold(0, |acc, x| acc + x.len()), 10);
-        assert_eq!(dest.values().fold(0, |acc, x| acc + x.len()), 10);
-
-        let cfg_re = Function::assemble_cflow_graph(mnes, src, dest, 0);
-
-        assert_eq!(cfg_re.num_vertices(), 3);
-        assert_eq!(cfg_re.num_edges(), 4);
-
-        for vx in cfg_re.vertices() {
-            if let Some(&ControlFlowTarget::Resolved(ref bb)) = cfg_re.vertex_label(vx) {
-                assert!((bb.area.start == 0 && bb.area.end == 6) || (bb.area.start == 10 && bb.area.end == 16) || (bb.area.start == 6 && bb.area.end == 10));
-            } else {
-                unreachable!();
-            }
-        }
-
-        for e in cfg_re.edges() {
-            if let Some(&ControlFlowTarget::Resolved(ref from)) = cfg_re.vertex_label(cfg_re.source(e)) {
-                if let Some(&ControlFlowTarget::Resolved(ref to)) = cfg_re.vertex_label(cfg_re.target(e)) {
-                    assert!(
-                        (from.area.start == 0 && to.area.start == 10) || (from.area.start == 10 && to.area.start == 10) ||
-                        (from.area.start == 10 && to.area.start == 6) || (from.area.start == 6 && to.area.start == 0)
-                    );
-                } else {
-                    unreachable!();
-                }
-            } else {
-                unreachable!();
-            }
-        }
-    }
-
-    #[test]
-    fn index_unresolved() {
-        let mut cfg = ControlFlowGraph::new();
-
-        let bb0 = BasicBlock::from_vec(vec![Mnemonic::dummy(0..1)]);
-        let bb1 = BasicBlock::from_vec(vec![Mnemonic::dummy(10..11)]);
-
-        let vx0 = cfg.add_vertex(ControlFlowTarget::Resolved(bb0));
-        let vx1 = cfg.add_vertex(ControlFlowTarget::Resolved(bb1));
-        let vx2 = cfg.add_vertex(ControlFlowTarget::Unresolved(Rvalue::new_u32(42)));
-        let vx3 = cfg.add_vertex(ControlFlowTarget::Unresolved(Rvalue::new_u32(23)));
-        let vx4 = cfg.add_vertex(
-            ControlFlowTarget::Unresolved(
-                Rvalue::Variable {
-                    name: Cow::Borrowed("a"),
-                    size: 8,
-                    offset: 0,
-                    subscript: None,
-                }
-            )
-        );
-
-        cfg.add_edge(Guard::always(), vx0, vx1);
-        cfg.add_edge(Guard::always(), vx2, vx1);
-        cfg.add_edge(Guard::always(), vx3, vx0);
-        cfg.add_edge(Guard::always(), vx4, vx3);
-
-        let (mnes, src, dest) = Function::index_cflow_graph(cfg, None);
-
-        assert_eq!(mnes.len(), 2);
-        assert_eq!(src.values().fold(0, |acc, x| acc + x.len()), 3);
-        assert_eq!(dest.values().fold(0, |acc, x| acc + x.len()), 3);
-
-        let cfg_re = Function::assemble_cflow_graph(mnes, src, dest, 0);
-
-        assert_eq!(cfg_re.num_vertices(), 4);
-        assert_eq!(cfg_re.num_edges(), 3);
-
-        for vx in cfg_re.vertices() {
-            match cfg_re.vertex_label(vx) {
-                Some(&ControlFlowTarget::Resolved(ref bb)) => {
-                    assert!((bb.area.start == 0 && bb.area.end == 1) || (bb.area.start == 10 && bb.area.end == 11));
-                }
-                Some(&ControlFlowTarget::Unresolved(Rvalue::Constant { value: ref c, size: 64 })) => {
-                    assert!(*c == 42 || *c == 23);
-                }
-                _ => {
-                    unreachable!();
-                }
-            }
-        }
-    }
-
-    #[test]
-    fn add_single() {
+    fn single_instruction() {
         let main = new_disassembler!(TestArchShort =>
             [ 0 ] = |st: &mut State<TestArchShort>| {
                 st.mnemonic(1,"A","",vec!(),&|_| { Ok(vec![]) }).unwrap();
@@ -584,30 +800,30 @@ mod tests {
 		);
         let data = OpaqueLayer::wrap(vec![0]);
         let reg = Region::new("".to_string(), data);
-        let func = Function::disassemble::<TestArchShort>(None, main, &reg, 0);
+        let func = Function::new::<TestArchShort>(main, 0, &reg, None).unwrap();
 
-        assert_eq!(func.cflow_graph.num_vertices(), 1);
-        assert_eq!(func.cflow_graph.num_edges(), 0);
+        assert_eq!(func.cflow_graph().node_count(), 1);
+        assert_eq!(func.cflow_graph().edge_count(), 0);
 
-        if let Some(vx) = func.cflow_graph.vertices().next() {
-            if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cflow_graph.vertex_label(vx) {
-                assert_eq!(bb.mnemonics.len(), 1);
-                assert_eq!(bb.mnemonics[0].opcode, "A".to_string());
-                assert_eq!(bb.mnemonics[0].area, Bound::new(0, 1));
-                assert_eq!(bb.area, Bound::new(0, 1));
-            } else {
-                unreachable!();
-            }
-        } else {
-            unreachable!();
-        }
+        let node = func.cflow_graph().node_indices().next().unwrap();
+        assert!(if let Some(&CfgNode::BasicBlock(_)) = func.cflow_graph().node_weight(node) { true } else { false });
 
-        assert_eq!(func.entry_point, func.cflow_graph.vertices().next());
-        assert_eq!(func.name, "func_0".to_string());
+        assert_eq!(func.entry_address(), 0);
+        assert_eq!(func.basic_blocks().len(), 1);
+        assert_eq!(func.name, "func_0");
+
+        let (bb_idx,bb) = func.basic_blocks().next().unwrap();
+        assert_eq!(bb.area(), 0..1);
+        assert_eq!(func.mnemonics(bb_idx).len(), 1);
+
+        let (mne_idx,mne) = func.mnemonics(bb_idx).next().unwrap();
+        assert_eq!(mne.opcode, "A");
+
     }
 
     #[test]
-    fn continuous() {
+    fn single_block() {
+        let _ = env_logger::init();
         let main = new_disassembler!(TestArchShort =>
             [ 0 ] = |st: &mut State<TestArchShort>| {
                 let next = st.address;
@@ -649,43 +865,38 @@ mod tests {
 
         let data = OpaqueLayer::wrap(vec![0, 1, 2, 3, 4, 5]);
         let reg = Region::new("".to_string(), data);
-        let func = Function::disassemble::<TestArchShort>(None, main, &reg, 0);
+        let func = Function::new::<TestArchShort>(main, 0, &reg, None).unwrap();
 
-        assert_eq!(func.cflow_graph.num_vertices(), 2);
-        assert_eq!(func.cflow_graph.num_edges(), 1);
+        assert_eq!(func.cflow_graph().node_count(), 2);
+        assert_eq!(func.cflow_graph().edge_count(), 1);
 
-        let mut bb_vx = None;
-        let mut ures_vx = None;
-
-        for vx in func.cflow_graph.vertices() {
-            if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cflow_graph.vertex_label(vx) {
-                assert_eq!(bb.mnemonics.len(), 6);
-                assert_eq!(bb.mnemonics[0].opcode, "test0".to_string());
-                assert_eq!(bb.mnemonics[0].area, Bound::new(0, 1));
-                assert_eq!(bb.mnemonics[1].opcode, "test1".to_string());
-                assert_eq!(bb.mnemonics[1].area, Bound::new(1, 2));
-                assert_eq!(bb.mnemonics[2].opcode, "test2".to_string());
-                assert_eq!(bb.mnemonics[2].area, Bound::new(2, 3));
-                assert_eq!(bb.mnemonics[3].opcode, "test3".to_string());
-                assert_eq!(bb.mnemonics[3].area, Bound::new(3, 4));
-                assert_eq!(bb.mnemonics[4].opcode, "test4".to_string());
-                assert_eq!(bb.mnemonics[4].area, Bound::new(4, 5));
-                assert_eq!(bb.mnemonics[5].opcode, "test5".to_string());
-                assert_eq!(bb.mnemonics[5].area, Bound::new(5, 6));
-                assert_eq!(bb.area, Bound::new(0, 6));
-                bb_vx = Some(vx);
-            } else if let Some(&ControlFlowTarget::Failed(c, _)) = func.cflow_graph.vertex_label(vx) {
-                assert_eq!(c, 6);
-                ures_vx = Some(vx);
-            } else {
-                unreachable!();
+        for n in func.cflow_graph().node_indices() {
+            match func.cflow_graph.node_weight(n) {
+                Some(&CfgNode::BasicBlock(bb)) => {
+                    let mnes = func.mnemonics(bb).collect::<Vec<_>>();
+                    assert_eq!(mnes.len(), 6);
+                    assert_eq!(mnes[0].1.opcode, "test0");
+                    assert_eq!(mnes[0].1.area, 0..1);
+                    assert_eq!(mnes[1].1.opcode, "test1");
+                    assert_eq!(mnes[1].1.area, 1..2);
+                    assert_eq!(mnes[2].1.opcode, "test2");
+                    assert_eq!(mnes[2].1.area, 2..3);
+                    assert_eq!(mnes[3].1.opcode, "test3");
+                    assert_eq!(mnes[3].1.area, 3..4);
+                    assert_eq!(mnes[4].1.opcode, "test4");
+                    assert_eq!(mnes[4].1.area, 4..5);
+                    assert_eq!(mnes[5].1.opcode, "test5");
+                    assert_eq!(mnes[5].1.area, 5..6);
+                    assert_eq!(func.basic_block(bb).area, 0..6);
+                }
+                Some(&CfgNode::Value(Value::Constant(Constant{ value: 6,.. }))) => {}
+                _ => unreachable!()
             }
         }
 
-        assert!(ures_vx.is_some() && bb_vx.is_some());
-        assert_eq!(func.entry_point, bb_vx);
-        assert_eq!(func.name, "func_0".to_string());
-        assert!(func.cflow_graph.edge(bb_vx.unwrap(), ures_vx.unwrap()).is_some());
+        assert_eq!(func.entry_address(), 0);
+        assert_eq!(func.basic_blocks().len(), 1);
+        assert_eq!(func.name, "func_0");
     }
 
     #[test]
@@ -711,58 +922,65 @@ mod tests {
 
         let data = OpaqueLayer::wrap(vec![0, 1, 2]);
         let reg = Region::new("".to_string(), data);
-        let func = Function::disassemble::<TestArchShort>(None, main, &reg, 0);
+        let func = Function::new::<TestArchShort>(main, 0, &reg, None).unwrap();
 
-        assert_eq!(func.cflow_graph.num_vertices(), 4);
-        assert_eq!(func.cflow_graph.num_edges(), 4);
+        assert_eq!(func.cflow_graph.node_count(), 4);
+        assert_eq!(func.cflow_graph.edge_count(), 4);
 
         let mut bb0_vx = None;
         let mut bb1_vx = None;
         let mut bb2_vx = None;
         let mut ures_vx = None;
 
-        for vx in func.cflow_graph.vertices() {
-            if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cflow_graph.vertex_label(vx) {
-                if bb.area.start == 0 {
-                    assert_eq!(bb.mnemonics.len(), 1);
-                    assert_eq!(bb.mnemonics[0].opcode, "test0".to_string());
-                    assert_eq!(bb.mnemonics[0].area, Bound::new(0, 1));
-                    assert_eq!(bb.area, Bound::new(0, 1));
-                    bb0_vx = Some(vx);
-                } else if bb.area.start == 1 {
-                    assert_eq!(bb.mnemonics.len(), 1);
-                    assert_eq!(bb.mnemonics[0].opcode, "test1".to_string());
-                    assert_eq!(bb.mnemonics[0].area, Bound::new(1, 2));
-                    assert_eq!(bb.area, Bound::new(1, 2));
-                    bb1_vx = Some(vx);
-                } else if bb.area.start == 2 {
-                    assert_eq!(bb.mnemonics.len(), 1);
-                    assert_eq!(bb.mnemonics[0].opcode, "test2".to_string());
-                    assert_eq!(bb.mnemonics[0].area, Bound::new(2, 3));
-                    assert_eq!(bb.area, Bound::new(2, 3));
-                    bb2_vx = Some(vx);
-                } else {
-                    unreachable!();
+        for n in func.cflow_graph.node_indices() {
+            match func.cflow_graph().node_weight(n) {
+                Some(&CfgNode::BasicBlock(bb_idx)) => {
+                    let bb = func.basic_block(bb_idx);
+                    let mnes = func.mnemonics(bb_idx).collect::<Vec<_>>();
+
+                    if bb.area.start == 0 {
+                        assert_eq!(mnes.len(), 1);
+                        assert_eq!(mnes[0].1.opcode, "test0");
+                        assert_eq!(mnes[0].1.area, 0..1);
+                        assert_eq!(bb.area, 0..1);
+                        bb0_vx = Some(n);
+                    } else if bb.area.start == 1 {
+                        assert_eq!(mnes.len(), 1);
+                        assert_eq!(mnes[0].1.opcode, "test1");
+                        assert_eq!(mnes[0].1.area, 1..2);
+                        assert_eq!(bb.area, 1..2);
+                        bb1_vx = Some(n);
+                    } else if bb.area.start == 2 {
+                        assert_eq!(mnes.len(), 1);
+                        assert_eq!(mnes[0].1.opcode, "test2");
+                        assert_eq!(mnes[0].1.area, 2..3);
+                        assert_eq!(bb.area, 2..3);
+                        bb2_vx = Some(n);
+                    } else {
+                        unreachable!();
+                    }
                 }
-            } else if let Some(&ControlFlowTarget::Failed(c, _)) = func.cflow_graph.vertex_label(vx) {
-                assert_eq!(c, 3);
-                ures_vx = Some(vx);
-            } else {
-                unreachable!();
+                Some(&CfgNode::Value(Value::Constant(Constant{ value,.. }))) => {
+                    assert_eq!(value, 3);
+                    ures_vx = Some(n);
+                }
+                _ => { unreachable!(); }
             }
         }
 
         assert!(ures_vx.is_some() && bb0_vx.is_some() && bb1_vx.is_some() && bb2_vx.is_some());
-        assert_eq!(func.entry_point, bb0_vx);
-        assert_eq!(func.name, "func_0".to_string());
-        assert!(func.cflow_graph.edge(bb0_vx.unwrap(), bb1_vx.unwrap()).is_some());
-        assert!(func.cflow_graph.edge(bb0_vx.unwrap(), bb2_vx.unwrap()).is_some());
-        assert!(func.cflow_graph.edge(bb1_vx.unwrap(), ures_vx.unwrap()).is_some());
-        assert!(func.cflow_graph.edge(bb2_vx.unwrap(), bb1_vx.unwrap()).is_some());
+
+        let entry_bb = func.entry_point();
+        assert_eq!(func.basic_block(entry_bb).node, bb0_vx.unwrap());
+        assert_eq!(func.name, "func_0");
+        assert!(func.cflow_graph().find_edge(bb0_vx.unwrap(), bb1_vx.unwrap()).is_some());
+        assert!(func.cflow_graph().find_edge(bb0_vx.unwrap(), bb2_vx.unwrap()).is_some());
+        assert!(func.cflow_graph().find_edge(bb1_vx.unwrap(), ures_vx.unwrap()).is_some());
+        assert!(func.cflow_graph().find_edge(bb2_vx.unwrap(), bb1_vx.unwrap()).is_some());
     }
 
     #[test]
-    fn function_loop() {
+    fn single_loop() {
         let main = new_disassembler!(TestArchShort =>
             [ 0 ] = |st: &mut State<TestArchShort>| {
                 st.mnemonic(1,"test0","",vec!(),&|_| { Ok(vec![]) }).unwrap();
@@ -783,34 +1001,38 @@ mod tests {
 
         let data = OpaqueLayer::wrap(vec![0, 1, 2]);
         let reg = Region::new("".to_string(), data);
-        let func = Function::disassemble::<TestArchShort>(None, main, &reg, 0);
+        let func = Function::new::<TestArchShort>(main, 0, &reg, None).unwrap();
 
-        assert_eq!(func.cflow_graph.num_vertices(), 1);
-        assert_eq!(func.cflow_graph.num_edges(), 1);
+        assert_eq!(func.cflow_graph.node_count(), 1);
+        assert_eq!(func.cflow_graph.edge_count(), 1);
 
-        let vx = func.cflow_graph.vertices().next().unwrap();
-        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cflow_graph.vertex_label(vx) {
+        let vx = func.cflow_graph.node_indices().next().unwrap();
+        if let Some(&CfgNode::BasicBlock(bb_idx)) = func.cflow_graph().node_weight(vx) {
+            let bb = func.basic_block(bb_idx);
+            let mnes = func.mnemonics(bb_idx).collect::<Vec<_>>();
+
             if bb.area.start == 0 {
-                assert_eq!(bb.mnemonics.len(), 3);
-                assert_eq!(bb.mnemonics[0].opcode, "test0".to_string());
-                assert_eq!(bb.mnemonics[0].area, Bound::new(0, 1));
-                assert_eq!(bb.mnemonics[1].opcode, "test1".to_string());
-                assert_eq!(bb.mnemonics[1].area, Bound::new(1, 2));
-                assert_eq!(bb.mnemonics[2].opcode, "test2".to_string());
-                assert_eq!(bb.mnemonics[2].area, Bound::new(2, 3));
-                assert_eq!(bb.area, Bound::new(0, 3));
+                assert_eq!(mnes.len(), 3);
+                assert_eq!(mnes[0].1.opcode, "test0");
+                assert_eq!(mnes[0].1.area, 0..1);
+                assert_eq!(mnes[1].1.opcode, "test1");
+                assert_eq!(mnes[1].1.area, 1..2);
+                assert_eq!(mnes[2].1.opcode, "test2");
+                assert_eq!(mnes[2].1.area, 2..3);
+                assert_eq!(bb.area, 0..3);
             } else {
                 unreachable!();
             }
         }
 
         assert_eq!(func.name, "func_0".to_string());
-        assert_eq!(func.entry_point, Some(vx));
-        assert!(func.cflow_graph.edge(vx, vx).is_some());
+        let entry_idx = func.entry_point();
+        assert_eq!(func.basic_block(entry_idx).node, vx);
+        assert!(func.cflow_graph.find_edge(vx, vx).is_some());
     }
 
     #[test]
-    fn empty() {
+    fn empty_function() {
         let main = new_disassembler!(TestArchShort =>
             [ 0 ] = |st: &mut State<TestArchShort>| {
                 st.mnemonic(1,"test0","",vec!(),&|_| { Ok(vec![]) }).unwrap();
@@ -831,92 +1053,133 @@ mod tests {
 
         let data = OpaqueLayer::wrap(vec![]);
         let reg = Region::new("".to_string(), data);
-        let func = Function::disassemble::<TestArchShort>(None, main, &reg, 0);
-
-        assert_eq!(func.cflow_graph.num_vertices(), 1);
-        assert_eq!(func.cflow_graph.num_edges(), 0);
-        assert_eq!(func.name, "func_0".to_string());
-        assert_eq!(func.entry_point, None);
-
-        let vx = func.cflow_graph.vertices().next().unwrap();
-        if let Some(&ControlFlowTarget::Failed(v, _)) = func.cflow_graph.vertex_label(vx) {
-            assert_eq!(v, 0);
-        }
+        assert!(Function::new::<TestArchShort>(main, 0, &reg, None).is_err());
     }
 
     #[test]
-    fn entry_split() {
-        let bb = BasicBlock::from_vec(vec![Mnemonic::dummy(0..1), Mnemonic::dummy(1..2)]);
-        let mut fun = Function::new("test_func".to_string(), "ram".to_string());
-        let vx0 = fun.cflow_graph.add_vertex(ControlFlowTarget::Resolved(bb));
-        let vx1 = fun.cflow_graph.add_vertex(ControlFlowTarget::Unresolved(Rvalue::new_u32(2)));
-
-        fun.entry_point = Some(vx0);
-        fun.cflow_graph.add_edge(Guard::always(), vx0, vx1);
-
+    fn resolve_indirect() {
+        let _ = env_logger::init();
         let main = new_disassembler!(TestArchShort =>
             [ 0 ] = |st: &mut State<TestArchShort>| {
+                let next = st.address;
                 st.mnemonic(1,"test0","",vec!(),&|_| { Ok(vec![]) }).unwrap();
-                st.jump(Rvalue::new_u32(1),Guard::always()).unwrap();
+                st.jump(Rvalue::new_u64(next + 1),Guard::always()).unwrap();
                 true
             },
             [ 1 ] = |st: &mut State<TestArchShort>| {
+                let next = st.address;
                 st.mnemonic(1,"test1","",vec!(),&|_| { Ok(vec![]) }).unwrap();
-                st.jump(Rvalue::new_u32(2),Guard::always()).unwrap();
+                st.jump(Rvalue::Variable{ name: "A".into(), subscript: None, size: 1, offset: 0 },Guard::always()).unwrap();
                 true
             },
             [ 2 ] = |st: &mut State<TestArchShort>| {
+                let next = st.address;
                 st.mnemonic(1,"test2","",vec!(),&|_| { Ok(vec![]) }).unwrap();
-                st.jump(Rvalue::new_u32(1),Guard::always()).unwrap();
+                st.jump(Rvalue::new_u64(next + 1),Guard::always()).unwrap();
+                true
+            },
+            [ 3 ] = |st: &mut State<TestArchShort>| {
+                let next = st.address;
+                st.mnemonic(1,"test3","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u64(next + 1),Guard::always()).unwrap();
                 true
             }
         );
 
-        let data = OpaqueLayer::wrap(vec![0, 1, 2]);
+        let data = OpaqueLayer::wrap(vec![0, 1, 2, 3, 4, 5]);
         let reg = Region::new("".to_string(), data);
-        let func = Function::disassemble::<TestArchShort>(Some(fun), main, &reg, 2);
+        let mut func = Function::new::<TestArchShort>(main.clone(), 0, &reg, None).unwrap();
 
-        assert_eq!(func.cflow_graph.num_vertices(), 3);
-        assert_eq!(func.cflow_graph.num_edges(), 3);
-        assert_eq!(func.name, "test_func".to_string());
+        assert_eq!(func.cflow_graph().node_count(), 2);
+        assert_eq!(func.cflow_graph().edge_count(), 1);
 
-        let mut bb0_vx = None;
-        let mut bb1_vx = None;
-        let mut bb2_vx = None;
-
-        for vx in func.cflow_graph.vertices() {
-            if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cflow_graph.vertex_label(vx) {
-                if bb.area.start == 0 {
-                    assert_eq!(bb.mnemonics.len(), 1);
-                    assert_eq!(bb.mnemonics[0].opcode, "dummy".to_string());
-                    assert_eq!(bb.mnemonics[0].area, Bound::new(0, 1));
-                    assert_eq!(bb.area, Bound::new(0, 1));
-                    bb0_vx = Some(vx);
-                } else if bb.area.start == 1 {
-                    assert_eq!(bb.mnemonics.len(), 1);
-                    assert_eq!(bb.mnemonics[0].opcode, "dummy".to_string());
-                    assert_eq!(bb.mnemonics[0].area, Bound::new(1, 2));
-                    assert_eq!(bb.area, Bound::new(1, 2));
-                    bb1_vx = Some(vx);
-                } else if bb.area.start == 2 {
-                    assert_eq!(bb.mnemonics.len(), 1);
-                    assert_eq!(bb.mnemonics[0].opcode, "test2".to_string());
-                    assert_eq!(bb.mnemonics[0].area, Bound::new(2, 3));
-                    assert_eq!(bb.area, Bound::new(2, 3));
-                    bb2_vx = Some(vx);
-                } else {
-                    unreachable!();
+        for n in func.cflow_graph().node_indices() {
+            match func.cflow_graph.node_weight(n) {
+                Some(&CfgNode::BasicBlock(bb)) => {
+                    assert_eq!(func.basic_block(bb).area, 0..2);
                 }
-            } else {
-                unreachable!();
+                Some(&CfgNode::Value(Value::Variable(Variable{ ref name, bits: 1, subscript: None }))) if *name == "A" => {}
+                a => unreachable!("got: {:?}",a)
             }
         }
 
-        assert!(bb0_vx.is_some() && bb1_vx.is_some() && bb2_vx.is_some());
-        assert_eq!(func.entry_point, bb0_vx);
-        assert!(func.cflow_graph.edge(bb0_vx.unwrap(), bb1_vx.unwrap()).is_some());
-        assert!(func.cflow_graph.edge(bb1_vx.unwrap(), bb2_vx.unwrap()).is_some());
-        assert!(func.cflow_graph.edge(bb2_vx.unwrap(), bb1_vx.unwrap()).is_some());
+        let unres = func.indirect_jumps().collect::<Vec<_>>();
+        assert_eq!(unres.len(), 1);
+        assert_eq!(unres[0], Variable{ name: "A".into(), bits: 1, subscript: None });
+
+        assert!(func.resolve_indirect_jump(Variable{ name: "A".into(), bits: 1, subscript: None },Constant::new(2,1).unwrap()));
+        assert!(func.extend::<TestArchShort>(main, &reg).is_ok());
+
+        assert_eq!(func.cflow_graph().node_count(), 2);
+        assert_eq!(func.cflow_graph().edge_count(), 1);
+
+        for n in func.cflow_graph().node_indices() {
+            match func.cflow_graph.node_weight(n) {
+                Some(&CfgNode::BasicBlock(bb)) => {
+                    assert_eq!(func.basic_block(bb).area, 0..4);
+                }
+                Some(&CfgNode::Value(Value::Constant(Constant{ value: 4,.. }))) => {}
+                _ => unreachable!()
+            }
+        }
+
+        let unres = func.indirect_jumps().collect::<Vec<_>>();
+        assert_eq!(unres.len(), 0);
+        assert!(!func.resolve_indirect_jump(Variable{ name: "A".into(), bits: 1, subscript: Some(0) },Constant::new(2,1).unwrap()));
+    }
+
+    #[test]
+    fn entry_split() {
+        let _ = env_logger::init();
+        let main = new_disassembler!(TestArchShort =>
+            [ 0 ] = |st: &mut State<TestArchShort>| {
+                let next = st.address;
+                st.mnemonic(1,"test0","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::new_u64(next + 1),Guard::always()).unwrap();
+                true
+            },
+            [ 1 ] = |st: &mut State<TestArchShort>| {
+                let next = st.address;
+                st.mnemonic(1,"test1","",vec!(),&|_| { Ok(vec![]) }).unwrap();
+                st.jump(Rvalue::Variable{ name: "A".into(), subscript: None, size: 1, offset: 0 },Guard::always()).unwrap();
+                true
+            }
+        );
+
+        let data = OpaqueLayer::wrap(vec![0, 1]);
+        let reg = Region::new("".to_string(), data);
+        let mut func = Function::new::<TestArchShort>(main.clone(), 0, &reg, None).unwrap();
+        let unres = func.indirect_jumps().collect::<Vec<_>>();
+        assert_eq!(unres.len(), 1);
+        assert_eq!(unres[0], Variable{ name: "A".into(), bits: 1, subscript: None });
+
+        assert!(func.resolve_indirect_jump(Variable{ name: "A".into(), bits: 1, subscript: None },Constant::new(1,1).unwrap()));
+        assert!(func.extend::<TestArchShort>(main, &reg).is_ok());
+
+        assert_eq!(func.cflow_graph().node_count(), 2);
+        assert_eq!(func.cflow_graph().edge_count(), 1);
+
+        let mut bb0_vx = None;
+        let mut bb1_vx = None;
+
+        for n in func.cflow_graph().node_indices() {
+            match func.cflow_graph.node_weight(n) {
+                Some(&CfgNode::BasicBlock(bb)) => {
+                    if func.basic_block(bb).area == (1..2) {
+                        bb1_vx = Some(n);
+                    } else if func.basic_block(bb).area == (0..1) {
+                        bb0_vx = Some(n);
+                    } else {
+                        unreachable!();
+                    }
+                }
+                _ => unreachable!()
+            }
+        }
+
+        assert!(bb0_vx.is_some() && bb1_vx.is_some());
+        let entry_idx = func.entry_point();
+        assert_eq!(func.basic_block(entry_idx).node, bb0_vx.unwrap());
     }
 
     #[test]
@@ -948,36 +1211,40 @@ mod tests {
             }
         );
 
-        let func = Function::disassemble::<TestArchWide>(None, dec, &reg, 0);
+        let func = Function::new::<TestArchWide>(dec, 0, &reg, None).unwrap();
 
-        assert_eq!(func.cflow_graph.num_vertices(), 3);
-        assert_eq!(func.cflow_graph.num_edges(), 2);
+        assert_eq!(func.cflow_graph.node_count(), 3);
+        assert_eq!(func.cflow_graph.edge_count(), 2);
 
         let mut bb0_vx = None;
         let mut bb1_vx = None;
 
-        for vx in func.cflow_graph.vertices() {
-            match func.cflow_graph.vertex_label(vx) {
-                Some(&ControlFlowTarget::Resolved(ref bb)) => {
+        for vx in func.cflow_graph().node_indices() {
+            match func.cflow_graph().node_weight(vx) {
+                Some(&CfgNode::BasicBlock(bb_idx)) => {
+                    let bb = func.basic_block(bb_idx);
+                    let mnes = func.mnemonics(bb_idx).collect::<Vec<_>>();
+
                     if bb.area.start == 0 {
-                        assert_eq!(bb.mnemonics.len(), 2);
-                        assert_eq!(bb.area, Bound::new(0, 4));
+                        assert_eq!(mnes.len(), 2);
+                        assert_eq!(bb.area, 0..4);
                         bb0_vx = Some(vx);
                     } else if bb.area.start == 4 {
-                        assert_eq!(bb.mnemonics.len(), 1);
-                        assert_eq!(bb.area, Bound::new(4, 6));
+                        assert_eq!(mnes.len(), 1);
+                        assert_eq!(bb.area, 4..6);
                         bb1_vx = Some(vx);
                     } else {
                         unreachable!();
                     }
                 }
-                Some(&ControlFlowTarget::Failed(6, _)) => {}
+                Some(&CfgNode::Value(Value::Constant(Constant{ value: 6,.. }))) => {}
                 _ => unreachable!(),
             }
         }
 
         assert!(bb0_vx.is_some() && bb1_vx.is_some());
-        assert_eq!(func.entry_point, bb0_vx);
+        let entry_idx = func.entry_point();
+        assert_eq!(func.basic_block(entry_idx).node, bb0_vx.unwrap());
     }
 
     #[test]
@@ -1002,23 +1269,26 @@ mod tests {
 
         let data = OpaqueLayer::wrap(vec![0, 1, 2]);
         let reg = Region::new("".to_string(), data);
-        let func = Function::disassemble::<TestArchShort>(None, main, &reg, 1);
+        let func = Function::new::<TestArchShort>(main, 1, &reg, None).unwrap();
 
-        assert_eq!(func.cflow_graph.num_vertices(), 2);
-        assert_eq!(func.cflow_graph.num_edges(), 2);
+        assert_eq!(func.cflow_graph.node_count(), 2);
+        assert_eq!(func.cflow_graph.edge_count(), 2);
 
         let mut bb0_vx = None;
         let mut bb1_vx = None;
 
-        for vx in func.cflow_graph.vertices() {
-            if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cflow_graph.vertex_label(vx) {
+        for vx in func.cflow_graph.node_indices() {
+            if let Some(&CfgNode::BasicBlock(bb_idx)) = func.cflow_graph().node_weight(vx) {
+                let bb = func.basic_block(bb_idx);
+                let mnes = func.mnemonics(bb_idx).collect::<Vec<_>>();
+
                 if bb.area.start == 0 {
-                    assert_eq!(bb.mnemonics.len(), 1);
-                    assert_eq!(bb.area, Bound::new(0, 1));
+                    assert_eq!(mnes.len(), 1);
+                    assert_eq!(bb.area, 0..1);
                     bb0_vx = Some(vx);
                 } else if bb.area.start == 1 {
-                    assert_eq!(bb.mnemonics.len(), 2);
-                    assert_eq!(bb.area, Bound::new(1, 3));
+                    assert_eq!(mnes.len(), 2);
+                    assert_eq!(bb.area, 1..3);
                     bb1_vx = Some(vx);
                 } else {
                     unreachable!();
@@ -1029,9 +1299,10 @@ mod tests {
         }
 
         assert!(bb0_vx.is_some() && bb1_vx.is_some());
-        assert_eq!(func.entry_point, bb1_vx);
-        assert!(func.cflow_graph.edge(bb0_vx.unwrap(), bb1_vx.unwrap()).is_some());
-        assert!(func.cflow_graph.edge(bb1_vx.unwrap(), bb0_vx.unwrap()).is_some());
+        let entry_idx = func.entry_point();
+        assert_eq!(func.basic_block(entry_idx).node, bb1_vx.unwrap());
+        assert!(func.cflow_graph.find_edge(bb0_vx.unwrap(), bb1_vx.unwrap()).is_some());
+        assert!(func.cflow_graph.find_edge(bb1_vx.unwrap(), bb0_vx.unwrap()).is_some());
     }
 
     #[test]
@@ -1056,28 +1327,31 @@ mod tests {
 
         let data = OpaqueLayer::wrap(vec![0, 1, 2]);
         let reg = Region::new("".to_string(), data);
-        let func = Function::disassemble::<TestArchShort>(None, main, &reg, 1);
+        let func = Function::new::<TestArchShort>(main, 1, &reg, None).unwrap();
 
-        assert_eq!(func.cflow_graph.num_vertices(), 3);
-        assert_eq!(func.cflow_graph.num_edges(), 3);
+        assert_eq!(func.cflow_graph.node_count(), 3);
+        assert_eq!(func.cflow_graph.edge_count(), 3);
 
         let mut bb01_vx = None;
         let mut bb1_vx = None;
         let mut bb2_vx = None;
 
-        for vx in func.cflow_graph.vertices() {
-            if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cflow_graph.vertex_label(vx) {
+        for vx in func.cflow_graph().node_indices() {
+            if let Some(&CfgNode::BasicBlock(bb_idx)) = func.cflow_graph().node_weight(vx) {
+                let bb = func.basic_block(bb_idx);
+                let mnes = func.mnemonics(bb_idx).collect::<Vec<_>>();
+
                 if bb.area.start == 0 {
-                    assert_eq!(bb.mnemonics.len(), 1);
-                    assert_eq!(bb.area, Bound::new(0, 2));
+                    assert_eq!(mnes.len(), 1);
+                    assert_eq!(bb.area, 0..2);
                     bb01_vx = Some(vx);
                 } else if bb.area.start == 1 {
-                    assert_eq!(bb.mnemonics.len(), 1);
-                    assert_eq!(bb.area, Bound::new(1, 2));
+                    assert_eq!(mnes.len(), 1);
+                    assert_eq!(bb.area, 1..2);
                     bb1_vx = Some(vx);
                 } else if bb.area.start == 2 {
-                    assert_eq!(bb.mnemonics.len(), 1);
-                    assert_eq!(bb.area, Bound::new(2, 3));
+                    assert_eq!(mnes.len(), 1);
+                    assert_eq!(bb.area, 2..3);
                     bb2_vx = Some(vx);
                 } else {
                     unreachable!();
@@ -1090,9 +1364,15 @@ mod tests {
         assert!(bb01_vx.is_some());
         assert!(bb1_vx.is_some());
         assert!(bb2_vx.is_some());
-        assert_eq!(func.entry_point, bb1_vx);
-        assert!(func.cflow_graph.edge(bb01_vx.unwrap(), bb2_vx.unwrap()).is_some());
-        assert!(func.cflow_graph.edge(bb1_vx.unwrap(), bb2_vx.unwrap()).is_some());
-        assert!(func.cflow_graph.edge(bb2_vx.unwrap(), bb01_vx.unwrap()).is_some());
-    }*/
+        let entry_idx = func.entry_point();
+        assert_eq!(func.basic_block(entry_idx).node, bb1_vx.unwrap());
+        assert!(func.cflow_graph.find_edge(bb01_vx.unwrap(), bb2_vx.unwrap()).is_some());
+        assert!(func.cflow_graph.find_edge(bb1_vx.unwrap(), bb2_vx.unwrap()).is_some());
+        assert!(func.cflow_graph.find_edge(bb2_vx.unwrap(), bb01_vx.unwrap()).is_some());
+    }
+
+    #[test]
+    fn iter_range() {
+        unimplemented!()
+    }
 }

--- a/core/src/neo/function.rs
+++ b/core/src/neo/function.rs
@@ -1,10 +1,13 @@
-use std::ops::{RangeFull,Range};
+#![allow(unused_variables, dead_code)]
+use std::ops::{RangeFull, Range};
 use std::iter::FromIterator;
 use uuid::Uuid;
 use petgraph::Graph;
 use petgraph::graph::{NodeIndices,NodeIndex};
 use petgraph::visit::{Walker,DfsPostOrder};
-use {Architecture,Guard,Region,MnemonicFormatToken,Rvalue,Lvalue};
+use {Fun,FunctionKind,Architecture,Guard,Region,MnemonicFormatToken,Rvalue,Lvalue};
+pub use Result as CResult;
+pub use BasicBlock as CBasicBlock;
 use neo::{Str,Result,Statement,Bitcode,Value,BitcodeIter,Constant,Operation,Variable,Endianess};
 
 mod core {
@@ -132,6 +135,67 @@ pub struct BasicBlockIterator<'a> {
     function: &'a Function,
     index: usize,
     max: usize,
+}
+
+pub struct EasyBasicBlockIterator<'a> {
+    function: &'a Function,
+    range: Range<usize>,
+}
+
+pub struct EasyMnemonicIterator<'a> {
+    function: &'a Function,
+    basic_block: &'a BasicBlock,
+    range: Range<usize>,
+}
+
+impl<'a> Iterator for EasyMnemonicIterator<'a> {
+    type Item = BitcodeIter<'a>;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.range.next() {
+            Some(idx) => {
+                let mne = &self.function.mnemonics[idx];
+                Some(self.function.bitcode.iter_range(mne.statements.clone()))
+            },
+            None => None
+        }
+     }
+}
+
+impl<'a> Iterator for EasyBasicBlockIterator<'a> {
+    type Item = EasyMnemonicIterator<'a>;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.range.next() {
+            Some(idx) => {
+                let basic_block = &self.function.basic_blocks[idx];
+                let mnes = &basic_block.mnemonics;
+                Some(EasyMnemonicIterator {
+                    function: self.function,
+                    basic_block,
+                    range: mnes.start.index..mnes.end.index,
+                })
+            },
+            None => None
+        }
+     }
+}
+
+// get us:
+//
+// for bb in f {
+//   for mne in bb {
+//     for statement in mne {
+//     }
+//   }
+// }
+impl<'a> IntoIterator for &'a Function {
+    type Item = EasyMnemonicIterator<'a>;
+    type IntoIter = EasyBasicBlockIterator<'a>;
+    fn into_iter(self) -> Self::IntoIter {
+       EasyBasicBlockIterator {
+            function: self,
+            range: 0..self.basic_blocks().len(),
+        }
+     }
 }
 
 impl<'a> Iterator for BasicBlockIterator<'a> {
@@ -337,23 +401,97 @@ pub struct Function {
     mnemonics: Vec<Mnemonic>,
     cflow_graph: Graph<CfgNode,Guard>,
     entry_point: BasicBlockIndex,
+    kind: FunctionKind,
+    aliases: Vec<String>,
+}
+
+impl Fun for Function {
+    fn aliases(&self) -> &[String] {
+        self.aliases.as_slice()
+    }
+    fn kind(&self) -> &FunctionKind {
+        &self.kind
+    }
+    fn add_alias(&mut self, name: String) {
+        self.aliases.push(name)
+    }
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn uuid(&self) -> &Uuid {
+        &self.uuid
+    }
+    fn set_uuid(&mut self, uuid: Uuid) {
+        self.uuid = uuid;
+    }
+    fn start(&self) -> u64 {
+        self.entry_address()
+    }
+    fn collect_call_addresses(&self) -> Vec<u64> {
+        self.collect_calls().into_iter().filter_map(|addr| {
+            if let Rvalue::Constant { value, .. } = addr {
+                Some(value)
+            } else {
+                None
+            }
+        }).collect()
+    }
+    fn collect_calls(&self) -> Vec<Rvalue> {
+        let mut ret = Vec::new();
+        for (bb, _) in self.basic_blocks() {
+            for statement in self.statements(bb) {
+                match statement {
+                    Statement::IndirectCall { target: Value::Constant(Constant { value, bits }) } => {
+                        ret.push(Rvalue::Constant {value, size: bits })
+                    },
+                    _ => ()
+                }
+            }
+        }
+        debug!("collected calls: {:?}", ret);
+        ret
+    }
+    fn statements<'a>(&'a self) -> Box<Iterator<Item=&'a core::Statement> + 'a> {
+        Box::new(vec![].into_iter())
+        //Function::statements(self)
+    }
+    fn set_plt(&mut self, name: &str, plt_address: u64) {
+        let old_name = self.name.clone().to_string();
+        self.aliases.push(old_name);
+        self.name = format!("{}@plt", name).into();
+        self.kind = FunctionKind::Stub { name: name.to_string(), plt_address };
+    }
+    fn new<A: Architecture>(start: u64, region: &Region, name: Option<String>, init: A::Configuration) -> CResult<Function> {
+        let name_ = name.clone();
+        let name = name.map(|name| ::std::borrow::Cow::Owned(name));
+        match Function::new::<A>(init, start, region, name) {
+            Ok(f) => Ok(f),
+            Err(e) => {
+                let msg = format!("Error disassembling: {:?} with {}", name_, e);
+                warn!("{}", msg);
+                Err(msg.into())
+            }
+        }
+    }
 }
 
 impl Function {
 	// disassembly
     pub fn new<A: Architecture>(init: A::Configuration, start: u64, region: &Region, name: Option<Str>) -> Result<Function>
-    where A: Debug, A::Configuration: Debug {
+    {
         let mut mnemonics = Vec::new();
         let mut by_source = HashMap::new();
         let mut by_destination = HashMap::new();
         let mut func = Function{
-            name: name.unwrap_or("(none)".into()),
+            name: name.unwrap_or(format!("func_{:x}", start).into()),
             uuid: Uuid::new_v4(),
             bitcode: Bitcode::default(),
             basic_blocks: Vec::new(),
             mnemonics: Vec::new(),
             cflow_graph: Graph::new(),
             entry_point: BasicBlockIndex::new(0),
+            kind: FunctionKind::Regular,
+            aliases: vec![],
         };
 
         disassemble::<A>(init,vec![start],region, &mut mnemonics, &mut by_source, &mut by_destination)?;
@@ -420,12 +558,24 @@ impl Function {
         }
     }
 
+    pub fn mnemonics_for(&self, bb: &BasicBlock) -> MnemonicIterator {
+        MnemonicIterator {
+            function: self,
+            index: bb.mnemonics.start.index,
+            max: bb.mnemonics.end.index - 1,
+        }
+    }
+
     pub fn basic_blocks<'a>(&'a self) -> BasicBlockIterator<'a> {
         BasicBlockIterator{
             function: self,
             index: 0,
             max: self.basic_blocks.len() - 1
         }
+    }
+
+    pub fn bitcode_size(&self) -> usize {
+        self.bitcode.num_bytes()
     }
 
     pub fn cflow_graph<'a>(&'a self) -> &'a Graph<CfgNode,Guard> {
@@ -527,7 +677,7 @@ fn disassemble<A: Architecture>(init: A::Configuration, starts: Vec<u64>, region
                                 mnemonics: &mut Vec<(Mnemonic,Vec<Statement>)>,
                                 by_source: &mut HashMap<u64,Vec<(Value,Guard)>>,
                                 by_destination: &mut HashMap<u64,Vec<(Value,Guard)>>) -> Result<()>
-where A: Debug, A::Configuration: Debug {
+{
     let mut todo = HashSet::<u64>::from_iter(starts.into_iter());
 
     while let Some(addr) = todo.iter().next().cloned() {
@@ -685,7 +835,6 @@ fn assemble_function(function: &mut Function, entry: u64, mut mnemonics: Vec<(Mn
         }
     }
 
-    function.name = format!("func_{:x}",entry).into();
     function.bitcode = bitcode;
     function.basic_blocks = basic_blocks;
     function.mnemonics = mnemonics.into_iter().enumerate().map(|(idx,(mut mne,_))| {
@@ -694,7 +843,8 @@ fn assemble_function(function: &mut Function, entry: u64, mut mnemonics: Vec<(Mn
     }).collect();
     function.cflow_graph = cfg;
     function.entry_point = BasicBlockIndex::new(entry_idx);
-
+    // we erase the functions name this way; need to keep track of whether we actually have a name or not
+    //if entry != function.start_address() { function.name = format!("func_{:x}",entry).into() };
     Ok(())
 }
 
@@ -833,7 +983,10 @@ fn to_statement(stmt: &core::Statement) -> Statement {
         }
 
 
-        _ => unimplemented!("{:?}",stmt)
+        _ => {
+            warn!("No implemented {:?}", stmt);
+            unimplemented!();
+        }
     }
 }
 

--- a/core/src/neo/il.rs
+++ b/core/src/neo/il.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 use uuid::Uuid;
+use smallvec::SmallVec;
 
 use neo::value::{Value,Variable};
 use neo::Str;
@@ -74,37 +75,86 @@ pub enum Operation<V>
 }
 
 impl<V> Operation<V> where V: Clone + PartialEq + Eq + Debug {
-    pub fn reads<'x>(&'x self) -> Vec<&'x V> {
+    pub fn reads<'x>(&'x self) -> SmallVec<[&'x V; 3]> {
+        use neo::Operation::*;
+
+        let mut ret = SmallVec::new();
+
         match self {
-            &Operation::Add(ref a, ref b) => vec![a,b],
-            &Operation::Subtract(ref a, ref b) => vec![a,b],
-            &Operation::Multiply(ref a, ref b) => vec![a,b],
-            &Operation::DivideUnsigned(ref a, ref b) => vec![a,b],
-            &Operation::DivideSigned(ref a, ref b) => vec![a,b],
-            &Operation::ShiftLeft(ref a, ref b) => vec![a,b],
-            &Operation::ShiftRightUnsigned(ref a, ref b) => vec![a,b],
-            &Operation::ShiftRightSigned(ref a, ref b) => vec![a,b],
-            &Operation::Modulo(ref a, ref b) => vec![a,b],
-            &Operation::And(ref a, ref b) => vec![a,b],
-            &Operation::InclusiveOr(ref a, ref b) => vec![a,b],
-            &Operation::ExclusiveOr(ref a, ref b) => vec![a,b],
+            &Add(ref a, ref b) => { ret.push(a); ret.push(b); }
+            &Subtract(ref a, ref b) => { ret.push(a); ret.push(b); }
+            &Multiply(ref a, ref b) => { ret.push(a); ret.push(b); }
+            &DivideUnsigned(ref a, ref b) => { ret.push(a); ret.push(b); }
+            &DivideSigned(ref a, ref b) => { ret.push(a); ret.push(b); }
+            &ShiftLeft(ref a, ref b) => { ret.push(a); ret.push(b); }
+            &ShiftRightUnsigned(ref a, ref b) => { ret.push(a); ret.push(b); }
+            &ShiftRightSigned(ref a, ref b) => { ret.push(a); ret.push(b); }
+            &Modulo(ref a, ref b) => { ret.push(a); ret.push(b); }
+            &And(ref a, ref b) => { ret.push(a); ret.push(b); }
+            &InclusiveOr(ref a, ref b) => { ret.push(a); ret.push(b); }
+            &ExclusiveOr(ref a, ref b) => { ret.push(a); ret.push(b); }
 
-            &Operation::Equal(ref a, ref b) => vec![a,b],
-            &Operation::LessOrEqualUnsigned(ref a, ref b) => vec![a,b],
-            &Operation::LessOrEqualSigned(ref a, ref b) => vec![a,b],
-            &Operation::LessUnsigned(ref a, ref b) => vec![a,b],
-            &Operation::LessSigned(ref a, ref b) => vec![a,b],
+            &Equal(ref a, ref b) => { ret.push(a); ret.push(b); }
+            &LessOrEqualUnsigned(ref a, ref b) => { ret.push(a); ret.push(b); }
+            &LessOrEqualSigned(ref a, ref b) => { ret.push(a); ret.push(b); }
+            &LessUnsigned(ref a, ref b) => { ret.push(a); ret.push(b); }
+            &LessSigned(ref a, ref b) => { ret.push(a); ret.push(b); }
 
-            &Operation::ZeroExtend(_, ref a) => vec![a],
-            &Operation::SignExtend(_, ref a) => vec![a],
-            &Operation::Move(ref a) => vec![a],
-            &Operation::Initialize(_,_) => vec![],
-            &Operation::Select(_, ref a, ref b) => vec![a,b],
+            &ZeroExtend(_, ref a) => { ret.push(a); }
+            &SignExtend(_, ref a) => { ret.push(a); }
+            &Move(ref a) => { ret.push(a); }
+            &Initialize(_,_) => {}
+            &Select(_, ref a, ref b) => { ret.push(a); ret.push(b); }
 
-            &Operation::Load(_, _, _, ref a) => vec![a],
+            &Load(_, _, _, ref a) => { ret.push(a); }
 
-            &Operation::Phi(ref a, ref b, ref c) => vec![a, b, c],
+            &Phi(ref a, ref b, ref c) => {
+                ret.push(a); ret.push(b); ret.push(c);
+            }
         }
+
+        ret
+    }
+
+    pub fn reads_mut<'x>(&'x mut self) -> SmallVec<[&'x mut V; 3]> {
+        use neo::Operation::*;
+
+        let mut ret = SmallVec::new();
+
+        match self {
+            &mut Add(ref mut a, ref mut b) => { ret.push(a); ret.push(b); }
+            &mut Subtract(ref mut a, ref mut b) => { ret.push(a); ret.push(b); }
+            &mut Multiply(ref mut a, ref mut b) => { ret.push(a); ret.push(b); }
+            &mut DivideUnsigned(ref mut a, ref mut b) => { ret.push(a); ret.push(b); }
+            &mut DivideSigned(ref mut a, ref mut b) => { ret.push(a); ret.push(b); }
+            &mut ShiftLeft(ref mut a, ref mut b) => { ret.push(a); ret.push(b); }
+            &mut ShiftRightUnsigned(ref mut a, ref mut b) => { ret.push(a); ret.push(b); }
+            &mut ShiftRightSigned(ref mut a, ref mut b) => { ret.push(a); ret.push(b); }
+            &mut Modulo(ref mut a, ref mut b) => { ret.push(a); ret.push(b); }
+            &mut And(ref mut a, ref mut b) => { ret.push(a); ret.push(b); }
+            &mut InclusiveOr(ref mut a, ref mut b) => { ret.push(a); ret.push(b); }
+            &mut ExclusiveOr(ref mut a, ref mut b) => { ret.push(a); ret.push(b); }
+
+            &mut Equal(ref mut a, ref mut b) => { ret.push(a); ret.push(b); }
+            &mut LessOrEqualUnsigned(ref mut a, ref mut b) => { ret.push(a); ret.push(b); }
+            &mut LessOrEqualSigned(ref mut a, ref mut b) => { ret.push(a); ret.push(b); }
+            &mut LessUnsigned(ref mut a, ref mut b) => { ret.push(a); ret.push(b); }
+            &mut LessSigned(ref mut a, ref mut b) => { ret.push(a); ret.push(b); }
+
+            &mut ZeroExtend(_, ref mut a) => { ret.push(a); }
+            &mut SignExtend(_, ref mut a) => { ret.push(a); }
+            &mut Move(ref mut a) => { ret.push(a); }
+            &mut Initialize(_,_) => {}
+            &mut Select(_, ref mut a, ref mut b) => { ret.push(a); ret.push(b); }
+
+            &mut Load(_, _, _, ref mut a) => { ret.push(a); }
+
+            &mut Phi(ref mut a, ref mut b, ref mut c) => {
+                ret.push(a); ret.push(b); ret.push(c);
+            }
+        }
+
+        ret
     }
 }
 

--- a/core/src/neo/il.rs
+++ b/core/src/neo/il.rs
@@ -73,6 +73,41 @@ pub enum Operation<V>
     Phi(V,V,V),
 }
 
+impl<V> Operation<V> where V: Clone + PartialEq + Eq + Debug {
+    pub fn reads<'x>(&'x self) -> Vec<&'x V> {
+        match self {
+            &Operation::Add(ref a, ref b) => vec![a,b],
+            &Operation::Subtract(ref a, ref b) => vec![a,b],
+            &Operation::Multiply(ref a, ref b) => vec![a,b],
+            &Operation::DivideUnsigned(ref a, ref b) => vec![a,b],
+            &Operation::DivideSigned(ref a, ref b) => vec![a,b],
+            &Operation::ShiftLeft(ref a, ref b) => vec![a,b],
+            &Operation::ShiftRightUnsigned(ref a, ref b) => vec![a,b],
+            &Operation::ShiftRightSigned(ref a, ref b) => vec![a,b],
+            &Operation::Modulo(ref a, ref b) => vec![a,b],
+            &Operation::And(ref a, ref b) => vec![a,b],
+            &Operation::InclusiveOr(ref a, ref b) => vec![a,b],
+            &Operation::ExclusiveOr(ref a, ref b) => vec![a,b],
+
+            &Operation::Equal(ref a, ref b) => vec![a,b],
+            &Operation::LessOrEqualUnsigned(ref a, ref b) => vec![a,b],
+            &Operation::LessOrEqualSigned(ref a, ref b) => vec![a,b],
+            &Operation::LessUnsigned(ref a, ref b) => vec![a,b],
+            &Operation::LessSigned(ref a, ref b) => vec![a,b],
+
+            &Operation::ZeroExtend(_, ref a) => vec![a],
+            &Operation::SignExtend(_, ref a) => vec![a],
+            &Operation::Move(ref a) => vec![a],
+            &Operation::Initialize(_,_) => vec![],
+            &Operation::Select(_, ref a, ref b) => vec![a,b],
+
+            &Operation::Load(_, _, _, ref a) => vec![a],
+
+            &Operation::Phi(ref a, ref b, ref c) => vec![a, b, c],
+        }
+    }
+}
+
 #[derive(Clone,PartialEq,Eq,Debug)]
 pub enum CallTarget {
     Function(Uuid),

--- a/core/src/neo/il.rs
+++ b/core/src/neo/il.rs
@@ -1,0 +1,298 @@
+use std::fmt::Debug;
+use uuid::Uuid;
+
+use neo::value::{Value,Variable};
+use neo::Str;
+
+#[derive(Debug,Clone,Copy,PartialEq,Eq)]
+pub enum Endianess {
+    Little,
+    Big,
+}
+
+/// A RREIL operation.
+#[derive(Clone,PartialEq,Eq,Debug)]
+pub enum Operation<V>
+    where V: Clone + PartialEq + Eq + Debug
+{
+    /// Integer addition
+    Add(V, V),
+    /// Integer subtraction
+    Subtract(V, V),
+    /// Unsigned integer multiplication
+    Multiply(V, V),
+    /// Unsigned integer division
+    DivideUnsigned(V, V),
+    /// Signed integer division
+    DivideSigned(V, V),
+    /// Bitwise left shift
+    ShiftLeft(V, V),
+    /// Bitwise logical right shift
+    ShiftRightUnsigned(V, V),
+    /// Bitwise arithmetic right shift
+    ShiftRightSigned(V, V),
+    /// Integer modulo
+    Modulo(V, V),
+    /// Bitwise logical and
+    And(V, V),
+    /// Bitwise logical or
+    InclusiveOr(V, V),
+    /// Bitwise logical xor
+    ExclusiveOr(V, V),
+
+    /// Compare both operands for equality and returns `1` or `0`
+    Equal(V, V),
+    /// Returns `1` if the first operand is less than or equal to the second and `0` otherwise.
+    /// Comparison assumes unsigned values.
+    LessOrEqualUnsigned(V, V),
+    /// Returns `1` if the first operand is less than or equal to the second and `0` otherwise.
+    /// Comparison assumes signed values.
+    LessOrEqualSigned(V, V),
+    /// Returns `1` if the first operand is less than the second and `0` otherwise.
+    /// Comparison assumes unsigned values.
+    LessUnsigned(V, V),
+    /// Returns `1` if the first operand is less than the second and `0` otherwise.
+    /// Comparison assumes signed values.
+    LessSigned(V, V),
+
+    /// Zero extends the operand.
+    ZeroExtend(usize, V),
+    /// Sign extends the operand.
+    SignExtend(usize, V),
+    /// Copies the operand without modification.
+    Move(V),
+    /// Initializes a global variable.
+    Initialize(Str,usize),
+    /// Copies only a range of bit from the operand.
+    Select(usize, V, V),
+
+    /// Reads a memory cell
+    Load(Str,Endianess,usize,V),
+
+    /// SSA Phi function
+    Phi(V,V,V),
+}
+
+#[derive(Clone,PartialEq,Eq,Debug)]
+pub enum CallTarget {
+    Function(Uuid),
+    External(Str),
+}
+
+#[derive(Clone,PartialEq,Eq,Debug)]
+pub enum Statement {
+    /// A single RREIL statement.
+    Expression{
+        /// Value that the operation result is assigned to
+        result: Variable,
+        /// Operation and its arguments
+        op: Operation<Value>,
+    },
+    /// Function call
+    Call{
+        function: CallTarget,
+    },
+    IndirectCall{
+        /// Call target
+        target: Value,
+    },
+    Return,
+    /// Writes a memory cell
+    Store{
+        region: Str,
+        endianess: Endianess,
+        bytes: usize,
+        address: Value,
+        value: Value,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quickcheck::{Arbitrary,Gen};
+
+    impl Arbitrary for Endianess {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            match g.gen_range(0, 1) {
+                0 => Endianess::Little,
+                1 => Endianess::Big,
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    impl Arbitrary for Operation<Value> {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            loop {
+                let op = match g.gen_range(0, 25) {
+                    0 => Operation::Add(Value::arbitrary(g), Value::arbitrary(g)),
+                    1 => Operation::Subtract(Value::arbitrary(g), Value::arbitrary(g)),
+                    2 => Operation::Multiply(Value::arbitrary(g), Value::arbitrary(g)),
+                    3 => Operation::DivideUnsigned(Value::arbitrary(g), Value::arbitrary(g)),
+                    4 => Operation::DivideSigned(Value::arbitrary(g), Value::arbitrary(g)),
+                    5 => Operation::ShiftLeft(Value::arbitrary(g), Value::arbitrary(g)),
+                    6 => Operation::ShiftRightUnsigned(Value::arbitrary(g), Value::arbitrary(g)),
+                    7 => Operation::ShiftRightSigned(Value::arbitrary(g), Value::arbitrary(g)),
+                    8 => Operation::Modulo(Value::arbitrary(g), Value::arbitrary(g)),
+                    9 => Operation::And(Value::arbitrary(g), Value::arbitrary(g)),
+                    10 => Operation::InclusiveOr(Value::arbitrary(g), Value::arbitrary(g)),
+                    11 => Operation::ExclusiveOr(Value::arbitrary(g), Value::arbitrary(g)),
+
+                    12 => Operation::Equal(Value::arbitrary(g), Value::arbitrary(g)),
+                    13 => Operation::LessOrEqualUnsigned(Value::arbitrary(g), Value::arbitrary(g)),
+                    14 => Operation::LessOrEqualSigned(Value::arbitrary(g), Value::arbitrary(g)),
+                    15 => Operation::LessUnsigned(Value::arbitrary(g), Value::arbitrary(g)),
+                    16 => Operation::LessSigned(Value::arbitrary(g), Value::arbitrary(g)),
+
+                    17 => Operation::ZeroExtend(g.gen(), Value::arbitrary(g)),
+                    18 => Operation::SignExtend(g.gen(), Value::arbitrary(g)),
+
+                    19 => Operation::Move(Value::arbitrary(g)),
+                    20 => Operation::Initialize(g.gen_ascii_chars().take(1).collect(),g.gen()),
+
+                    21 => Operation::Select(g.gen(), Value::arbitrary(g), Value::arbitrary(g)),
+
+                    22 => Operation::Load(g.gen_ascii_chars().take(1).collect(), Endianess::arbitrary(g), g.gen(), Value::arbitrary(g)),
+
+                    23 => {
+                        // XXX: make sizes equal?
+                        let a = Value::arbitrary(g);
+                        let b = Value::arbitrary(g);
+                        Operation::Phi(a,b,Value::undef())
+                    }
+                    24 => {
+                        let a = Value::arbitrary(g);
+                        let b = Value::arbitrary(g);
+                        let c = Value::arbitrary(g);
+                        Operation::Phi(a,b,c)
+                    }
+
+                    _ => unreachable!(),
+                };
+
+                match op {
+                    Operation::Add(Value::Undefined, Value::Undefined) => {}
+                    Operation::Subtract(Value::Undefined, Value::Undefined) => {}
+                    Operation::Multiply(Value::Undefined, Value::Undefined) => {}
+                    Operation::DivideUnsigned(Value::Undefined, Value::Undefined) => {}
+                    Operation::DivideSigned(Value::Undefined, Value::Undefined) => {}
+                    Operation::Modulo(Value::Undefined, Value::Undefined) => {}
+                    Operation::ShiftLeft(Value::Undefined, Value::Undefined) => {}
+                    Operation::ShiftRightUnsigned(Value::Undefined, Value::Undefined) => {}
+                    Operation::ShiftRightSigned(Value::Undefined, Value::Undefined) => {}
+                    Operation::And(Value::Undefined, Value::Undefined) => {}
+                    Operation::InclusiveOr(Value::Undefined, Value::Undefined) => {}
+                    Operation::ExclusiveOr(Value::Undefined, Value::Undefined) => {}
+                    Operation::Equal(Value::Undefined, Value::Undefined) => {}
+                    Operation::LessOrEqualUnsigned(Value::Undefined, Value::Undefined) => {}
+                    Operation::LessOrEqualSigned(Value::Undefined, Value::Undefined) => {}
+                    Operation::LessUnsigned(Value::Undefined, Value::Undefined) => {}
+                    Operation::LessSigned(Value::Undefined, Value::Undefined) => {}
+                    Operation::ZeroExtend(_, Value::Undefined) => {}
+                    Operation::SignExtend(_, Value::Undefined) => {}
+                    Operation::Select(_, Value::Undefined, _) => {}
+                    Operation::Select(_, _, Value::Undefined) => {}
+                    Operation::Phi(Value::Undefined, _, _) => {}
+                    Operation::Phi(_, Value::Undefined, _) => {}
+                    Operation::Phi(Value::Constant(_), _, _) => {}
+                    Operation::Phi(_, Value::Constant(_), _) => {}
+                    Operation::Phi(_, _, Value::Constant(_)) => {}
+
+                    _ => { return op; }
+                }
+            }
+
+
+
+            /*
+               match op {
+               Operation::Add(_, _) |
+               Operation::Subtract(_, _) |
+               Operation::Multiply(_, _) |
+               Operation::DivideUnsigned(_, _) |
+               Operation::DivideSigned(_, _) |
+               Operation::Modulo(_, _) |
+               Operation::ShiftLeft(_, _) |
+               Operation::ShiftRightUnsigned(_, _) |
+               Operation::ShiftRightSigned(_, _) |
+               Operation::And(_, _) |
+               Operation::InclusiveOr(_, _) |
+               Operation::ExclusiveOr(_, _) |
+               Operation::Equal(_, _) |
+               Operation::LessOrEqualUnsigned(_, _) |
+               Operation::LessOrEqualSigned(_, _) |
+               Operation::LessUnsigned(_, _) |
+               Operation::LessSigned(_, _) => {
+               let mut sz = None;
+               for o in op.operands_mut() {
+               if sz.is_none() {
+               sz = o.bits();
+               } else {
+               match o {
+               &mut Value::Undefined => {}
+               &mut Value::Constant(Constant { ref mut bits, .. }) => *bits = sz.unwrap(),
+               &mut Value::Variable(Variable { ref mut bits, .. }) => *bits = sz.unwrap(),
+               }
+               }
+               }
+               }
+               Operation::Select(ref mut off, ref mut rv1, ref mut rv2) => {
+               if let (Some(sz1), Some(sz2)) = (rv1.bits(), rv2.bits()) {
+               if sz2 > sz1 {
+               let t2 = rv1.clone();
+             *rv1 = rv2.clone();
+             *rv2 = t2;
+             }
+             }
+             if let (Some(sz1), Some(sz2)) = (rv1.bits(), rv2.bits()) {
+             *off = g.gen_range(0, sz1 - sz2 + 1);
+             }
+             }
+             _ => {}
+             }*/
+        }
+    }
+
+    impl Arbitrary for CallTarget {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            match g.gen_range(0, 2) {
+                0 => CallTarget::Function(Uuid::new_v4()),
+                1 => CallTarget::External(g.gen_ascii_chars().take(1).collect()),
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    impl Arbitrary for Statement {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            match g.gen_range(0, 5) {
+                0 => Statement::Expression{
+                    result: Variable::arbitrary(g),
+                    op: Operation::<Value>::arbitrary(g),
+                },
+                1 => Statement::Call{ function: CallTarget::arbitrary(g) },
+                2 => Statement::IndirectCall{ target: Value::arbitrary(g) },
+                3 => Statement::Return,
+                4 => {
+                    let mut addr = Value::arbitrary(g);
+                    let mut val = Value::arbitrary(g);
+
+                    while addr == Value::Undefined && val == Value::Undefined {
+                        addr = Value::arbitrary(g);
+                        val = Value::arbitrary(g);
+                    }
+
+                    Statement::Store{
+                        region: g.gen_ascii_chars().take(1).collect::<String>().into(),
+                        endianess: Endianess::arbitrary(g),
+                        bytes: g.gen_range(1,11),
+                        address: addr,
+                        value: val,
+                    }
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
+}

--- a/core/src/neo/mod.rs
+++ b/core/src/neo/mod.rs
@@ -17,7 +17,7 @@ pub use neo::errors::*;
 pub use self::il::{Operation,Statement,Endianess,CallTarget};
 pub use self::value::{Variable,Constant,Value};
 pub use self::bitcode::{Bitcode,BitcodeIter};
-pub use self::function::{Function};
+pub use self::function::{Function,CfgNode,Mnemonic,BasicBlock,BasicBlockIndex};
 
 use std::borrow::Cow;
 pub type Str = Cow<'static,str>;

--- a/core/src/neo/mod.rs
+++ b/core/src/neo/mod.rs
@@ -1,4 +1,3 @@
-#![recursion_limit = "1024"]
 
 mod value;
 mod il;
@@ -13,7 +12,7 @@ mod errors {
         }
     }
 }
-use neo::errors::*;
+pub use neo::errors::*;
 
 pub use self::il::{Operation,Statement,Endianess,CallTarget};
 pub use self::value::{Variable,Constant,Value};
@@ -22,4 +21,3 @@ pub use self::function::{Function};
 
 use std::borrow::Cow;
 pub type Str = Cow<'static,str>;
-

--- a/core/src/neo/mod.rs
+++ b/core/src/neo/mod.rs
@@ -1,0 +1,25 @@
+#![recursion_limit = "1024"]
+
+mod value;
+mod il;
+mod bitcode;
+mod function;
+mod errors {
+    error_chain!{
+        foreign_links {
+            Fmt(::std::fmt::Error);
+            Io(::std::io::Error);
+            Leb128(::leb128::read::Error);
+        }
+    }
+}
+use neo::errors::*;
+
+pub use self::il::{Operation,Statement,Endianess,CallTarget};
+pub use self::value::{Variable,Constant,Value};
+pub use self::bitcode::{Bitcode,BitcodeIter};
+pub use self::function::{Function};
+
+use std::borrow::Cow;
+pub type Str = Cow<'static,str>;
+

--- a/core/src/neo/mod.rs
+++ b/core/src/neo/mod.rs
@@ -17,7 +17,7 @@ pub use neo::errors::*;
 pub use self::il::{Operation,Statement,Endianess,CallTarget};
 pub use self::value::{Variable,Constant,Value};
 pub use self::bitcode::{Bitcode,BitcodeIter};
-pub use self::function::{Function,CfgNode,Mnemonic,BasicBlock,BasicBlockIndex};
+pub use self::function::{Function, CfgNode, Mnemonic, MnemonicIndex, MnemonicIterator, BasicBlockIterator, BasicBlock, BasicBlockIndex};
 
 use std::borrow::Cow;
 pub type Str = Cow<'static,str>;

--- a/core/src/neo/value.rs
+++ b/core/src/neo/value.rs
@@ -1,0 +1,138 @@
+use std::borrow::Cow;
+use neo::{Result,Str};
+use {Rvalue,Lvalue};
+
+#[derive(Clone,PartialEq,Eq,Debug)]
+pub struct Variable {
+    pub name: Str,
+    pub bits: usize,
+    pub subscript: Option<usize>,
+}
+
+impl Variable {
+    pub fn new<N: Into<Str> + Sized>(name: N, bits: usize, subscript: Option<usize>) -> Result<Variable> {
+        let name: Str = name.into();
+
+        if bits == 0 { return Err("Variable can't have size 0".into()); }
+        if name == "" { return Err("Variable can't have an empty name".into()); }
+
+        Ok(Variable{
+            name: name,
+            subscript: subscript,
+            bits: bits
+        })
+    }
+}
+
+#[derive(Clone,PartialEq,Eq,Debug)]
+pub struct Constant {
+    pub value: u64,
+    pub bits: usize,
+}
+
+impl Constant {
+    pub fn new(value: u64, bits: usize) -> Result<Constant> {
+        if bits == 0 { return Err("Variable can't have size 0".into()); }
+
+        Ok(Constant{
+            value: value,
+            bits: bits
+        })
+    }
+}
+
+#[derive(Clone,PartialEq,Eq,Debug)]
+pub enum Value {
+    Undefined,
+    Variable(Variable),
+    Constant(Constant),
+}
+
+impl Value {
+    pub fn val(val: u64, bits: usize) -> Result<Value> {
+        Ok(Value::Constant(Constant::new(val,bits)?))
+    }
+
+    pub fn var<N: Into<Str> + Sized>(name: N, bits: usize, subscript: Option<usize>) -> Result<Value> {
+        Ok(Value::Variable(Variable::new(name,bits,subscript)?))
+    }
+
+    pub fn undef() -> Value {
+        Value::Undefined
+    }
+
+    pub fn bits(&self) -> Option<usize> {
+        match self {
+            &Value::Variable(Variable{ bits,.. }) => Some(bits),
+            &Value::Constant(Constant{ bits,.. }) => Some(bits),
+            &Value::Undefined => None,
+        }
+    }
+}
+
+impl From<Variable> for Value {
+    fn from(v: Variable) -> Value {
+        Value::Variable(v)
+    }
+}
+
+impl From<Constant> for Value {
+    fn from(v: Constant) -> Value {
+        Value::Constant(v)
+    }
+}
+
+impl From<Rvalue> for Value {
+    fn from(v: Rvalue) -> Value {
+        match v {
+            Rvalue::Undefined => Value::undef(),
+            Rvalue::Variable{ name, subscript, size,.. } => Value::var(name,size,subscript).unwrap(),
+            Rvalue::Constant{ value, size } => Value::val(value,size).unwrap(),
+        }
+    }
+}
+
+impl From<Lvalue> for Value {
+    fn from(v: Lvalue) -> Value {
+        match v {
+            Lvalue::Undefined => Value::undef(),
+            Lvalue::Variable{ name, subscript, size,.. } => Value::var(name,size,subscript).unwrap(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quickcheck::{Arbitrary,Gen};
+
+     impl Arbitrary for Variable {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            Variable {
+                name: Cow::Owned(g.gen_ascii_chars().take(2).collect()),
+                bits: 1 << g.gen_range(0, 11),
+                subscript: Some(g.gen_range(0, 5)),
+            }
+        }
+    }
+
+    impl Arbitrary for Constant {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            Constant{
+                value: g.gen(),
+                bits: 1 << g.gen_range(0, 11),
+            }
+        }
+    }
+
+    impl Arbitrary for Value {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            match g.gen_range(0, 2) {
+                0 => Value::Undefined,
+                1 => Value::Variable(Variable::arbitrary(g)),
+                2 => Value::Constant(Constant::arbitrary(g)),
+                _ => unreachable!(),
+            }
+        }
+    }
+}

--- a/core/src/neo/value.rs
+++ b/core/src/neo/value.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use neo::{Result,Str};
 use {Rvalue,Lvalue};
 
@@ -104,6 +103,7 @@ impl From<Lvalue> for Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::borrow::Cow;
     use quickcheck::{Arbitrary,Gen};
 
      impl Arbitrary for Variable {

--- a/core/src/neo/value.rs
+++ b/core/src/neo/value.rs
@@ -52,8 +52,8 @@ impl Value {
         Ok(Value::Constant(Constant::new(val,bits)?))
     }
 
-    pub fn var<N: Into<Str> + Sized>(name: N, bits: usize, subscript: Option<usize>) -> Result<Value> {
-        Ok(Value::Variable(Variable::new(name,bits,subscript)?))
+    pub fn var<N: Into<Str> + Sized, S: Into<Option<usize>> + Sized>(name: N, bits: usize, subscript: S) -> Result<Value> {
+        Ok(Value::Variable(Variable::new(name,bits,subscript.into())?))
     }
 
     pub fn undef() -> Value {

--- a/core/src/project.rs
+++ b/core/src/project.rs
@@ -21,7 +21,7 @@
 //! Projects are a set of `Program`s, associated memory `Region`s and comments.
 
 
-use {CallGraphRef, Function, Program, Region, Result, World};
+use {CallGraphRef, Fun, Program, Region, Result, World};
 use panopticon_graph_algos::GraphTrait;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use flate2::Compression;
@@ -39,11 +39,11 @@ use uuid::Uuid;
 
 /// Complete Panopticon session
 #[derive(Serialize,Deserialize,Debug)]
-pub struct Project {
+pub struct Project<F> {
     /// Human-readable name
     pub name: String,
     /// Recognized code
-    pub code: Vec<Program>,
+    pub code: Vec<Program<F>>,
     /// Memory regions
     pub data: World,
     /// Comments
@@ -52,26 +52,9 @@ pub struct Project {
     pub imports: HashMap<u64, String>,
 }
 
-impl Project {
-    /// Returns a new `Project` named `s` from memory `Region` `r`.
-    pub fn new(s: String, r: Region) -> Project {
-        Project {
-            name: s,
-            code: Vec::new(),
-            data: World::new(r),
-            comments: HashMap::new(),
-            imports: HashMap::new(),
-        }
-    }
-
-    /// Returns this project's root Region
-    pub fn region(&self) -> &Region {
-        // this cannot fail because World::new guarantees that data.root = r
-        self.data.dependencies.vertex_label(self.data.root).unwrap()
-    }
-
+impl<'de, F: Fun + Deserialize<'de> + Serialize> Project<F> {
     /// Reads a serialized project from disk.
-    pub fn open(p: &Path) -> Result<Project> {
+    pub fn open(p: &Path) -> Result<Self> {
         let mut fd = match File::open(p) {
             Ok(fd) => fd,
             Err(e) => return Err(format!("failed to open file: {:?}", e).into()),
@@ -94,60 +77,6 @@ impl Project {
         }
     }
 
-    /// Returns the program with UUID `uu`
-    pub fn find_program_by_uuid(&self, uu: &Uuid) -> Option<&Program> {
-        self.code.iter().find(|x| x.uuid == *uu)
-    }
-
-    /// Returns the program with UUID `uu`
-    pub fn find_program_by_uuid_mut(&mut self, uu: &Uuid) -> Option<&mut Program> {
-        self.code.iter_mut().find(|x| x.uuid == *uu)
-    }
-
-    /// Returns function and enclosing program with UUID `uu`
-    pub fn find_function_by_uuid<'a>(&'a self, uu: &Uuid) -> Option<&'a Function> {
-        for p in self.code.iter() {
-            if let Some(f) = p.find_function_by_uuid(uu) {
-                return Some(f);
-            }
-        }
-
-        None
-    }
-
-    /// Returns function and enclosing program with UUID `uu`
-    pub fn find_function_by_uuid_mut<'a>(&'a mut self, uu: &Uuid) -> Option<&'a mut Function> {
-        for p in self.code.iter_mut() {
-            if let Some(f) = p.find_function_by_uuid_mut(uu) {
-                return Some(f);
-            }
-        }
-
-        None
-    }
-
-    /// Returns function/reference and enclosing program with UUID `uu`
-    pub fn find_call_target_by_uuid<'a>(&'a self, uu: &Uuid) -> Option<(CallGraphRef, &'a Program)> {
-        for p in self.code.iter() {
-            if let Some(ct) = p.find_call_target_by_uuid(uu) {
-                return Some((ct, p));
-            }
-        }
-
-        None
-    }
-
-    /// Returns function/reference and enclosing program with UUID `uu`
-    pub fn find_call_target_by_uuid_mut<'a>(&'a mut self, uu: &Uuid) -> Option<(CallGraphRef, &'a mut Program)> {
-        for p in self.code.iter_mut() {
-            if let Some(ct) = p.find_call_target_by_uuid(uu) {
-                return Some((ct, p));
-            }
-        }
-
-        None
-    }
-
     /// Serializes the project into the file at `p`. The format looks like this:
     /// [u8;10] magic = "PANOPTICON"
     /// u32     version = 0
@@ -165,6 +94,83 @@ impl Project {
             Ok(()) => Ok(()),
             Err(e) => Err(format!("failed to write to save file: {}",e).into()),
         }
+    }
+
+}
+
+impl<F> Project<F> {
+    /// Returns a new `Project` named `s` from memory `Region` `r`.
+    pub fn new(s: String, r: Region) -> Self {
+        Project {
+            name: s,
+            code: Vec::new(),
+            data: World::new(r),
+            comments: HashMap::new(),
+            imports: HashMap::new(),
+        }
+    }
+
+    /// Returns this project's root Region
+    pub fn region(&self) -> &Region {
+        // this cannot fail because World::new guarantees that data.root = r
+        self.data.dependencies.vertex_label(self.data.root).unwrap()
+    }
+}
+
+
+impl<F: Fun> Project<F> {
+    /// Returns the program with UUID `uu`
+    pub fn find_program_by_uuid(&self, uu: &Uuid) -> Option<&Program<F>> {
+        self.code.iter().find(|x| x.uuid == *uu)
+    }
+
+    /// Returns the program with UUID `uu`
+    pub fn find_program_by_uuid_mut(&mut self, uu: &Uuid) -> Option<&mut Program<F>> {
+        self.code.iter_mut().find(|x| x.uuid == *uu)
+    }
+
+    /// Returns function and enclosing program with UUID `uu`
+    pub fn find_function_by_uuid<'a>(&'a self, uu: &Uuid) -> Option<&'a F> {
+        for p in self.code.iter() {
+            if let Some(f) = p.find_function_by_uuid(uu) {
+                return Some(f);
+            }
+        }
+
+        None
+    }
+
+    /// Returns function and enclosing program with UUID `uu`
+    pub fn find_function_by_uuid_mut<'a>(&'a mut self, uu: &Uuid) -> Option<&'a mut F> {
+        for p in self.code.iter_mut() {
+            if let Some(f) = p.find_function_by_uuid_mut(uu) {
+                return Some(f);
+            }
+        }
+
+        None
+    }
+
+    /// Returns function/reference and enclosing program with UUID `uu`
+    pub fn find_call_target_by_uuid<'a>(&'a self, uu: &Uuid) -> Option<(CallGraphRef, &'a Program<F>)> {
+        for p in self.code.iter() {
+            if let Some(ct) = p.find_call_target_by_uuid(uu) {
+                return Some((ct, p));
+            }
+        }
+
+        None
+    }
+
+    /// Returns function/reference and enclosing program with UUID `uu`
+    pub fn find_call_target_by_uuid_mut<'a>(&'a mut self, uu: &Uuid) -> Option<(CallGraphRef, &'a mut Program<F>)> {
+        for p in self.code.iter_mut() {
+            if let Some(ct) = p.find_call_target_by_uuid(uu) {
+                return Some((ct, p));
+            }
+        }
+
+        None
     }
 }
 

--- a/core/src/project.rs
+++ b/core/src/project.rs
@@ -22,7 +22,6 @@
 
 
 use {CallGraphRef, Fun, Program, Region, Result, World};
-use panopticon_graph_algos::GraphTrait;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use flate2::Compression;
 use flate2::read::ZlibDecoder;
@@ -48,8 +47,6 @@ pub struct Project<F> {
     pub data: World,
     /// Comments
     pub comments: HashMap<(String, u64), String>,
-    /// Symbolic References (Imports)
-    pub imports: HashMap<u64, String>,
 }
 
 impl<'de, F: Fun + Deserialize<'de> + Serialize> Project<F> {
@@ -106,14 +103,13 @@ impl<F> Project<F> {
             code: Vec::new(),
             data: World::new(r),
             comments: HashMap::new(),
-            imports: HashMap::new(),
         }
     }
 
     /// Returns this project's root Region
     pub fn region(&self) -> &Region {
         // this cannot fail because World::new guarantees that data.root = r
-        self.data.dependencies.vertex_label(self.data.root).unwrap()
+        self.data.dependencies.node_weight(self.data.root).unwrap()
     }
 }
 

--- a/data-flow/Cargo.toml
+++ b/data-flow/Cargo.toml
@@ -4,5 +4,7 @@ version = "0.16.0"
 authors = ["seu <seu@panopticon.re>"]
 
 [dependencies]
+bit-set = "0.4.0"
+petgraph = "0.4.9"
 panopticon-core = { path = "../core" }
 panopticon-graph-algos = { path = "../graph-algos" }

--- a/data-flow/Cargo.toml
+++ b/data-flow/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["seu <seu@panopticon.re>"]
 
 [dependencies]
 bit-set = "0.4.0"
-petgraph = "0.4.9"
 env_logger = "0.3"
 log = "0.3.6"
 smallvec = "0.4.4"
+petgraph = { version = "0.4.10", features = ["serde-1"], git = "https://github.com/m4b/petgraph", branch = "dominance_frontiers" }
 panopticon-core = { path = "../core" }
 panopticon-graph-algos = { path = "../graph-algos" }

--- a/data-flow/Cargo.toml
+++ b/data-flow/Cargo.toml
@@ -6,5 +6,8 @@ authors = ["seu <seu@panopticon.re>"]
 [dependencies]
 bit-set = "0.4.0"
 petgraph = "0.4.9"
+env_logger = "0.3"
+log = "0.3.6"
+smallvec = "0.4.4"
 panopticon-core = { path = "../core" }
 panopticon-graph-algos = { path = "../graph-algos" }

--- a/data-flow/src/lib.rs
+++ b/data-flow/src/lib.rs
@@ -22,7 +22,6 @@
 //! module implements functions to compute liveness sets and basic reverse data flow information.
 
 extern crate panopticon_core;
-extern crate panopticon_graph_algos;
 extern crate bit_set;
 extern crate petgraph;
 extern crate smallvec;
@@ -32,10 +31,101 @@ extern crate log;
 #[cfg(test)]
 extern crate env_logger;
 
-mod liveness;
-pub use liveness::{liveness, liveness_sets};
+use panopticon_core::{Function, BasicBlock, Result, Guard, ControlFlowTarget, ControlFlowEdge, ControlFlowRef, Operation, Rvalue};
+use std::collections::{HashMap, HashSet};
+use std::borrow::Cow;
 
+use petgraph::Graph;
+
+pub trait DataFlow: Sized {
+    /// Convert `func` into semi-pruned SSA form.
+    fn ssa_conversion(&mut self) -> Result<()> {
+        let (globals, usage) = self.global_names();
+        self.phi_functions(&globals, &usage)?;
+        self.rename_variables(&globals)
+    }
+    /// Computes the set of global variables in `func` and their points of usage. Globals are
+    /// variables that are used in multiple basic blocks. Returns (Globals,Usage).
+    fn global_names(&self) -> (ssa::Globals, ssa::Usage) {
+        ssa::global_names(self)
+    }
+
+    /// Does a simple sanity check on all RREIL statements in `func`, returns every variable name
+    /// found and its maximal size in bits.
+    fn type_check(&self) -> Result<HashMap<Cow<'static, str>, usize>> {
+        ssa::type_check(self)
+    }
+
+    /// Inserts SSA Phi functions at junction points in the control flow graph of `func`. The
+    /// algorithm produces the semi-pruned SSA form found in Cooper, Torczon: "Engineering a Compiler".
+    fn phi_functions(&mut self, globals: &ssa::Globals, usage: &ssa::Usage) -> Result<()> {
+        ssa::phi_functions(self, globals, usage)
+    }
+
+    /// Sets the SSA subscripts of all variables in `func`. Follows the algorithm outlined
+    /// Cooper, Torczon: "Engineering a Compiler". The function expects that Phi functions to be
+    /// already inserted.
+    fn rename_variables(&mut self, globals: &ssa::Globals) -> Result<()> {
+        ssa::rename_variables(self, globals)
+    }
+    /// Computes for every control flow guard the dependent RREIL operation via reverse data flow
+    /// analysis.
+    fn flag_operations(&self) -> HashMap<ControlFlowEdge, Operation<Rvalue>> {
+        ssa::flag_operations(self)
+    }
+    /// Computes for each basic block in `func` the set of live variables using simple fixed point
+    /// iteration.
+    fn liveness<Function: DataFlow>(&self) -> HashMap<ControlFlowRef, HashSet<Cow<'static, str>>> {
+        liveness::liveness(self)
+    }
+
+    fn entry_point_mut(&mut self) -> &mut BasicBlock;
+    fn entry_point_ref(&self) -> ControlFlowRef;
+    fn cfg(&self) -> &Graph<ControlFlowTarget, Guard>;
+    fn cfg_mut(&mut self) -> &mut Graph<ControlFlowTarget, Guard>;
+}
+
+impl DataFlow for Function {
+    fn entry_point_mut(&mut self) -> &mut BasicBlock {
+        Function::entry_point_mut(self)
+    }
+    fn entry_point_ref(&self) -> ControlFlowRef {
+        Function::entry_point_ref(self)
+    }
+
+    fn cfg(&self) -> &Graph<ControlFlowTarget, Guard> {
+        Function::cfg(self)
+    }
+
+    fn cfg_mut(&mut self) -> &mut Graph<ControlFlowTarget, Guard> {
+        Function::cfg_mut(self)
+    }
+}
+
+impl DataFlow for panopticon_core::neo::Function {
+    // @flanfly: can technically implement it for neo by calling its specific functions in `neo::*` here, as it mutates self
+    fn ssa_conversion(&mut self) -> Result<()> {
+        neo::rewrite_to_ssa(self).map_err(|e| {
+            format!("{}", e).into()
+        })
+    }
+    fn entry_point_mut(&mut self) -> &mut BasicBlock {
+        unimplemented!()
+    }
+    fn entry_point_ref(&self) -> ControlFlowRef {
+        unimplemented!()
+    }
+
+    fn cfg(&self) -> &Graph<ControlFlowTarget, Guard> {
+        unimplemented!()
+    }
+
+    fn cfg_mut(&mut self) -> &mut Graph<ControlFlowTarget, Guard> {
+        unimplemented!()
+    }
+}
+
+mod liveness;
 mod ssa;
-pub use ssa::{flag_operations, ssa_convertion, type_check};
 
 pub mod neo;

--- a/data-flow/src/lib.rs
+++ b/data-flow/src/lib.rs
@@ -23,9 +23,13 @@
 
 extern crate panopticon_core;
 extern crate panopticon_graph_algos;
+extern crate bit_set;
+extern crate petgraph;
 
 mod liveness;
 pub use liveness::{liveness, liveness_sets};
 
 mod ssa;
 pub use ssa::{flag_operations, ssa_convertion, type_check};
+
+pub mod neo;

--- a/data-flow/src/lib.rs
+++ b/data-flow/src/lib.rs
@@ -25,6 +25,12 @@ extern crate panopticon_core;
 extern crate panopticon_graph_algos;
 extern crate bit_set;
 extern crate petgraph;
+extern crate smallvec;
+#[macro_use]
+extern crate log;
+
+#[cfg(test)]
+extern crate env_logger;
 
 mod liveness;
 pub use liveness::{liveness, liveness_sets};

--- a/data-flow/src/liveness.rs
+++ b/data-flow/src/liveness.rs
@@ -16,26 +16,29 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-use panopticon_core::{ControlFlowRef, ControlFlowTarget, Function, Guard, Lvalue, Operation, Rvalue, Statement};
-use panopticon_graph_algos::{GraphTrait, IncidenceGraphTrait};
+use panopticon_core::{ControlFlowTarget, ControlFlowRef, Guard, Lvalue, Operation, Rvalue, Statement};
+use petgraph::Direction;
+use petgraph::visit::{Walker, EdgeRef, DfsPostOrder};
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
+use DataFlow;
 
 /// Computes the set of killed (VarKill) and upward exposed variables (UEvar) for each basic block
 /// in `func`. Returns (VarKill,UEvar).
-pub fn liveness_sets(func: &Function) -> (HashMap<ControlFlowRef, HashSet<Cow<'static, str>>>, HashMap<ControlFlowRef, HashSet<Cow<'static, str>>>) {
+pub(crate) fn liveness_sets<Function: DataFlow>(func: &Function) -> (HashMap<ControlFlowRef, HashSet<Cow<'static, str>>>, HashMap<ControlFlowRef, HashSet<Cow<'static, str>>>) {
     let mut uevar = HashMap::<ControlFlowRef, HashSet<&str>>::new();
     let mut varkill = HashMap::<ControlFlowRef, HashSet<Cow<'static, str>>>::new();
-    let ord = func.postorder();
+    // don't allocate the postorder
+    let ord = DfsPostOrder::new(func.cfg(), func.entry_point_ref()).iter(func.cfg());
     let cfg = func.cfg();
 
     // init UEVar and VarKill sets
-    for &vx in ord.iter() {
+    for vx in ord {
         let uev = uevar.entry(vx).or_insert(HashSet::<&str>::new());
         let vk = varkill.entry(vx).or_insert(HashSet::<Cow<'static, str>>::new());
 
-        if let Some(&ControlFlowTarget::Resolved(ref bb)) = cfg.vertex_label(vx) {
+        if let Some(&ControlFlowTarget::Resolved(ref bb)) = cfg.node_weight(vx.into()) {
             for mne in bb.mnemonics.iter() {
                 for rv in mne.operands.iter() {
                     if let &Rvalue::Variable { ref name, .. } = rv {
@@ -67,8 +70,8 @@ pub fn liveness_sets(func: &Function) -> (HashMap<ControlFlowRef, HashSet<Cow<'s
             }
         }
 
-        for e in cfg.out_edges(vx) {
-            if let Some(&Guard::Predicate { flag: Rvalue::Variable { ref name, .. }, .. }) = cfg.edge_label(e) {
+        for e in cfg.edges_directed(vx.into(), Direction::Outgoing) {
+            if let &Guard::Predicate { flag: Rvalue::Variable { ref name, .. }, .. } = e.weight() {
                 if !vk.contains(name) {
                     uev.insert(name);
                 }
@@ -81,14 +84,14 @@ pub fn liveness_sets(func: &Function) -> (HashMap<ControlFlowRef, HashSet<Cow<'s
 
 /// Computes for each basic block in `func` the set of live variables using simple fixed point
 /// iteration.
-pub fn liveness(func: &Function) -> HashMap<ControlFlowRef, HashSet<Cow<'static, str>>> {
+pub(crate) fn liveness<Function: DataFlow>(func: &Function) -> HashMap<ControlFlowRef, HashSet<Cow<'static, str>>> {
     let (varkill, uevar) = liveness_sets(func);
     let mut liveout = HashMap::<ControlFlowRef, HashSet<&str>>::new();
-    let ord = func.postorder();
+    let ord = DfsPostOrder::new(func.cfg(), func.entry_point_ref()).iter(func.cfg());
     let cfg = func.cfg();
 
-    for &vx in ord.iter() {
-        if let Some(&ControlFlowTarget::Resolved(_)) = cfg.vertex_label(vx) {
+    for vx in ord.clone() {
+        if let Some(&ControlFlowTarget::Resolved(_)) = cfg.node_weight(vx) {
             liveout.insert(vx, HashSet::<&str>::new());
         }
     }
@@ -99,18 +102,18 @@ pub fn liveness(func: &Function) -> HashMap<ControlFlowRef, HashSet<Cow<'static,
         let mut new_liveout = HashMap::<ControlFlowRef, HashSet<&str>>::new();
 
         fixpoint = true;
-        for &vx in ord.iter() {
+        for vx in ord.clone() {
             let mut s = HashSet::<&str>::new();
 
-            if let Some(&ControlFlowTarget::Resolved(_)) = cfg.vertex_label(vx) {
-                for e in cfg.out_edges(vx) {
-                    let m = cfg.target(e);
+            if let Some(&ControlFlowTarget::Resolved(_)) = cfg.node_weight(vx) {
+                for e in cfg.edges_directed(vx, Direction::Outgoing) {
+                    let m = e.target();
 
                     for x in uevar[&m].iter() {
                         s.insert(x);
                     }
 
-                    if let Some(&ControlFlowTarget::Resolved(_)) = cfg.vertex_label(m) {
+                    if let Some(&ControlFlowTarget::Resolved(_)) = cfg.node_weight(m) {
                         for x in liveout[&m].iter() {
                             if !varkill[&m].contains(*x) {
                                 s.insert(x);
@@ -122,14 +125,11 @@ pub fn liveness(func: &Function) -> HashMap<ControlFlowRef, HashSet<Cow<'static,
                 if liveout[&vx] != s {
                     fixpoint = false;
                 }
-
                 new_liveout.insert(vx, s);
             }
         }
-
         liveout = new_liveout;
     }
-
     HashMap::from_iter(liveout.iter().map(|(&k, v)| (k, HashSet::from_iter(v.iter().map(|x| Cow::Owned(x.to_string()))))))
 }
 
@@ -137,11 +137,11 @@ pub fn liveness(func: &Function) -> HashMap<ControlFlowRef, HashSet<Cow<'static,
 mod tests {
     use super::*;
     use panopticon_core::{BasicBlock, ControlFlowGraph, ControlFlowTarget, Function, Guard, Lvalue, Mnemonic, Operation, Rvalue, Statement, Region};
-    use panopticon_graph_algos::{GraphTrait, MutableGraphTrait, VertexListGraphTrait};
-    use ssa::{phi_functions, rename_variables};
+    use ssa::{phi_functions};
     use std::borrow::Cow;
     use std::collections::HashSet;
     use std::iter::FromIterator;
+    use DataFlow;
 
     #[test]
     fn live() {
@@ -248,20 +248,20 @@ mod tests {
         let bb4 = BasicBlock::from_vec(vec![mne4]);
         let mut cfg = ControlFlowGraph::new();
 
-        let v0 = cfg.add_vertex(ControlFlowTarget::Resolved(bb0));
-        let v1 = cfg.add_vertex(ControlFlowTarget::Resolved(bb1));
-        let v2 = cfg.add_vertex(ControlFlowTarget::Resolved(bb2));
-        let v3 = cfg.add_vertex(ControlFlowTarget::Resolved(bb3));
-        let v4 = cfg.add_vertex(ControlFlowTarget::Resolved(bb4));
+        let v0 = cfg.add_node(ControlFlowTarget::Resolved(bb0));
+        let v1 = cfg.add_node(ControlFlowTarget::Resolved(bb1));
+        let v2 = cfg.add_node(ControlFlowTarget::Resolved(bb2));
+        let v3 = cfg.add_node(ControlFlowTarget::Resolved(bb3));
+        let v4 = cfg.add_node(ControlFlowTarget::Resolved(bb4));
 
         let g = Guard::from_flag(&x.clone().into()).ok().unwrap();
 
-        cfg.add_edge(Guard::always(), v0, v1);
-        cfg.add_edge(g.negation(), v1, v2);
-        cfg.add_edge(g.clone(), v1, v3);
-        cfg.add_edge(Guard::always(), v2, v3);
-        cfg.add_edge(g.negation(), v3, v1);
-        cfg.add_edge(g.clone(), v3, v4);
+        cfg.add_edge( v0,  v1, Guard::always());
+        cfg.add_edge( v1,  v2, g.negation());
+        cfg.add_edge( v1,  v3, g.clone());
+        cfg.add_edge( v2,  v3, Guard::always());
+        cfg.add_edge( v3,  v1, g.negation());
+        cfg.add_edge( v3,  v4, g.clone());
         let mut func = Function::undefined(0, None, &Region::undefined("ram".to_owned(), 100), None);
 
         *func.cfg_mut() = cfg;
@@ -304,7 +304,6 @@ mod tests {
             Some(&HashSet::from_iter(vec![Cow::Borrowed("x"), Cow::Borrowed("i"), Cow::Borrowed("s")]))
         );
         assert_eq!(vk.get(&v4), Some(&HashSet::new()));
-
         let res = liveness(&func);
 
         assert_eq!(res.len(), 5);
@@ -544,42 +543,42 @@ mod tests {
         let bb8 = BasicBlock::from_vec(vec![mne8]);
         let mut cfg = ControlFlowGraph::new();
 
-        let v0 = cfg.add_vertex(ControlFlowTarget::Resolved(bb0));
-        let v1 = cfg.add_vertex(ControlFlowTarget::Resolved(bb1));
-        let v2 = cfg.add_vertex(ControlFlowTarget::Resolved(bb2));
-        let v3 = cfg.add_vertex(ControlFlowTarget::Resolved(bb3));
-        let v4 = cfg.add_vertex(ControlFlowTarget::Resolved(bb4));
-        let v5 = cfg.add_vertex(ControlFlowTarget::Resolved(bb5));
-        let v6 = cfg.add_vertex(ControlFlowTarget::Resolved(bb6));
-        let v7 = cfg.add_vertex(ControlFlowTarget::Resolved(bb7));
-        let v8 = cfg.add_vertex(ControlFlowTarget::Resolved(bb8));
+        let v0 = cfg.add_node(ControlFlowTarget::Resolved(bb0));
+        let v1 = cfg.add_node(ControlFlowTarget::Resolved(bb1));
+        let v2 = cfg.add_node(ControlFlowTarget::Resolved(bb2));
+        let v3 = cfg.add_node(ControlFlowTarget::Resolved(bb3));
+        let v4 = cfg.add_node(ControlFlowTarget::Resolved(bb4));
+        let v5 = cfg.add_node(ControlFlowTarget::Resolved(bb5));
+        let v6 = cfg.add_node(ControlFlowTarget::Resolved(bb6));
+        let v7 = cfg.add_node(ControlFlowTarget::Resolved(bb7));
+        let v8 = cfg.add_node(ControlFlowTarget::Resolved(bb8));
 
-        cfg.add_edge(Guard::always(), v0, v1);
+        cfg.add_edge( v0,  v1, Guard::always());
 
         let g1 = Guard::from_flag(&f.clone().into()).ok().unwrap();
-        cfg.add_edge(g1.clone(), v1, v2);
-        cfg.add_edge(g1.negation(), v1, v5);
+        cfg.add_edge( v1,  v2, g1.clone());
+        cfg.add_edge( v1,  v5, g1.negation());
 
-        cfg.add_edge(Guard::always(), v2, v3);
+        cfg.add_edge( v2,  v3, Guard::always());
 
         let g3 = Guard::from_flag(&f.clone().into()).ok().unwrap();
-        cfg.add_edge(g3.clone(), v3, v1);
-        cfg.add_edge(g3.negation(), v3, v4);
+        cfg.add_edge( v3,  v1, g3.clone());
+        cfg.add_edge( v3,  v4, g3.negation());
 
         let g5 = Guard::from_flag(&f.clone().into()).ok().unwrap();
-        cfg.add_edge(g5.clone(), v5, v6);
-        cfg.add_edge(g5.negation(), v5, v8);
+        cfg.add_edge( v5,  v6, g5.clone());
+        cfg.add_edge( v5,  v8, g5.negation());
 
-        cfg.add_edge(Guard::always(), v6, v7);
-        cfg.add_edge(Guard::always(), v7, v3);
-        cfg.add_edge(Guard::always(), v8, v7);
+        cfg.add_edge( v6,  v7, Guard::always());
+        cfg.add_edge( v7,  v3, Guard::always());
+        cfg.add_edge( v8,  v7, Guard::always());
 
         let mut func = Function::undefined(0, None, &Region::undefined("ram".to_owned(), 100), None);
 
         *func.cfg_mut() = cfg;
         func.set_entry_point_ref(v0);
-
-        assert!(phi_functions(&mut func).is_ok());
+        let (globals, usage) = func.global_names();
+        assert!(phi_functions(&mut func, &globals, &usage).is_ok());
 
         let a0 = Lvalue::Variable { name: Cow::Borrowed("a"), size: 32, subscript: None };
         let b0 = Lvalue::Variable { name: Cow::Borrowed("b"), size: 32, subscript: None };
@@ -588,14 +587,14 @@ mod tests {
         let i0 = Lvalue::Variable { name: Cow::Borrowed("i"), size: 32, subscript: None };
 
         // bb0
-        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().vertex_label(v0) {
+        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().node_weight(v0) {
             assert!(bb.mnemonics[0].opcode != "__phi".to_string());
         } else {
             unreachable!()
         }
 
         // bb1
-        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().vertex_label(v1) {
+        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().node_weight(v1) {
             assert_eq!(bb.mnemonics[0].opcode, "__phi".to_string());
             assert_eq!(bb.mnemonics[1].opcode, "__phi".to_string());
             assert_eq!(bb.mnemonics[2].opcode, "__phi".to_string());
@@ -621,14 +620,14 @@ mod tests {
         }
 
         // bb2
-        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().vertex_label(v2) {
+        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().node_weight(v2) {
             assert!(bb.mnemonics[0].opcode != "__phi".to_string());
         } else {
             unreachable!()
         }
 
         // bb3
-        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().vertex_label(v3) {
+        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().node_weight(v3) {
             assert_eq!(bb.mnemonics[0].opcode, "__phi".to_string());
             assert_eq!(bb.mnemonics[1].opcode, "__phi".to_string());
             assert_eq!(bb.mnemonics[2].opcode, "__phi".to_string());
@@ -651,28 +650,28 @@ mod tests {
         }
 
         // bb4
-        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().vertex_label(v4) {
+        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().node_weight(v4) {
             assert!(bb.mnemonics[0].opcode != "__phi".to_string());
         } else {
             unreachable!()
         }
 
         // bb5
-        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().vertex_label(v5) {
+        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().node_weight(v5) {
             assert!(bb.mnemonics[0].opcode != "__phi".to_string());
         } else {
             unreachable!()
         }
 
         // bb6
-        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().vertex_label(v6) {
+        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().node_weight(v6) {
             assert!(bb.mnemonics[0].opcode != "__phi".to_string());
         } else {
             unreachable!()
         }
 
         // bb7
-        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().vertex_label(v7) {
+        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().node_weight(v7) {
             assert_eq!(bb.mnemonics[0].opcode, "__phi".to_string());
             assert_eq!(bb.mnemonics[1].opcode, "__phi".to_string());
             assert!(bb.mnemonics[2].opcode != "__phi".to_string());
@@ -918,46 +917,44 @@ mod tests {
         let bb8 = BasicBlock::from_vec(vec![mne8]);
         let mut cfg = ControlFlowGraph::new();
 
-        let v0 = cfg.add_vertex(ControlFlowTarget::Resolved(bb0));
-        let v1 = cfg.add_vertex(ControlFlowTarget::Resolved(bb1));
-        let v2 = cfg.add_vertex(ControlFlowTarget::Resolved(bb2));
-        let v3 = cfg.add_vertex(ControlFlowTarget::Resolved(bb3));
-        let v4 = cfg.add_vertex(ControlFlowTarget::Resolved(bb4));
-        let v5 = cfg.add_vertex(ControlFlowTarget::Resolved(bb5));
-        let v6 = cfg.add_vertex(ControlFlowTarget::Resolved(bb6));
-        let v7 = cfg.add_vertex(ControlFlowTarget::Resolved(bb7));
-        let v8 = cfg.add_vertex(ControlFlowTarget::Resolved(bb8));
+        let v0 = cfg.add_node(ControlFlowTarget::Resolved(bb0));
+        let v1 = cfg.add_node(ControlFlowTarget::Resolved(bb1));
+        let v2 = cfg.add_node(ControlFlowTarget::Resolved(bb2));
+        let v3 = cfg.add_node(ControlFlowTarget::Resolved(bb3));
+        let v4 = cfg.add_node(ControlFlowTarget::Resolved(bb4));
+        let v5 = cfg.add_node(ControlFlowTarget::Resolved(bb5));
+        let v6 = cfg.add_node(ControlFlowTarget::Resolved(bb6));
+        let v7 = cfg.add_node(ControlFlowTarget::Resolved(bb7));
+        let v8 = cfg.add_node(ControlFlowTarget::Resolved(bb8));
 
-        cfg.add_edge(Guard::always(), v0, v1);
+        cfg.add_edge( v0,  v1, Guard::always());
 
         let g1 = Guard::from_flag(&f.clone().into()).ok().unwrap();
-        cfg.add_edge(g1.clone(), v1, v2);
-        cfg.add_edge(g1.negation(), v1, v5);
+        cfg.add_edge( v1,  v2, g1.clone());
+        cfg.add_edge( v1,  v5, g1.negation());
 
-        cfg.add_edge(Guard::always(), v2, v3);
+        cfg.add_edge( v2,  v3, Guard::always());
 
         let g3 = Guard::from_flag(&f.clone().into()).ok().unwrap();
-        cfg.add_edge(g3.clone(), v3, v1);
-        cfg.add_edge(g3.negation(), v3, v4);
+        cfg.add_edge( v3,  v1, g3.clone());
+        cfg.add_edge( v3,  v4, g3.negation());
 
         let g5 = Guard::from_flag(&f.clone().into()).ok().unwrap();
-        cfg.add_edge(g5.clone(), v5, v6);
-        cfg.add_edge(g5.negation(), v5, v8);
+        cfg.add_edge( v5,  v6, g5.clone());
+        cfg.add_edge( v5,  v8, g5.negation());
 
-        cfg.add_edge(Guard::always(), v6, v7);
-        cfg.add_edge(Guard::always(), v7, v3);
-        cfg.add_edge(Guard::always(), v8, v7);
+        cfg.add_edge( v6,  v7, Guard::always());
+        cfg.add_edge( v7,  v3, Guard::always());
+        cfg.add_edge( v8,  v7, Guard::always());
 
         let mut func = Function::undefined(0, None, &Region::undefined("ram".to_owned(), 100), None);
 
         *func.cfg_mut() = cfg;
         func.set_entry_point_ref(v0);
+        assert!(func.ssa_conversion().is_ok());
 
-        assert!(phi_functions(&mut func).is_ok());
-        assert!(rename_variables(&mut func).is_ok());
-
-        for v in func.cfg().vertices() {
-            if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().vertex_label(v) {
+        for v in func.cfg().node_indices() {
+            if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().node_weight(v) {
                 bb.execute(
                     |i| {
                         if let Lvalue::Variable { subscript, .. } = i.assignee {

--- a/data-flow/src/neo/liveness.rs
+++ b/data-flow/src/neo/liveness.rs
@@ -1,0 +1,188 @@
+use std::marker::PhantomData;
+use panopticon_core::neo::{Function,Operation,Statement,Variable,Value,Result};
+use panopticon_core::{Guard,Rvalue};
+use bit_set::BitSet;
+use petgraph::Direction;
+
+pub struct LivenessSets<'a> {
+    variables: Vec<Variable>,
+    var_kill: Vec<BitSet>,
+    ue_var: Vec<BitSet>,
+    phantom: PhantomData<&'a Function>,
+}
+
+impl<'a> LivenessSets<'a> {
+    fn new(func: &'a Function) -> LivenessSets<'a> {
+        let num_bb = func.basic_blocks().len();
+        LivenessSets{
+            variables: vec![],
+            var_kill: vec![BitSet::default(); num_bb],
+            ue_var: vec![BitSet::default(); num_bb],
+            phantom: PhantomData::default(),
+        }
+    }
+
+    fn record_read(&mut self, bb: usize, var: &Variable) -> Result<()> {
+        let &Variable{ ref name, bits,.. } = var;
+        let vk = &mut self.var_kill[bb];
+        let uev = &mut self.ue_var[bb];
+        let var = Variable::new(name.clone(),bits,None)?;
+        let var_idx = match self.variables.iter().position(|x| *x == var) {
+            Some(p) => p,
+            None => { self.variables.push(var); self.variables.len() - 1 }
+        };
+
+        if !vk.contains(var_idx) {
+            uev.insert(var_idx);
+        }
+
+        Ok(())
+    }
+
+    fn record_write(&mut self, bb: usize, var: &Variable) -> Result<()> {
+        let &Variable{ ref name, bits,.. } = var;
+        let vk = &mut self.var_kill[bb];
+        let var = Variable::new(name.clone(),bits,None)?;
+        let var_idx = match self.variables.iter().position(|x| *x == var) {
+            Some(p) => p,
+            None => { self.variables.push(var); self.variables.len() - 1 }
+        };
+
+        vk.insert(var_idx);
+        Ok(())
+    }
+}
+
+/// Computes the set of killed (VarKill) and upward exposed variables (UEvar) for each basic block
+/// in `func`. Returns (VarKill,UEvar).
+pub fn liveness_sets<'a>(func: &'a Function) -> Result<LivenessSets<'a>> {
+    let mut ret = LivenessSets::new(func);
+    let cfg = func.cflow_graph();
+
+    for (idx,bb) in func.basic_blocks() {
+        for stmt in func.statements(bb) {
+            match stmt {
+                Statement::Expression{ op: Operation::Phi(_,_,_),.. } => { /* skip */ }
+                Statement::Expression{ op, result } => {
+                    for value in op.reads() {
+                        if let &Value::Variable(ref var) = value {
+                            ret.record_read(idx.index(),var)?;
+                        }
+                    }
+                    ret.record_write(idx.index(),&result)?;
+                }
+                Statement::IndirectCall{ target: Value::Variable(ref var) } => {
+                    ret.record_read(idx.index(),var)?;
+                }
+                Statement::Store{ address, value,.. } => {
+                    if let Value::Variable(ref var) = address {
+                        ret.record_read(idx.index(),var)?;
+                    }
+                    if let Value::Variable(ref var) = value {
+                        ret.record_read(idx.index(),var)?;
+                    }
+                }
+                _ => { /* skip */ }
+            }
+        }
+
+        for e in cfg.edges_directed(bb.node,Direction::Outgoing) {
+            match e.weight() {
+                &Guard::Predicate{ flag: Rvalue::Variable{ ref name, size,.. },.. } => {
+                    ret.record_read(idx.index(),&Variable::new(name.clone(),size,None)?)?;
+                }
+                _ => { /* skip */ }
+            }
+        }
+    }
+
+    Ok(ret)
+}
+
+pub struct Globals<'a> {
+    pub variables: Vec<Variable>,
+    pub globals: BitSet,
+    pub usage: Vec<BitSet>,
+    phantom: PhantomData<&'a Function>,
+}
+
+impl<'a> Globals<'a> {
+    fn new(func: &'a Function, liveness: &LivenessSets<'a>) -> Globals<'a> {
+        let num_bb = func.basic_blocks().len();
+        Globals{
+            variables: liveness.variables.clone(),
+            globals: BitSet::with_capacity(liveness.variables.len()),
+            usage: vec![BitSet::with_capacity(num_bb); liveness.variables.len()],
+            phantom: PhantomData::default(),
+        }
+    }
+}
+
+pub fn globals<'a>(func: &'a Function, liveness: &LivenessSets<'a>) -> Result<Globals<'a>> {
+    let mut ret = Globals::new(func,liveness);
+
+    for uevar in liveness.ue_var.iter() {
+        ret.globals.union(uevar);
+    }
+
+    for (bb,varkill) in liveness.var_kill.iter().enumerate() {
+        for i in varkill.iter() { ret.usage[i].insert(bb); }
+    }
+
+    Ok(ret)
+}
+
+/*
+/// Computes for each basic block in `func` the set of live variables using simple fixed point
+/// iteration.
+pub fn liveness<'a>(func: &'a Function, &LivenessSets<'a>) -> HashMap<ControlFlowRef, HashSet<Cow<'static, str>>> {
+    let (varkill, uevar) = liveness_sets(func);
+    let mut liveout = HashMap::<ControlFlowRef, HashSet<&str>>::new();
+    let ord = func.postorder();
+    let cfg = func.cfg();
+
+    for &vx in ord.iter() {
+        if let Some(&ControlFlowTarget::Resolved(_)) = cfg.vertex_label(vx) {
+            liveout.insert(vx, HashSet::<&str>::new());
+        }
+    }
+
+    // compute LiveOut sets
+    let mut fixpoint = false;
+    while !fixpoint {
+        let mut new_liveout = HashMap::<ControlFlowRef, HashSet<&str>>::new();
+
+        fixpoint = true;
+        for &vx in ord.iter() {
+            let mut s = HashSet::<&str>::new();
+
+            if let Some(&ControlFlowTarget::Resolved(_)) = cfg.vertex_label(vx) {
+                for e in cfg.out_edges(vx) {
+                    let m = cfg.target(e);
+
+                    for x in uevar[&m].iter() {
+                        s.insert(x);
+                    }
+
+                    if let Some(&ControlFlowTarget::Resolved(_)) = cfg.vertex_label(m) {
+                        for x in liveout[&m].iter() {
+                            if !varkill[&m].contains(*x) {
+                                s.insert(x);
+                            }
+                        }
+                    }
+                }
+
+                if liveout[&vx] != s {
+                    fixpoint = false;
+                }
+
+                new_liveout.insert(vx, s);
+            }
+        }
+
+        liveout = new_liveout;
+    }
+
+    HashMap::from_iter(liveout.iter().map(|(&k, v)| (k, HashSet::from_iter(v.iter().map(|x| Cow::Owned(x.to_string()))))))
+}*/

--- a/data-flow/src/neo/liveness.rs
+++ b/data-flow/src/neo/liveness.rs
@@ -1,24 +1,97 @@
 use std::marker::PhantomData;
-use panopticon_core::neo::{Function,Operation,Statement,Variable,Value,Result};
+use panopticon_core::neo::{Function,Operation,Statement,Variable,Value,Result,CfgNode};
 use panopticon_core::{Guard,Rvalue};
 use bit_set::BitSet;
 use petgraph::Direction;
 
-pub struct LivenessSets<'a> {
-    variables: Vec<Variable>,
-    var_kill: Vec<BitSet>,
-    ue_var: Vec<BitSet>,
+/// Computes the set of killed (VarKill) and upward exposed variables (UEvar) for each basic block
+/// in `func`. Returns (VarKill,UEvar).
+#[derive(Debug)]
+pub struct Liveness<'a> {
+    pub variables: Vec<Variable>,
+    pub var_kill: Vec<BitSet>,
+    pub ue_var: Vec<BitSet>,
     phantom: PhantomData<&'a Function>,
 }
 
-impl<'a> LivenessSets<'a> {
-    fn new(func: &'a Function) -> LivenessSets<'a> {
+impl<'a> Liveness<'a> {
+    pub fn new(func: &'a Function) -> Result<Liveness<'a>> {
         let num_bb = func.basic_blocks().len();
-        LivenessSets{
+        let mut ret = Liveness{
             variables: vec![],
             var_kill: vec![BitSet::default(); num_bb],
             ue_var: vec![BitSet::default(); num_bb],
             phantom: PhantomData::default(),
+        };
+        let cfg = func.cflow_graph();
+
+        for (idx,bb) in func.basic_blocks() {
+            for stmt in func.statements(bb) {
+                match stmt {
+                    Statement::Expression{ op: Operation::Phi(_,_,_),.. } => { /* skip */ }
+                    Statement::Expression{ op, result } => {
+                        for value in op.reads() {
+                            if let &Value::Variable(ref var) = value {
+                                ret.record_read(idx.index(),var)?;
+                            }
+                        }
+                        ret.record_write(idx.index(),&result)?;
+                    }
+                    Statement::IndirectCall{ target: Value::Variable(ref var) } => {
+                        ret.record_read(idx.index(),var)?;
+                    }
+                    Statement::Store{ address, value,.. } => {
+                        if let Value::Variable(ref var) = address {
+                            ret.record_read(idx.index(),var)?;
+                        }
+                        if let Value::Variable(ref var) = value {
+                            ret.record_read(idx.index(),var)?;
+                        }
+                    }
+                    _ => { /* skip */ }
+                }
+            }
+
+            for e in cfg.edges_directed(bb.node,Direction::Outgoing) {
+                match e.weight() {
+                    &Guard::Predicate{ flag: Rvalue::Variable{ ref name, size,.. },.. } => {
+                        ret.record_read(idx.index(),&Variable::new(name.clone(),size,None)?)?;
+                    }
+                    _ => { /* skip */ }
+                }
+            }
+        }
+
+        Self::propagate(func,&mut ret);
+
+        Ok(ret)
+    }
+
+    fn propagate(func: &Function, liveness_sets: &mut Self) {
+        let cfg = func.cflow_graph();
+        let mut fixedpoint = false;
+
+        while !fixedpoint {
+            fixedpoint = true;
+            for (bb_idx,bb) in func.basic_blocks().rev() {
+                let vk = &liveness_sets.var_kill[bb_idx.index()];
+
+                for succ in cfg.neighbors_directed(bb.node,Direction::Outgoing) {
+                    match cfg.node_weight(succ) {
+                        Some(&CfgNode::BasicBlock(succ_idx)) => {
+                            let in_ue = liveness_sets.ue_var[succ_idx.index()].clone();
+
+                            for var in in_ue.into_iter() {
+                                // XXX
+                                if !vk.contains(var) {
+                                    fixedpoint &= !liveness_sets.ue_var[bb_idx.index()].insert(var);
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
         }
     }
 
@@ -32,6 +105,7 @@ impl<'a> LivenessSets<'a> {
             None => { self.variables.push(var); self.variables.len() - 1 }
         };
 
+        // XXX
         if !vk.contains(var_idx) {
             uev.insert(var_idx);
         }
@@ -51,54 +125,15 @@ impl<'a> LivenessSets<'a> {
         vk.insert(var_idx);
         Ok(())
     }
-}
 
-/// Computes the set of killed (VarKill) and upward exposed variables (UEvar) for each basic block
-/// in `func`. Returns (VarKill,UEvar).
-pub fn liveness_sets<'a>(func: &'a Function) -> Result<LivenessSets<'a>> {
-    let mut ret = LivenessSets::new(func);
-    let cfg = func.cflow_graph();
-
-    for (idx,bb) in func.basic_blocks() {
-        for stmt in func.statements(bb) {
-            match stmt {
-                Statement::Expression{ op: Operation::Phi(_,_,_),.. } => { /* skip */ }
-                Statement::Expression{ op, result } => {
-                    for value in op.reads() {
-                        if let &Value::Variable(ref var) = value {
-                            ret.record_read(idx.index(),var)?;
-                        }
-                    }
-                    ret.record_write(idx.index(),&result)?;
-                }
-                Statement::IndirectCall{ target: Value::Variable(ref var) } => {
-                    ret.record_read(idx.index(),var)?;
-                }
-                Statement::Store{ address, value,.. } => {
-                    if let Value::Variable(ref var) = address {
-                        ret.record_read(idx.index(),var)?;
-                    }
-                    if let Value::Variable(ref var) = value {
-                        ret.record_read(idx.index(),var)?;
-                    }
-                }
-                _ => { /* skip */ }
-            }
-        }
-
-        for e in cfg.edges_directed(bb.node,Direction::Outgoing) {
-            match e.weight() {
-                &Guard::Predicate{ flag: Rvalue::Variable{ ref name, size,.. },.. } => {
-                    ret.record_read(idx.index(),&Variable::new(name.clone(),size,None)?)?;
-                }
-                _ => { /* skip */ }
-            }
-        }
+    pub fn index_for(&self, v: &Variable) -> Result<usize> {
+        self.variables.iter()
+            .position(|x| x == v)
+            .ok_or("variable not part of this liveness set".into())
     }
-
-    Ok(ret)
 }
 
+#[derive(Debug)]
 pub struct Globals<'a> {
     pub variables: Vec<Variable>,
     pub globals: BitSet,
@@ -107,82 +142,174 @@ pub struct Globals<'a> {
 }
 
 impl<'a> Globals<'a> {
-    fn new(func: &'a Function, liveness: &LivenessSets<'a>) -> Globals<'a> {
+    pub fn new(func: &'a Function, liveness: &Liveness<'a>) -> Result<Globals<'a>> {
         let num_bb = func.basic_blocks().len();
-        Globals{
+        let mut ret = Globals{
             variables: liveness.variables.clone(),
             globals: BitSet::with_capacity(liveness.variables.len()),
             usage: vec![BitSet::with_capacity(num_bb); liveness.variables.len()],
             phantom: PhantomData::default(),
+        };
+
+        Self::compute(&mut ret,liveness);
+        Ok(ret)
+    }
+
+    fn compute(globals: &mut Self, liveness: &Liveness<'a>) {
+        for uevar in liveness.ue_var.iter() {
+            globals.globals.union_with(uevar);
         }
+
+        for (bb,varkill) in liveness.var_kill.iter().enumerate() {
+            for i in varkill.iter() { globals.usage[i].insert(bb); }
+        }
+    }
+
+    pub fn index_for(&self, v: &Variable) -> Result<usize> {
+        self.variables.iter()
+            .position(|x| x == v)
+            .ok_or("variable not part of this globals set".into())
     }
 }
 
-pub fn globals<'a>(func: &'a Function, liveness: &LivenessSets<'a>) -> Result<Globals<'a>> {
-    let mut ret = Globals::new(func,liveness);
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use panopticon_core::{Guard, OpaqueLayer, Region, TestArch};
+    use panopticon_core::neo::{Function};
+    use ssa::{phi_functions, rename_variables};
+    use std::borrow::Cow;
+    use std::collections::HashSet;
+    use std::iter::FromIterator;
+    use env_logger;
 
-    for uevar in liveness.ue_var.iter() {
-        ret.globals.union(uevar);
+    /*
+     * (B0)
+     * 0:  Mi1   ; mov i 1
+     *
+     * (B1)
+     * 3:  Cxi1  ; cmp x i 1
+     * 7:  Bx14  ; brlt x 14
+     *
+     * (B2)
+     * 11: Ms0   ; mov s 0
+     *
+     * (B3)
+     * 14: Assi  ; add s s i
+     * 18: Aiii  ; add i i i
+     * 22: Cxi1  ; cmp x i 1
+     * 26: Bx3   ; brlt x 3
+     *
+     * (B4)
+     * 29: Mss   ; use s
+     * 32: R     ; ret
+     */
+    #[test]
+    fn live_variables_analysis() {
+        use std::iter;
+
+        let _ = env_logger::init();
+        let data = OpaqueLayer::wrap(b"Mi1Cxi1Bx14Ms0AssiAiiiCxi1Bx3Mss".to_vec());
+        let reg = Region::new("".to_string(), data);
+        let func = Function::new::<TestArch>((), 0, &reg, None).unwrap();
+        let lvs = Liveness::new(&func).unwrap();
+        let i = lvs.index_for(&Variable::new("i", 32, None).unwrap()).unwrap();
+        let x = lvs.index_for(&Variable::new("x", 1, None).unwrap()).unwrap();
+        let s = lvs.index_for(&Variable::new("s", 32, None).unwrap()).unwrap();
+        let i_set = BitSet::from_iter(iter::once(i));
+        let x_set = BitSet::from_iter(iter::once(x));
+        let s_set = BitSet::from_iter(iter::once(s));
+        let is_set = BitSet::from_iter(vec![i,s].into_iter());
+        let isx_set = BitSet::from_iter(vec![i,s,x].into_iter());
+
+        assert_eq!(lvs.ue_var.len(), 5);
+        assert_eq!(lvs.ue_var[0], s_set);
+        assert_eq!(lvs.ue_var[1], is_set);
+        assert_eq!(lvs.ue_var[2], i_set);
+        assert_eq!(lvs.ue_var[3], is_set);
+        assert_eq!(lvs.ue_var[4], s_set);
+
+        assert_eq!(lvs.var_kill.len(), 5);
+        assert_eq!(lvs.var_kill[0], i_set);
+        assert_eq!(lvs.var_kill[1], x_set);
+        assert_eq!(lvs.var_kill[2], s_set);
+        assert_eq!(lvs.var_kill[3], isx_set);
+        assert_eq!(lvs.var_kill[4], s_set);
     }
 
-    for (bb,varkill) in liveness.var_kill.iter().enumerate() {
-        for i in varkill.iter() { ret.usage[i].insert(bb); }
+    /*
+     * (B0)
+     * 0:  Mix   ; mov i x
+     * 3:  J9    ; B1
+     *
+     * (B1)
+     * 9:  Mis   ; mov i s
+     * 12: R     ; ret
+     */
+    #[test]
+    fn ue_vars_trans() {
+        use std::iter;
+
+        let _ = env_logger::init();
+        let data = OpaqueLayer::wrap(b"MixJ9xxxxMisR".to_vec());
+        let reg = Region::new("".to_string(), data);
+        let func = Function::new::<TestArch>((), 0, &reg, None).unwrap();
+        let lvs = Liveness::new(&func).unwrap();
+        let x = lvs.index_for(&Variable::new("x", 32, None).unwrap()).unwrap();
+        let s = lvs.index_for(&Variable::new("s", 32, None).unwrap()).unwrap();
+        let s_set = BitSet::from_iter(iter::once(s));
+        let xs_set = BitSet::from_iter(vec![x,s].into_iter());
+
+        assert_eq!(lvs.ue_var.len(), 2);
+        assert_eq!(lvs.ue_var[0], xs_set);
+        assert_eq!(lvs.ue_var[1], s_set);
     }
 
-    Ok(ret)
+    /*
+     * (B0)
+     * 0:  Mi1   ; mov i 1
+     *
+     * (B1)
+     * 3:  Cxi1  ; cmp x i 1
+     * 7:  Bx3   ; brlt x 3
+     *
+     * (B2)
+     * 10: Ms0   ; mov s 0
+     * 13: Assi  ; add s s i
+     * 17: Aiii  ; add i i i
+     * 21: My1   ; mov y 1
+     * 24: Aiiy  ; add i i y
+     * 28: Cxi1  ; cmp x i 1
+     * 32: Bx3   ; brlt x _
+     *
+     * (B3)
+     * 37: My4   ; mov y 4
+     * 41: Mss   ; use s
+     * 44: R     ; ret
+     */
+    #[test]
+    fn global_variables() {
+        let _ = env_logger::init();
+        let data = OpaqueLayer::wrap(b"Mi1Cxi1Bx3Ms0AssiAiiiMy1AiiyCxi1Bx3My4MssR".to_vec());
+        let reg = Region::new("".to_string(), data);
+        let func = Function::new::<TestArch>((), 0, &reg, None).unwrap();
+        let lvs = Liveness::new(&func).unwrap();
+        let gbls = Globals::new(&func,&lvs).unwrap();
+        let i = gbls.index_for(&Variable::new("i", 32, None).unwrap()).unwrap();
+        let x = gbls.index_for(&Variable::new("x", 1, None).unwrap()).unwrap();
+        let s = gbls.index_for(&Variable::new("s", 32, None).unwrap()).unwrap();
+        let y = gbls.index_for(&Variable::new("y", 32, None).unwrap()).unwrap();
+        let isx_set = BitSet::from_iter(vec![i,s].into_iter());
+        let i_usage = BitSet::from_iter(vec![0,2].into_iter());
+        let s_usage = BitSet::from_iter(vec![2,3].into_iter());
+        let x_usage = BitSet::from_iter(vec![1,2].into_iter());
+        let y_usage = BitSet::from_iter(vec![2,3].into_iter());
+
+        assert_eq!(gbls.globals, isx_set);
+        assert_eq!(gbls.usage.len(), 4);
+        assert_eq!(gbls.usage[i], i_usage);
+        assert_eq!(gbls.usage[s], s_usage);
+        assert_eq!(gbls.usage[x], x_usage);
+        assert_eq!(gbls.usage[y], y_usage);
+    }
 }
-
-/*
-/// Computes for each basic block in `func` the set of live variables using simple fixed point
-/// iteration.
-pub fn liveness<'a>(func: &'a Function, &LivenessSets<'a>) -> HashMap<ControlFlowRef, HashSet<Cow<'static, str>>> {
-    let (varkill, uevar) = liveness_sets(func);
-    let mut liveout = HashMap::<ControlFlowRef, HashSet<&str>>::new();
-    let ord = func.postorder();
-    let cfg = func.cfg();
-
-    for &vx in ord.iter() {
-        if let Some(&ControlFlowTarget::Resolved(_)) = cfg.vertex_label(vx) {
-            liveout.insert(vx, HashSet::<&str>::new());
-        }
-    }
-
-    // compute LiveOut sets
-    let mut fixpoint = false;
-    while !fixpoint {
-        let mut new_liveout = HashMap::<ControlFlowRef, HashSet<&str>>::new();
-
-        fixpoint = true;
-        for &vx in ord.iter() {
-            let mut s = HashSet::<&str>::new();
-
-            if let Some(&ControlFlowTarget::Resolved(_)) = cfg.vertex_label(vx) {
-                for e in cfg.out_edges(vx) {
-                    let m = cfg.target(e);
-
-                    for x in uevar[&m].iter() {
-                        s.insert(x);
-                    }
-
-                    if let Some(&ControlFlowTarget::Resolved(_)) = cfg.vertex_label(m) {
-                        for x in liveout[&m].iter() {
-                            if !varkill[&m].contains(*x) {
-                                s.insert(x);
-                            }
-                        }
-                    }
-                }
-
-                if liveout[&vx] != s {
-                    fixpoint = false;
-                }
-
-                new_liveout.insert(vx, s);
-            }
-        }
-
-        liveout = new_liveout;
-    }
-
-    HashMap::from_iter(liveout.iter().map(|(&k, v)| (k, HashSet::from_iter(v.iter().map(|x| Cow::Owned(x.to_string()))))))
-}*/

--- a/data-flow/src/neo/mod.rs
+++ b/data-flow/src/neo/mod.rs
@@ -1,0 +1,7 @@
+//mod ssa;
+//pub use ssa::{
+//    ssa_convertion,
+//};
+
+mod liveness;
+pub use neo::liveness::{LivenessSets,liveness_sets,Globals,globals};

--- a/data-flow/src/neo/mod.rs
+++ b/data-flow/src/neo/mod.rs
@@ -4,4 +4,7 @@
 //};
 
 mod liveness;
-pub use neo::liveness::{LivenessSets,liveness_sets,Globals,globals};
+pub use neo::liveness::{Liveness,Globals};
+
+mod ssa;
+pub use neo::ssa::rewrite_to_ssa;

--- a/data-flow/src/neo/ssa.rs
+++ b/data-flow/src/neo/ssa.rs
@@ -1,0 +1,772 @@
+use std::iter::FromIterator;
+
+use petgraph::{Direction,Graph};
+use petgraph::graph::{NodeIndex};
+use petgraph::algo::dominators;
+use petgraph::algo::dominators::Dominators;
+use bit_set::BitSet;
+use smallvec::SmallVec;
+
+use panopticon_core::neo::{Function, Result, CfgNode, Statement, Operation, Mnemonic, BasicBlock, BasicBlockIndex, Value, Variable};
+use panopticon_core::Guard;
+
+use neo::Globals;
+
+pub fn phi_functions<'a>(func: &'a Function, globals: &Globals<'a>, domfronts: &Vec<BitSet>) -> Result<Vec<BitSet>> {
+    let mut ret = vec![BitSet::with_capacity(globals.variables.len()); func.basic_blocks().len()];
+
+    for g_idx in globals.globals.iter() {
+        let mut worklist = globals.usage[g_idx].clone();
+
+        while !worklist.is_empty() {
+            let bb_idx = worklist.iter().next().unwrap();
+
+            worklist.remove(bb_idx);
+            for df_idx in domfronts[bb_idx].iter() {
+                if !ret[df_idx].contains(g_idx) {
+                    ret[df_idx].insert(g_idx);
+                    worklist.insert(df_idx);
+                }
+            }
+        }
+    }
+
+    Ok(ret)
+}
+
+fn dominance_frontiers(func: &Function, doms: &Dominators<NodeIndex>) -> Result<Vec<BitSet>> {
+    let cfg = func.cflow_graph();
+    let num_bb = func.basic_blocks().len();
+    let mut ret = vec![BitSet::with_capacity(num_bb); num_bb];
+
+    for n in cfg.node_indices() {
+        if let Some(&CfgNode::BasicBlock(bb_idx)) = cfg.node_weight(n) {
+            let preds = cfg.neighbors_directed(n,Direction::Incoming).collect::<Vec<_>>();
+
+            if preds.len() > 1 {
+                for p in preds {
+                    let mut runner = p;
+                    let idom = doms.immediate_dominator(n);
+
+                    while idom.is_some() && Some(runner) != idom {
+                        if let Some(&CfgNode::BasicBlock(run_idx)) = cfg.node_weight(runner) {
+                            ret[run_idx.index()].insert(bb_idx.index());
+                            runner = doms.immediate_dominator(runner).unwrap();
+                        } else {
+                            return Err("Internal error: cfg node has a predecessor that's not a basic block".into());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(ret)
+}
+
+fn fix_uninitialized_variables(basic_block: &mut Vec<(Mnemonic,Vec<Statement>)>, uninit: BitSet, variables: &Vec<Variable>) {
+    basic_block.retain(|&(ref mne,_)| mne.opcode != "__init");
+
+    let start = basic_block[0].0.area.start;
+    for bit in uninit.iter() {
+        let var = &variables[bit];
+        let mne = Mnemonic::new(start..start,"__init");
+        let stmts = vec![Statement::Expression{
+            op: Operation::Initialize(var.name.clone(),var.bits),
+            result: var.clone()
+        }];
+
+        basic_block.insert(0,(mne,stmts));
+    }
+}
+
+struct NameStack {
+    counter: Vec<usize>,
+    stack: Vec<Vec<usize>>,
+}
+
+impl NameStack {
+    pub fn new(num_vars: usize) -> NameStack {
+        NameStack{
+            counter: vec![0; num_vars],
+            stack: vec![vec![]; num_vars],
+        }
+    }
+
+    pub fn new_name(&mut self, var: usize) -> Result<usize> {
+        let i = *self.counter.get(var)
+            .ok_or("Internal error: unknown variable")?;
+
+        self.counter[var] += 1;
+        self.stack[var].push(i);
+
+        Ok(i)
+    }
+
+    pub fn pop(&mut self, var: usize) -> Result<()> {
+        self.stack[var].pop()
+            .map(|_| ())
+            .ok_or("Internal error: empty name stack".into())
+    }
+
+    pub fn top(&self, var: usize) -> Result<usize> {
+        self.stack.get(var)
+            .ok_or("Internal error: unknown variable".into())
+            .and_then(|x| {
+                x.last().cloned()
+                 .ok_or("Internal error: empty name stack".into())
+            })
+    }
+}
+
+#[derive(Debug,PartialEq,Eq,PartialOrd,Ord)]
+enum DomTreeEvent {
+    Enter{
+        index: BasicBlockIndex,
+        successors: SmallVec<[BasicBlockIndex; 2]>,
+        start: u64,
+        num_in_edges: usize
+    },
+    Leave(BasicBlockIndex),
+}
+
+fn insert_phi_operations(basic_blocks: &mut [Vec<(Mnemonic,Vec<Statement>)>], phis: Vec<BitSet>,
+                         dom_events: &Vec<DomTreeEvent>, variables: &Vec<Variable>) -> Result<()> {
+    // Remove all Phi functions
+    for (bb_idx,vars) in phis.iter().enumerate() {
+        let bb = &mut basic_blocks[bb_idx];
+
+        bb.retain(|&(ref mne,_)| mne.opcode != "__phi");
+    }
+
+    for ev in dom_events {
+        match ev {
+            &DomTreeEvent::Enter{ index: bb_idx, start, num_in_edges,.. } => {
+                // Insert new Phi functions
+                for var_idx in phis[bb_idx.index()].iter() {
+                    let &Variable{ ref name, bits,.. } = &variables[var_idx];
+                    let mne = Mnemonic::new(start..start,"__phi");
+                    let num_phis = if num_in_edges <= 3 { 1 } else { (num_in_edges + 1) / 2 };
+                    let mut stmts = Vec::with_capacity(num_phis);
+
+                    for i in 0..num_phis {
+                        let prev = if i > 0 {
+                            Value::var(name.clone(),bits,None)?
+                        } else {
+                            Value::undef()
+                        };
+
+                        stmts.push(Statement::Expression{
+                            op: Operation::Phi(prev,Value::undef(),Value::undef()),
+                            result: Variable::new(name.clone(),bits,None)?,
+                        });
+                    }
+
+                    basic_blocks[bb_idx.index()].insert(0,(mne,stmts));
+                }
+            }
+            &DomTreeEvent::Leave(_) => { /* skip */ }
+        }
+    }
+
+    Ok(())
+}
+
+fn assign_subscripts(basic_blocks: &mut [Vec<(Mnemonic,Vec<Statement>)>],
+                     dom_events: Vec<DomTreeEvent>, variables: &Vec<Variable>) -> Result<()> {
+    let find_variable = |v: &Variable| -> Result<usize> {
+        variables.iter()
+            .position(|w| v.name == w.name && v.bits == w.bits)
+            .ok_or("Internal error: unknown variable".into())
+    };
+    let mut name_stack = NameStack::new(variables.len());
+
+    for ev in dom_events {
+        match ev {
+            DomTreeEvent::Enter{ index: bb_idx, start, successors, num_in_edges } => {
+                // Rewrite operations
+                for &mut (_,ref mut stmts) in basic_blocks[bb_idx.index()].iter_mut() {
+                    for stmt in stmts.iter_mut() {
+                        use panopticon_core::neo::Statement::*;
+
+                        match stmt {
+                            &mut Expression{ op: Operation::Phi(_,_,_), ref mut result } => {
+                                let var_idx = find_variable(&*result)?;
+                                result.subscript = Some(name_stack.new_name(var_idx)?);
+                            }
+                            &mut Expression{ ref mut op, ref mut result } => {
+                                for v in op.reads_mut() {
+                                    if let &mut Value::Variable(ref mut var) = v {
+                                        let var_idx = find_variable(&*var)?;
+                                        var.subscript = Some(name_stack.top(var_idx)?);
+                                    }
+                                }
+
+                                let var_idx = find_variable(&*result)?;
+                                result.subscript = Some(name_stack.new_name(var_idx)?);
+                            }
+                            &mut Call{ .. } => { /* skip */}
+                            &mut IndirectCall{ .. } => { /* skip */}
+                            &mut Return => { /* skip */}
+                            &mut Store{ ref mut address, ref mut value,.. } => {
+                                if let &mut Value::Variable(ref mut var) = address {
+                                    let var_idx = find_variable(&*var)?;
+                                    var.subscript = Some(name_stack.top(var_idx)?);
+                                }
+                                if let &mut Value::Variable(ref mut var) = value {
+                                    let var_idx = find_variable(&*var)?;
+                                    var.subscript = Some(name_stack.top(var_idx)?);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Fill Phi function args of all successor nodes
+                'outer: for succ in successors {
+                    let succ_bb: &mut Vec<(Mnemonic,Vec<_>)> = &mut basic_blocks[succ.index()];
+
+                    debug!("in {} handle successor {}",bb_idx.index(),succ.index());
+
+                    for &mut (ref mne,ref mut stmts) in succ_bb.iter_mut() {
+                        debug!("    mne {:?} {:?}",mne.area,mne.opcode);
+                        if mne.opcode != "__phi" { continue /*'outer*/; }
+
+                        for stmt in stmts.iter_mut() {
+                            use panopticon_core::neo::Statement::*;
+                            use panopticon_core::neo::Operation::Phi;
+
+                            match stmt {
+                                &mut Expression{ op: Phi(ref mut a, ref mut b, ref mut c), ref result } => {
+                                    debug!("  phi for {:?}",result);
+                                    let var_idx = find_variable(result)?;
+                                    if *a == Value::Undefined {
+                                        *a = Value::var(result.name.clone(),result.bits,name_stack.top(var_idx)?)?;
+                                    } else if *b == Value::Undefined {
+                                        *b = Value::var(result.name.clone(),result.bits,name_stack.top(var_idx)?)?;
+                                    } else if *c == Value::Undefined {
+                                        *c = Value::var(result.name.clone(),result.bits,name_stack.top(var_idx)?)?;
+                                    } else {
+                                        /* fall-thru to next Phi */
+                                    }
+                                }
+                                s => { return Err(format!("Internal error: non-phi operation '{:?}' in __phi mnemonic in basic block {:#x}",s,start).into()); }
+                            }
+                        }
+                    }
+                }
+            }
+            DomTreeEvent::Leave(bb_idx) => {
+                // Pop ssa names
+                let this_bb = &mut basic_blocks[bb_idx.index()];
+
+                for &mut (_,ref mut stmts) in this_bb.iter_mut() {
+                    for stmt in stmts.iter_mut() {
+                        use panopticon_core::neo::Statement::*;
+
+                        match stmt {
+                            &mut Expression{ ref mut result,.. } => {
+                                let var_idx = find_variable(&*result)?;
+                                name_stack.pop(var_idx);
+                            }
+                            &mut Call{ .. } => { /* skip */ }
+                            &mut IndirectCall{ .. } => { /* skip */ }
+                            &mut Return => { /* skip */ }
+                            &mut Store{ .. } => { /* skip */ }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn dominator_tree(func: &Function, doms: &Dominators<NodeIndex>) -> Result<Vec<DomTreeEvent>> {
+    let num_bb = func.basic_blocks().len();
+    let cfg = func.cflow_graph();
+    let mut tree = vec![BitSet::with_capacity(num_bb); num_bb];
+
+    for (bb_idx,bb) in func.basic_blocks() {
+        if let Some(idom) = doms.immediate_dominator(bb.node) {
+            if let Some(&CfgNode::BasicBlock(p_idx)) = cfg.node_weight(idom) {
+                tree[p_idx.index()].insert(bb_idx.index());
+            }
+        }
+    }
+
+    let mut completed = BitSet::with_capacity(num_bb);
+    let mut processing = BitSet::with_capacity(num_bb);
+    let mut stack = Vec::with_capacity(num_bb);
+    let entry_idx = match cfg.node_weight(doms.root()) {
+        Some(&CfgNode::BasicBlock(i)) => i,
+        _ => { return Err("Internal error: dominator tree root isn't a basic block".into()); }
+    };
+    let mut ret = Vec::with_capacity(num_bb * 2);
+
+    stack.push(entry_idx.index());
+
+    {
+        let entry = func.basic_block(entry_idx);
+        let in_edges = cfg.edges_directed(entry.node,Direction::Incoming).count();
+        let succ = cfg.neighbors_directed(entry.node,Direction::Outgoing).filter_map(|x| {
+            match cfg.node_weight(x) {
+                Some(&CfgNode::BasicBlock(i)) => Some(i),
+                _ => None
+            }
+        }).collect::<SmallVec<[BasicBlockIndex; 2]>>();
+
+        ret.push(DomTreeEvent::Enter{
+            index: entry_idx,
+            start: entry.area.start,
+            num_in_edges: in_edges,
+            successors: succ,
+        });
+    }
+
+    'outer: while !stack.is_empty() {
+        let n = *stack.last().unwrap();
+
+        for m in tree[n].iter() {
+            if !processing.contains(m) {
+                // Enter node
+                let bb_idx = BasicBlockIndex::new(m);
+                let bb = func.basic_block(bb_idx);
+                let in_edges = cfg.edges_directed(bb.node,Direction::Incoming).count();
+                let succ = cfg.neighbors_directed(bb.node,Direction::Outgoing).filter_map(|x| {
+                    match cfg.node_weight(x) {
+                        Some(&CfgNode::BasicBlock(i)) => Some(i),
+                        _ => None
+                    }
+                }).collect::<SmallVec<[BasicBlockIndex; 2]>>();
+
+                ret.push(DomTreeEvent::Enter{
+                    index: bb_idx,
+                    start: bb.area.start,
+                    num_in_edges: in_edges,
+                    successors: succ,
+                });
+                stack.push(m);
+                processing.insert(m);
+                continue 'outer;
+            }
+        }
+
+        // Leave node
+        ret.push(DomTreeEvent::Leave(BasicBlockIndex::new(n)));
+        completed.insert(n);
+        stack.pop();
+    }
+
+    Ok(ret)
+}
+
+pub fn rewrite_to_ssa(func: &mut Function) -> Result<()> {
+    use neo::{Liveness,Globals};
+
+    let entry = func.entry_point();
+    let doms = dominators::simple_fast(func.cflow_graph(),func.basic_block(entry).node);
+    let dom_events = dominator_tree(func,&doms)?;
+    let (phis,uninit,variables) = {
+        let live = Liveness::new(&func).unwrap();
+        let globals = Globals::new(&func,&live).unwrap();
+        let df = dominance_frontiers(&func,&doms).unwrap();
+        let phis = phi_functions(&func,&globals,&df).unwrap();
+        let mut uninit = live.ue_var[entry.index()].clone();
+
+        uninit.union_with(&globals.globals.difference(&live.var_kill[entry.index()]).collect());
+        (phis,uninit,live.variables.clone())
+    };
+    let fst_addr = func.first_address();
+
+    func.rewrite(|basic_blocks| {
+        fix_uninitialized_variables(&mut basic_blocks[entry.index()],uninit,&variables);
+        insert_phi_operations(basic_blocks,phis,&dom_events,&variables)?;
+        assign_subscripts(basic_blocks,dom_events,&variables)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use panopticon_core::{Guard, OpaqueLayer, Region, TestArch};
+    use panopticon_core::neo::{Function,Variable};
+    use neo::{Liveness,Globals};
+    use env_logger;
+    use petgraph::dot::Dot;
+    use std::iter;
+
+    /*
+     * (B0)
+     * 0:  Mx1  ; mov x 1
+     *
+     * (B1)
+     * 3:  Mx1  ; mov x 1
+     * 6:  Cfx1 ; cmp f x 1
+     * 10: Bf28 ; brle f (B5)
+     *
+     * (B2)
+     * 14: Mx1  ; mov x 1
+     *
+     * (B3)
+     * 17: Mx1  ; mov x 1
+     * 20: Cfx1 ; cmp f x 1
+     * 24: Bf3  ; brle f (B1)
+     *
+     * (B4)
+     * 27: R    ; ret
+     *
+     * (B5)
+     * 28: Mx1  ; mov x 1
+     * 31: Cfx1 ; cmp f x 1
+     * 34: Bf48 ; brle f (B8)
+     *
+     * (B6)
+     * 40:  Mx1 ; mov x 1
+     *
+     * (B7)
+     * 42:  Mx1 ; mov x 1
+     * 45:  J17 ; jmp (B3)
+     *
+     * (B8)
+     * 48:  J42 ; jmp (B7)
+     */
+    #[test]
+    fn dom_frontiers() {
+        let _ = env_logger::init();
+        let data = OpaqueLayer::wrap(b"Mx1Mx1Cfx1Bf28Mx1Mx1Cfx1Bf3RMx1Cfx1Bf48Mx1Mx1J17J42".to_vec());
+        let reg = Region::new("".to_string(), data);
+        let func = Function::new::<TestArch>((), 0, &reg, None).unwrap();
+        let ent_idx = func.entry_point();
+        let doms = dominators::simple_fast(func.cflow_graph(),func.basic_block(ent_idx).node);
+        let df = dominance_frontiers(&func,&doms).unwrap();
+        let set_1 = BitSet::from_iter(iter::once(1));
+        let set_3 = BitSet::from_iter(iter::once(3));
+        let set_7 = BitSet::from_iter(iter::once(7));
+        let expected_df = vec![
+            BitSet::default(),
+            set_1.clone(),
+            set_3.clone(),
+            set_1.clone(),
+            BitSet::default(),
+            set_3.clone(),
+            set_7.clone(),
+            set_3.clone(),
+            set_7.clone(),
+        ];
+
+        assert_eq!(df, expected_df);
+    }
+
+    /*
+     * (B0)
+     * 0:  Mi1  ; mov i 1
+     *
+     * (B1)
+     * 3:  Ma1  ; mov a 1
+     * 6:  Mc1  ; mov c 1
+     * 9:  Cfac ; cmp f a c
+     * 13: Bf46 ; br f (B5)
+     *
+     * (B2)
+     * 17: Mb1  ; mov b 1
+     * 20: Mc1  ; mov c 1
+     * 23: Md1  ; mov d 1
+     *
+     * (B3)
+     * 26: Ayab ; add y a b
+     * 30: Azcd ; add z c d
+     * 34: Aii1 ; add i i 1
+     * 38: Cfi1 ; cmp f i 1
+     * 42: Bf3  ; br f (B1)
+     *
+     * (B4)
+     * 45: R    ; ret
+     *
+     * (B5)
+     * 46: Ma1  ; mov a 1
+     * 49: Md1  ; mov d 1
+     * 52: Cfad ; cmp f a d
+     * 56: Bf69 ; br f (B8)
+     *
+     * (B6)
+     * 60:  Md1 ; mov d 1
+     *
+     * (B7)
+     * 63:  Mb1 ; mov b 1
+     * 66:  J26 ; jmp (B3)
+     *
+     * (B8)
+     * 69:  Mc1 ; mov c 1
+     * 72:  J63 ; jmp (B7)
+     */
+    #[test]
+    fn phi_placement() {
+        let _ = env_logger::init();
+        let data = OpaqueLayer::wrap(b"Mi1Ma1Mc1CfacBf46Mb1Mc1Md1AyabAzcdAii1Cfi1Bf3RMa1Md1CfadBf69Md1Mb1J26Mc1J63".to_vec());
+        let reg = Region::new("".to_string(), data);
+        let func = Function::new::<TestArch>((), 0, &reg, None).unwrap();
+        let ent_idx = func.entry_point();
+        let live = Liveness::new(&func).unwrap();
+        let globals = Globals::new(&func,&live).unwrap();
+        let doms = dominators::simple_fast(func.cflow_graph(),func.basic_block(ent_idx).node);
+        let df = dominance_frontiers(&func,&doms).unwrap();
+        let phis = phi_functions(&func,&globals,&df).unwrap();
+        let i = globals.index_for(&Variable::new("i",32,None).unwrap()).unwrap();
+        let a = globals.index_for(&Variable::new("a",32,None).unwrap()).unwrap();
+        let b = globals.index_for(&Variable::new("b",32,None).unwrap()).unwrap();
+        let c = globals.index_for(&Variable::new("c",32,None).unwrap()).unwrap();
+        let d = globals.index_for(&Variable::new("d",32,None).unwrap()).unwrap();
+        let abcdi_set = BitSet::from_iter(vec![a,b,c,d,i].into_iter());
+        let abcd_set = BitSet::from_iter(vec![a,b,c,d].into_iter());
+        let cd_set = BitSet::from_iter(vec![c,d].into_iter());
+        let expected_phis = vec![
+            BitSet::default(),
+            abcdi_set,
+            BitSet::default(),
+            abcd_set,
+            BitSet::default(),
+            BitSet::default(),
+            BitSet::default(),
+            cd_set,
+            BitSet::default(),
+        ];
+
+        assert_eq!(phis, expected_phis);
+    }
+
+    /*
+     * (B0)
+     * 0:  Mi1  ; mov i s
+     * 3:  Cfi0 ; cmp f i 0
+     * 7:  Bf18 ; br f (B2)
+     *
+     * (B1)
+     * 11: Aii3 ; add i i 3
+     * 15: J22  ; jmp (B3)
+     *
+     * (B2)
+     * 18: Ai23 ; add i 2 3
+     *
+     * (B3)
+     * 22: Ms3  ; mov s 3
+     * 25: Aisx ; add i s x
+     * 29: R    ; ret
+     */
+    #[test]
+    fn uninitialized_variables() {
+        let _ = env_logger::init();
+        let data = OpaqueLayer::wrap(b"MisCfi0Bf18Aii3J22Ai23Ms3AisxR".to_vec());
+        let reg = Region::new("".to_string(), data);
+        let mut func = Function::new::<TestArch>((), 0, &reg, None).unwrap();
+        let ent_idx = func.entry_point();
+        let (uninit,vars) = {
+            let live = Liveness::new(&func).unwrap();
+            let s = live.index_for(&Variable::new("s", 32, None).unwrap()).unwrap();
+            let x = live.index_for(&Variable::new("x", 32, None).unwrap()).unwrap();
+            let xs_set = BitSet::from_iter(vec![x,s].into_iter());
+            let uninit = live.ue_var[ent_idx.index()].clone();
+
+            assert_eq!(uninit, xs_set);
+
+            (uninit,live.variables.clone())
+        };
+        let _ = func.rewrite(|basic_blocks| {
+            let ent_bb = &mut basic_blocks[ent_idx.index()];
+            fix_uninitialized_variables(ent_bb,uninit,&vars);
+            Ok(())
+        }).unwrap();
+
+        let mnes = func.mnemonics(ent_idx).collect::<Vec<_>>();
+        assert_eq!(mnes.len(), 5);
+
+        assert_eq!(mnes[0].1.opcode, "__init");
+        let mne0 = func.statements(mnes[0].0).collect::<Vec<_>>();
+        assert_eq!(mne0.len(), 1);
+        if let Statement::Expression{ op: Operation::Initialize(ref name,len), result: Variable{ name: ref res_name, bits: res_bits,.. } } = mne0[0] {
+            assert_eq!(name, res_name);
+            assert_eq!(len, res_bits);
+            assert!(name == "x" || name == "s");
+        } else {
+            unreachable!()
+        }
+
+        assert_eq!(mnes[1].1.opcode, "__init");
+        let mne1 = func.statements(mnes[1].0).collect::<Vec<_>>();
+        assert_eq!(mne1.len(), 1);
+        if let Statement::Expression{ op: Operation::Initialize(ref name,len), result: Variable{ name: ref res_name, bits: res_bits,.. } } = mne1[0] {
+            assert_eq!(name, res_name);
+            assert_eq!(len, res_bits);
+            assert!(name == "x" || name == "s");
+        } else {
+            unreachable!()
+        }
+
+        let live = Liveness::new(&func).unwrap();
+        let uninit = live.ue_var[ent_idx.index()].clone();
+
+        assert!(uninit.is_empty());
+    }
+
+    #[test]
+    fn uninitialized_variables_reentrant() {
+        let _ = env_logger::init();
+        let data = OpaqueLayer::wrap(b"MisCfi0Bf18Aii3J22Ai23Ms3AisxR".to_vec());
+        let reg = Region::new("".to_string(), data);
+        let mut func = Function::new::<TestArch>((), 0, &reg, None).unwrap();
+        let ent_idx = func.entry_point();
+        let (uninit,vars) = {
+            let live = Liveness::new(&func).unwrap();
+            let s = live.index_for(&Variable::new("s", 32, None).unwrap()).unwrap();
+            let x = live.index_for(&Variable::new("x", 32, None).unwrap()).unwrap();
+            let xs_set = BitSet::from_iter(vec![x,s].into_iter());
+            let uninit = live.ue_var[ent_idx.index()].clone();
+
+            assert_eq!(uninit, xs_set);
+
+            (uninit,live.variables.clone())
+        };
+        let _ = func.rewrite(|basic_blocks| {
+            let ent_bb = &mut basic_blocks[ent_idx.index()];
+            fix_uninitialized_variables(ent_bb,uninit.clone(),&vars);
+            Ok(())
+        }).unwrap();
+        let _ = func.rewrite(|basic_blocks| {
+            let ent_bb = &mut basic_blocks[ent_idx.index()];
+            fix_uninitialized_variables(ent_bb,uninit,&vars);
+            Ok(())
+        }).unwrap();
+
+        let mnes = func.mnemonics(ent_idx).collect::<Vec<_>>();
+        assert_eq!(mnes.len(), 5);
+
+        assert_eq!(mnes[0].1.opcode, "__init");
+        let mne0 = func.statements(mnes[0].0).collect::<Vec<_>>();
+        assert_eq!(mne0.len(), 1);
+        if let Statement::Expression{ op: Operation::Initialize(ref name,len), result: Variable{ name: ref res_name, bits: res_bits,.. } } = mne0[0] {
+            assert_eq!(name, res_name);
+            assert_eq!(len, res_bits);
+            assert!(name == "x" || name == "s");
+        } else {
+            unreachable!()
+        }
+
+        assert_eq!(mnes[1].1.opcode, "__init");
+        let mne1 = func.statements(mnes[1].0).collect::<Vec<_>>();
+        assert_eq!(mne1.len(), 1);
+        if let Statement::Expression{ op: Operation::Initialize(ref name,len), result: Variable{ name: ref res_name, bits: res_bits,.. } } = mne1[0] {
+            assert_eq!(name, res_name);
+            assert_eq!(len, res_bits);
+            assert!(name == "x" || name == "s");
+        } else {
+            unreachable!()
+        }
+
+        let live = Liveness::new(&func).unwrap();
+        let uninit = live.ue_var[ent_idx.index()].clone();
+
+        assert!(uninit.is_empty());
+    }
+
+    #[test]
+    fn dominator_tree_events() {
+        let _ = env_logger::init();
+        let data = OpaqueLayer::wrap(b"Mi1Ma1Mc1CfacBf46Mb1Mc1Md1AyabAzcdAii1Cfi1Bf3RMa1Md1CfadBf69Md1Mb1J26Mc1J63".to_vec());
+        let reg = Region::new("".to_string(), data);
+        let func = Function::new::<TestArch>((), 0, &reg, None).unwrap();
+        let ent_idx = func.entry_point();
+        let doms = dominators::simple_fast(func.cflow_graph(),func.basic_block(ent_idx).node);
+        let mut events = dominator_tree(&func,&doms).unwrap();
+
+        let mut ctx = BitSet::with_capacity(func.basic_blocks().len());
+        for ev in events.iter() {
+            match ev {
+                &DomTreeEvent::Enter{ ref index, num_in_edges, ref successors, start } => {
+                    debug!("enter {}",index.index());
+                    assert!(ctx.insert(index.index()));
+                    match index.index() {
+                        0 => {
+                            assert_eq!(num_in_edges, 0);
+                            assert_eq!(successors.len(), 1);
+                            assert_eq!(successors[0].index(), 1);
+                            assert_eq!(start, 0);
+                        }
+                        1 => {
+                            assert_eq!(num_in_edges, 2);
+                            assert_eq!(successors.len(), 2);
+                            assert!(successors[0].index() == 2 || successors[0].index() == 5);
+                            assert!(successors[1].index() == 2 || successors[1].index() == 5);
+                            assert_eq!(start, 3);
+                        }
+                        2 => {
+                            assert_eq!(num_in_edges, 1);
+                            assert_eq!(successors.len(), 1);
+                            assert_eq!(successors[0].index(), 3);
+                            assert_eq!(start, 17);
+                        }
+                        3 => {
+                            assert_eq!(num_in_edges, 2);
+                            assert_eq!(successors.len(), 2);
+                            assert!(successors[0].index() == 4 || successors[0].index() == 1);
+                            assert!(successors[1].index() == 4 || successors[1].index() == 1);
+                            assert_eq!(start, 26);
+                        }
+                        4 => {
+                            assert_eq!(num_in_edges, 1);
+                            assert_eq!(successors.len(), 0);
+                            assert_eq!(start, 45);
+                        }
+                        5 => {
+                            assert_eq!(num_in_edges, 1);
+                            assert_eq!(successors.len(), 2);
+                            assert!(successors[0].index() == 6 || successors[0].index() == 8);
+                            assert!(successors[1].index() == 6 || successors[1].index() == 8);
+                            assert_eq!(start, 46);
+                        }
+                        6 => {
+                            assert_eq!(num_in_edges, 1);
+                            assert_eq!(successors.len(), 1);
+                            assert_eq!(successors[0].index(), 7);
+                            assert_eq!(start, 60);
+                        }
+                        7 => {
+                            assert_eq!(num_in_edges, 2);
+                            assert_eq!(successors.len(), 1);
+                            assert_eq!(successors[0].index(), 3);
+                            assert_eq!(start, 63);
+                        }
+                        8 => {
+                            assert_eq!(num_in_edges, 1);
+                            assert_eq!(successors.len(), 1);
+                            assert_eq!(successors[0].index(), 7);
+                            assert_eq!(start, 69);
+                        }
+                        _ => { unreachable!() }
+                    }
+                }
+                &DomTreeEvent::Leave(ref index) => {
+                    debug!("leave {}",index.index());
+                    assert!(index.index() <= 8 && index.index() >= 0);
+                    assert!(ctx.remove(index.index()));
+                }
+            }
+        }
+
+        assert!(ctx.is_empty());
+
+        assert_eq!(events.len(), 9*2);
+        events.sort();
+        events.dedup();
+        assert_eq!(events.len(), 9*2);
+    }
+
+    #[test]
+    fn phi_rename() {
+        let _ = env_logger::init();
+        let data = OpaqueLayer::wrap(b"Mi1Ma1Mc1CfacBf46Mb1Mc1Md1AyabAzcdAii1Cfi1Bf3RMa1Md1CfadBf69Md1Mb1J26Mc1J63".to_vec());
+        let reg = Region::new("".to_string(), data);
+        let mut func = Function::new::<TestArch>((), 0, &reg, None).unwrap();
+        let _ = rewrite_to_ssa(&mut func).unwrap();
+    }
+}

--- a/data-flow/src/ssa.rs
+++ b/data-flow/src/ssa.rs
@@ -16,19 +16,25 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-use liveness_sets;
-use panopticon_core::{ControlFlowEdge, ControlFlowGraph, ControlFlowRef, ControlFlowTarget, Function, Guard, Lvalue, Mnemonic, Operation, Result, Rvalue,
-                      Statement};
-use panopticon_graph_algos::{BidirectionalGraphTrait, EdgeListGraphTrait, GraphTrait, IncidenceGraphTrait, MutableGraphTrait, VertexListGraphTrait};
-use panopticon_graph_algos::dominator::{dominance_frontiers, immediate_dominator};
+use liveness;
+use panopticon_core::{ControlFlowGraph, ControlFlowTarget, ControlFlowRef, ControlFlowEdge, Guard, Lvalue, Mnemonic, Operation, Result, Rvalue, Statement};
+use petgraph::{Direction};
+use petgraph::algo::dominators::{self, Dominators};
+use petgraph::visit::EdgeRef;
+
 use std::borrow::Cow;
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
 
+use DataFlow;
+
+pub type Globals = HashSet<Cow<'static, str>>;
+pub type Usage = HashMap<Cow<'static, str>, HashSet<ControlFlowRef>>;
+
 /// Does a simple sanity check on all RREIL statements in `func`, returns every variable name
 /// found and its maximal size in bits.
-pub fn type_check(func: &Function) -> Result<HashMap<Cow<'static, str>, usize>> {
+pub(crate) fn type_check<Function: DataFlow>(func: &Function) -> Result<HashMap<Cow<'static, str>, usize>> {
     let mut ret = HashMap::<Cow<'static, str>, usize>::new();
     let cfg = func.cfg();
     fn set_len(v: &Rvalue, ret: &mut HashMap<Cow<'static, str>, usize>) {
@@ -40,9 +46,8 @@ pub fn type_check(func: &Function) -> Result<HashMap<Cow<'static, str>, usize>> 
             _ => {}
         }
     }
-
-    for vx in cfg.vertices() {
-        if let Some(&ControlFlowTarget::Resolved(ref bb)) = cfg.vertex_label(vx) {
+    for vx in cfg.node_indices() {
+        if let Some(&ControlFlowTarget::Resolved(ref bb)) = cfg.node_weight(vx) {
             for mne in bb.mnemonics.iter() {
                 for o in mne.operands.iter() {
                     set_len(o, &mut ret);
@@ -58,26 +63,24 @@ pub fn type_check(func: &Function) -> Result<HashMap<Cow<'static, str>, usize>> 
                             }
                         }
                     }
-
                     set_len(&instr.assignee.clone().into(), &mut ret);
                 }
             }
         }
     }
 
-    for ed in cfg.edges() {
-        if let Some(&Guard::Predicate { ref flag, .. }) = cfg.edge_label(ed) {
+    for ed in cfg.edge_indices() {
+        if let Some(&Guard::Predicate { ref flag, .. }) = cfg.edge_weight(ed) {
             set_len(flag, &mut ret);
         }
     }
-
     Ok(ret)
 }
 
 /// Computes the set of gloable variables in `func` and their points of usage. Globales are
 /// variables that are used in multiple basic blocks. Returns (Globals,Usage).
-pub fn global_names(func: &Function) -> (HashSet<Cow<'static, str>>, HashMap<Cow<'static, str>, HashSet<ControlFlowRef>>) {
-    let (varkill, uevar) = liveness_sets(func);
+pub(crate) fn global_names<Function: DataFlow>(func: &Function) -> (HashSet<Cow<'static, str>>, HashMap<Cow<'static, str>, HashSet<ControlFlowRef>>) {
+    let (varkill, uevar) = liveness::liveness_sets(func);
     let mut usage = HashMap::<Cow<'static, str>, HashSet<ControlFlowRef>>::new();
     let mut globals = HashSet::<Cow<'static, str>>::new();
 
@@ -98,11 +101,8 @@ pub fn global_names(func: &Function) -> (HashSet<Cow<'static, str>>, HashMap<Cow
 
 /// Inserts SSA Phi functions at junction points in the control flow graph of `func`. The
 /// algorithm produces the semi-pruned SSA form found in Cooper, Torczon: "Engineering a Compiler".
-pub fn phi_functions(func: &mut Function) -> Result<()> {
-    let lens = type_check(func)?;
-    let (globals, usage) = global_names(func);
-
-    // initalize all variables - TODO: I believe this should be inside of disassemble, no? E.g., creating a Function, then disassemble, is essentially a malformed object.
+pub(crate) fn phi_functions<Function: DataFlow>(func: &mut Function, globals: &Globals, usage: &Usage) -> Result<()> {
+    let lens = func.type_check()?;
     {
         let bb = func.entry_point_mut();
         let pos = bb.area.start;
@@ -141,14 +141,16 @@ pub fn phi_functions(func: &mut Function) -> Result<()> {
         bb.mnemonics.insert(0, mne);
     }
 
-    let idom = immediate_dominator(func.entry_point_ref(), func.cfg());
-    if idom.len() != func.cfg().num_vertices() {
-        return Err("No all basic blocks are reachable from function entry point".into());
-    }
+    let doms = dominators::simple_fast(func.cfg(), func.entry_point_ref());
 
-    let df = dominance_frontiers(&idom, func.cfg());
-    let mut phis = HashSet::<(&Cow<'static, str>, ControlFlowRef)>::new();
-    let mut cfg = &mut func.cfg_mut();
+    // FIXME: need exactsizeiterator for petgraph Dominators
+    //        if doms.count() != func.cfg().num_nodes() {
+    //            return Err("No all basic blocks are reachable from function entry point".into());
+    //        }
+
+    let df = doms.dominance_frontiers(func.cfg());
+    let mut phis = HashSet::<(&Cow<'static, str>, _)>::new();
+    let cfg = func.cfg_mut();
 
     for v in globals.iter() {
         let mut worklist = if let Some(wl) = usage.get(v) {
@@ -163,8 +165,8 @@ pub fn phi_functions(func: &mut Function) -> Result<()> {
 
             worklist.remove(&w);
             for d in frontiers.iter() {
-                let arg_num = cfg.in_edges(*d).filter_map(|p| usage.get(v).map(|b| b.contains(&cfg.source(p)))).count();
-                if let Some(&mut ControlFlowTarget::Resolved(ref mut bb)) = cfg.vertex_label_mut(*d) {
+                let arg_num = cfg.edges_directed(*d, Direction::Incoming).filter_map(|p| usage.get(v).map(|b| b.contains(&(p.source())))).count();
+                if let Some(&mut ControlFlowTarget::Resolved(ref mut bb)) = cfg.node_weight_mut(*d) {
                     if !phis.contains(&(v, *d)) {
 
                         let pos = bb.area.start;
@@ -187,7 +189,7 @@ pub fn phi_functions(func: &mut Function) -> Result<()> {
 
                         bb.mnemonics.insert(0, mne);
                         phis.insert((v, *d));
-                        worklist.insert(*d);
+                        worklist.insert((*d));
                     }
                 }
             }
@@ -200,17 +202,19 @@ pub fn phi_functions(func: &mut Function) -> Result<()> {
 /// Sets the SSA subscripts of all variables in `func`. Follows the algorithm outlined
 /// Cooper, Torczon: "Engineering a Compiler". The function expects that Phi functions to be
 /// already inserted.
-pub fn rename_variables(func: &mut Function) -> Result<()> {
-    let (globals, _) = global_names(func);
-    let mut stack = HashMap::<Cow<'static, str>, Vec<usize>>::from_iter(globals.iter().map(|x| (x.clone(), Vec::new())));
-    let mut counter = HashMap::<Cow<'static, str>, usize>::new();
-    let idom = immediate_dominator(func.entry_point_ref(), func.cfg());
+pub(crate) fn rename_variables<Function: DataFlow>(func: &mut Function, globals: &Globals) -> Result<()> {
+    type Counter = HashMap<Cow<'static, str>, usize>;
+    type Stack = HashMap<Cow<'static, str>, Vec<usize>>;
+    let mut stack = Stack::from_iter(globals.iter().map(|x| (x.clone(), Vec::new())));
+    let mut counter = Counter::new();
+    let doms = dominators::simple_fast(func.cfg(), func.entry_point_ref());
 
-    if idom.len() != func.cfg().num_vertices() {
-        return Err("No all basic blocks are reachable from function entry point".into());
-    }
+    // FIXME: check dominator matches node count
+    //        if dom.len() != func.cfg().node_count() {
+    //            return Err("No all basic blocks are reachable from function entry point".into());
+    //        }
 
-    fn new_name(n: &Cow<'static, str>, counter: &mut HashMap<Cow<'static, str>, usize>, stack: &mut HashMap<Cow<'static, str>, Vec<usize>>) -> usize {
+    fn new_name(n: &Cow<'static, str>, counter: &mut Counter, stack: &mut Stack) -> usize {
         let i = *counter.entry(n.clone()).or_insert(0);
 
         counter.get_mut(n).map(|x| *x += 1);
@@ -220,12 +224,12 @@ pub fn rename_variables(func: &mut Function) -> Result<()> {
     }
     fn rename(
         b: ControlFlowRef,
-        counter: &mut HashMap<Cow<'static, str>, usize>,
-        stack: &mut HashMap<Cow<'static, str>, Vec<usize>>,
+        counter: &mut Counter,
+        stack: &mut Stack,
         cfg: &mut ControlFlowGraph,
-        idom: &HashMap<ControlFlowRef, ControlFlowRef>,
+        doms: &Dominators<ControlFlowRef>,
     ) -> Result<()> {
-        if let Some(&mut ControlFlowTarget::Resolved(ref mut bb)) = cfg.vertex_label_mut(b) {
+        if let Some(&mut ControlFlowTarget::Resolved(ref mut bb)) = cfg.node_weight_mut(b) {
             bb.rewrite(
                 |i| match i {
                     &mut Statement {
@@ -238,6 +242,8 @@ pub fn rename_variables(func: &mut Function) -> Result<()> {
 
             for mne in bb.mnemonics.iter_mut() {
                 if mne.opcode != "__phi" {
+                    // this is where operand names are renamed from
+                    // 80e: mov ?, ? -> 80e: mov rbp, rsp
                     for o in mne.operands.iter_mut() {
                         if let &mut Rvalue::Variable { ref name, ref mut subscript, .. } = o {
                             *subscript = stack.get(name).and_then(|x| x.last()).cloned();
@@ -265,16 +271,17 @@ pub fn rename_variables(func: &mut Function) -> Result<()> {
             }
         }
 
-        let mut succ = cfg.out_edges(b).collect::<Vec<_>>();
-        succ.sort();
+        // FIXME: original is sorted, but it is sorting cfg indexes, which shouldn't be important for this algo?
+        // FIXME: actually need the walker api
+        let succ = cfg.edges_directed(b, Direction::Outgoing).map(|edge| (edge.id(), edge.target())).collect::<Vec<_>>();
 
-        for s in succ {
-            if let Some(&mut Guard::Predicate { flag: Rvalue::Variable { ref name, ref mut subscript, .. }, .. }) = cfg.edge_label_mut(s) {
+        for (id, target_vertex) in succ {
+            if let Some(&mut Guard::Predicate { flag: Rvalue::Variable { ref name, ref mut subscript, .. }, .. }) = cfg.edge_weight_mut(id) {
                 *subscript = stack[name].last().cloned();
             }
 
-            let v = cfg.target(s);
-            match cfg.vertex_label_mut(v) {
+            let v = target_vertex;
+            match cfg.node_weight_mut(v) {
                 Some(&mut ControlFlowTarget::Resolved(ref mut bb)) => {
                     bb.rewrite(
                         |i| match i {
@@ -297,13 +304,18 @@ pub fn rename_variables(func: &mut Function) -> Result<()> {
             }
         }
 
-        for (k, _) in idom.iter().filter(|&(_, &v)| v == b) {
-            if *k != b {
-                rename(*k, counter, stack, cfg, idom)?;
+        for k in cfg.node_indices().filter_map(|node| {
+            match doms.immediate_dominator(node) {
+                // add this node to the rename list iff its immediate dominator is the node we just renamed (b)
+                Some(v) if v == b => Some(node),
+                _ => None,
             }
+        }) {
+            // since immediate_dominator(k) != k in petgraph, we do not have to worry about infinite recursion
+            rename(k, counter, stack, cfg, doms)?;
         }
 
-        if let Some(&mut ControlFlowTarget::Resolved(ref mut bb)) = cfg.vertex_label_mut(b) {
+        if let Some(&mut ControlFlowTarget::Resolved(ref mut bb)) = cfg.node_weight_mut(b) {
             bb.execute(
                 |i| match i {
                     &Statement { assignee: Lvalue::Variable { ref name, .. }, .. } => {
@@ -322,25 +334,19 @@ pub fn rename_variables(func: &mut Function) -> Result<()> {
         &mut counter,
         &mut stack,
         func.cfg_mut(),
-        &idom,
+        &doms,
     )
 }
 
-/// Convert `func` into semi-pruned SSA form.
-pub fn ssa_convertion(func: &mut Function) -> Result<()> {
-    phi_functions(func)?;
-    rename_variables(func)
-}
-
-/// Computes for every control flow guard the dependend RREIL operation via reverse data flow
+/// Computes for every control flow guard the dependent RREIL operation via reverse data flow
 /// analysis.
-pub fn flag_operations(func: &Function) -> HashMap<ControlFlowEdge, Operation<Rvalue>> {
+pub(crate) fn flag_operations<Function: DataFlow>(func: &Function) -> HashMap<ControlFlowEdge, Operation<Rvalue>> {
     let mut ret = HashMap::new();
-
-    for e in func.cfg().edges() {
-        if !ret.contains_key(&e) {
-            if let Some(&Guard::Predicate { ref flag, .. }) = func.cfg().edge_label(e) {
-                let maybe_bb = func.cfg().vertex_label(func.cfg().source(e));
+    let cfg = func.cfg();
+    for e in cfg.edge_references() {
+        if !ret.contains_key(&e.id()) {
+            if let &Guard::Predicate { ref flag, .. } = e.weight() {
+                let maybe_bb = func.cfg().node_weight(e.source());
                 if let Some(&ControlFlowTarget::Resolved(ref bb)) = maybe_bb {
                     let mut maybe_stmt = None;
                     bb.execute(
@@ -360,7 +366,7 @@ pub fn flag_operations(func: &Function) -> HashMap<ControlFlowEdge, Operation<Rv
                     );
 
                     if maybe_stmt.is_some() {
-                        ret.insert(e.clone(), maybe_stmt.unwrap());
+                        ret.insert(e.id(), maybe_stmt.unwrap());
                     }
                 }
             }
@@ -374,9 +380,10 @@ pub fn flag_operations(func: &Function) -> HashMap<ControlFlowEdge, Operation<Rv
 mod tests {
     use super::*;
     use panopticon_core::{BasicBlock, ControlFlowGraph, ControlFlowTarget, Function, Guard, Lvalue, Mnemonic, Operation, Region, Rvalue, Statement};
-    use panopticon_graph_algos::{GraphTrait, MutableGraphTrait, VertexListGraphTrait};
     use std::borrow::Cow;
     use std::collections::HashSet;
+    use petgraph::Graph;
+    use petgraph::algo::dominators;
 
     #[test]
     fn phi() {
@@ -607,42 +614,42 @@ mod tests {
         let bb8 = BasicBlock::from_vec(vec![mne8]);
         let mut cfg = ControlFlowGraph::new();
 
-        let v0 = cfg.add_vertex(ControlFlowTarget::Resolved(bb0));
-        let v1 = cfg.add_vertex(ControlFlowTarget::Resolved(bb1));
-        let v2 = cfg.add_vertex(ControlFlowTarget::Resolved(bb2));
-        let v3 = cfg.add_vertex(ControlFlowTarget::Resolved(bb3));
-        let v4 = cfg.add_vertex(ControlFlowTarget::Resolved(bb4));
-        let v5 = cfg.add_vertex(ControlFlowTarget::Resolved(bb5));
-        let v6 = cfg.add_vertex(ControlFlowTarget::Resolved(bb6));
-        let v7 = cfg.add_vertex(ControlFlowTarget::Resolved(bb7));
-        let v8 = cfg.add_vertex(ControlFlowTarget::Resolved(bb8));
+        let v0 = cfg.add_node(ControlFlowTarget::Resolved(bb0));
+        let v1 = cfg.add_node(ControlFlowTarget::Resolved(bb1));
+        let v2 = cfg.add_node(ControlFlowTarget::Resolved(bb2));
+        let v3 = cfg.add_node(ControlFlowTarget::Resolved(bb3));
+        let v4 = cfg.add_node(ControlFlowTarget::Resolved(bb4));
+        let v5 = cfg.add_node(ControlFlowTarget::Resolved(bb5));
+        let v6 = cfg.add_node(ControlFlowTarget::Resolved(bb6));
+        let v7 = cfg.add_node(ControlFlowTarget::Resolved(bb7));
+        let v8 = cfg.add_node(ControlFlowTarget::Resolved(bb8));
 
-        cfg.add_edge(Guard::always(), v0, v1);
+        cfg.add_edge( v0,  v1, Guard::always());
 
         let g1 = Guard::from_flag(&f.clone().into()).ok().unwrap();
-        cfg.add_edge(g1.clone(), v1, v2);
-        cfg.add_edge(g1.negation(), v1, v5);
+        cfg.add_edge( v1,  v2, g1.clone());
+        cfg.add_edge( v1,  v5, g1.negation());
 
-        cfg.add_edge(Guard::always(), v2, v3);
+        cfg.add_edge( v2,  v3, Guard::always());
 
         let g3 = Guard::from_flag(&f.clone().into()).ok().unwrap();
-        cfg.add_edge(g3.clone(), v3, v1);
-        cfg.add_edge(g3.negation(), v3, v4);
+        cfg.add_edge( v3,  v1, g3.clone());
+        cfg.add_edge( v3,  v4, g3.negation());
 
         let g5 = Guard::from_flag(&f.clone().into()).ok().unwrap();
-        cfg.add_edge(g5.clone(), v5, v6);
-        cfg.add_edge(g5.negation(), v5, v8);
+        cfg.add_edge( v5,  v6, g5.clone());
+        cfg.add_edge( v5,  v8, g5.negation());
 
-        cfg.add_edge(Guard::always(), v6, v7);
-        cfg.add_edge(Guard::always(), v7, v3);
-        cfg.add_edge(Guard::always(), v8, v7);
+        cfg.add_edge( v6,  v7, Guard::always());
+        cfg.add_edge( v7,  v3, Guard::always());
+        cfg.add_edge( v8,  v7, Guard::always());
 
         let mut func = Function::undefined(0, None, &Region::undefined("ram".to_owned(), 100), None);
 
         *func.cfg_mut() = cfg;
         func.set_entry_point_ref(v0);
-
-        assert!(phi_functions(&mut func).is_ok());
+        let (globals, usage) = func.global_names();
+        assert!(phi_functions(&mut func, &globals, &usage).is_ok());
 
         let a0 = Lvalue::Variable { name: Cow::Borrowed("a"), size: 32, subscript: None };
         let b0 = Lvalue::Variable { name: Cow::Borrowed("b"), size: 32, subscript: None };
@@ -651,14 +658,14 @@ mod tests {
         let i0 = Lvalue::Variable { name: Cow::Borrowed("i"), size: 32, subscript: None };
 
         // bb0
-        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().vertex_label(v0) {
+        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().node_weight(v0) {
             assert!(bb.mnemonics[0].opcode != "__phi".to_string());
         } else {
             unreachable!()
         }
 
         // bb1
-        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().vertex_label(v1) {
+        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().node_weight(v1) {
             assert_eq!(bb.mnemonics[0].opcode, "__phi".to_string());
             assert_eq!(bb.mnemonics[1].opcode, "__phi".to_string());
             assert_eq!(bb.mnemonics[2].opcode, "__phi".to_string());
@@ -684,14 +691,14 @@ mod tests {
         }
 
         // bb2
-        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().vertex_label(v2) {
+        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().node_weight(v2) {
             assert!(bb.mnemonics[0].opcode != "__phi".to_string());
         } else {
             unreachable!()
         }
 
         // bb3
-        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().vertex_label(v3) {
+        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().node_weight(v3) {
             assert_eq!(bb.mnemonics[0].opcode, "__phi".to_string());
             assert_eq!(bb.mnemonics[1].opcode, "__phi".to_string());
             assert_eq!(bb.mnemonics[2].opcode, "__phi".to_string());
@@ -714,28 +721,28 @@ mod tests {
         }
 
         // bb4
-        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().vertex_label(v4) {
+        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().node_weight(v4) {
             assert!(bb.mnemonics[0].opcode != "__phi".to_string());
         } else {
             unreachable!()
         }
 
         // bb5
-        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().vertex_label(v5) {
+        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().node_weight(v5) {
             assert!(bb.mnemonics[0].opcode != "__phi".to_string());
         } else {
             unreachable!()
         }
 
         // bb6
-        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().vertex_label(v6) {
+        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().node_weight(v6) {
             assert!(bb.mnemonics[0].opcode != "__phi".to_string());
         } else {
             unreachable!()
         }
 
         // bb7
-        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().vertex_label(v7) {
+        if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().node_weight(v7) {
             assert_eq!(bb.mnemonics[0].opcode, "__phi".to_string());
             assert_eq!(bb.mnemonics[1].opcode, "__phi".to_string());
             assert!(bb.mnemonics[2].opcode != "__phi".to_string());
@@ -981,46 +988,45 @@ mod tests {
         let bb8 = BasicBlock::from_vec(vec![mne8]);
         let mut cfg = ControlFlowGraph::new();
 
-        let v0 = cfg.add_vertex(ControlFlowTarget::Resolved(bb0));
-        let v1 = cfg.add_vertex(ControlFlowTarget::Resolved(bb1));
-        let v2 = cfg.add_vertex(ControlFlowTarget::Resolved(bb2));
-        let v3 = cfg.add_vertex(ControlFlowTarget::Resolved(bb3));
-        let v4 = cfg.add_vertex(ControlFlowTarget::Resolved(bb4));
-        let v5 = cfg.add_vertex(ControlFlowTarget::Resolved(bb5));
-        let v6 = cfg.add_vertex(ControlFlowTarget::Resolved(bb6));
-        let v7 = cfg.add_vertex(ControlFlowTarget::Resolved(bb7));
-        let v8 = cfg.add_vertex(ControlFlowTarget::Resolved(bb8));
+        let v0 = cfg.add_node(ControlFlowTarget::Resolved(bb0));
+        let v1 = cfg.add_node(ControlFlowTarget::Resolved(bb1));
+        let v2 = cfg.add_node(ControlFlowTarget::Resolved(bb2));
+        let v3 = cfg.add_node(ControlFlowTarget::Resolved(bb3));
+        let v4 = cfg.add_node(ControlFlowTarget::Resolved(bb4));
+        let v5 = cfg.add_node(ControlFlowTarget::Resolved(bb5));
+        let v6 = cfg.add_node(ControlFlowTarget::Resolved(bb6));
+        let v7 = cfg.add_node(ControlFlowTarget::Resolved(bb7));
+        let v8 = cfg.add_node(ControlFlowTarget::Resolved(bb8));
 
-        cfg.add_edge(Guard::always(), v0, v1);
+        cfg.add_edge( v0,  v1, Guard::always());
 
         let g1 = Guard::from_flag(&f.clone().into()).ok().unwrap();
-        cfg.add_edge(g1.clone(), v1, v2);
-        cfg.add_edge(g1.negation(), v1, v5);
+        cfg.add_edge( v1,  v2, g1.clone());
+        cfg.add_edge( v1,  v5, g1.negation());
 
-        cfg.add_edge(Guard::always(), v2, v3);
+        cfg.add_edge( v2,  v3, Guard::always());
 
         let g3 = Guard::from_flag(&f.clone().into()).ok().unwrap();
-        cfg.add_edge(g3.clone(), v3, v1);
-        cfg.add_edge(g3.negation(), v3, v4);
+        cfg.add_edge( v3,  v1, g3.clone());
+        cfg.add_edge( v3,  v4, g3.negation());
 
         let g5 = Guard::from_flag(&f.clone().into()).ok().unwrap();
-        cfg.add_edge(g5.clone(), v5, v6);
-        cfg.add_edge(g5.negation(), v5, v8);
+        cfg.add_edge( v5,  v6, g5.clone());
+        cfg.add_edge( v5,  v8, g5.negation());
 
-        cfg.add_edge(Guard::always(), v6, v7);
-        cfg.add_edge(Guard::always(), v7, v3);
-        cfg.add_edge(Guard::always(), v8, v7);
+        cfg.add_edge( v6,  v7, Guard::always());
+        cfg.add_edge( v7,  v3, Guard::always());
+        cfg.add_edge( v8,  v7, Guard::always());
 
         let mut func = Function::undefined(0, None, &Region::undefined("ram".to_owned(), 100), None);
 
         *func.cfg_mut() = cfg;
         func.set_entry_point_ref(v0);
 
-        assert!(phi_functions(&mut func).is_ok());
-        assert!(rename_variables(&mut func).is_ok());
+        assert!(func.ssa_conversion().is_ok());
 
-        for v in func.cfg().vertices() {
-            if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().vertex_label(v) {
+        for v in func.cfg().node_indices() {
+            if let Some(&ControlFlowTarget::Resolved(ref bb)) = func.cfg().node_weight(v) {
                 bb.execute(
                     |i| {
                         if let Lvalue::Variable { subscript, .. } = i.assignee {
@@ -1038,5 +1044,161 @@ mod tests {
                 unreachable!()
             }
         }
+    }
+
+    #[test]
+    fn dom_pet() {
+        let mut g = Graph::<usize, ()>::new();
+        let v1 = g.add_node(1);
+        let v2 = g.add_node(2);
+        let v3 = g.add_node(3);
+        let v4 = g.add_node(4);
+        let v5 = g.add_node(5);
+        let v6 = g.add_node(6);
+
+        g.add_edge(v1, v2, ());
+        g.add_edge(v2, v3, ());
+        g.add_edge(v2, v4, ());
+        g.add_edge(v2, v6, ());
+        g.add_edge(v3, v5, ());
+        g.add_edge(v4, v5, ());
+        g.add_edge(v5, v2, ());
+
+        let dom = dominators::simple_fast(&g, v1);
+        assert_eq!(dom.dominators(v1).unwrap().collect::<Vec<_>>(), vec![v1]);
+        assert_eq!(dom.dominators(v2).unwrap().collect::<Vec<_>>(), vec![v2,v1]);
+        assert_eq!(dom.dominators(v3).unwrap().collect::<Vec<_>>(), vec![v3,v2,v1]);
+        assert_eq!(dom.dominators(v4).unwrap().collect::<Vec<_>>(), vec![v4,v2,v1]);
+        assert_eq!(dom.dominators(v5).unwrap().collect::<Vec<_>>(), vec![v5,v2,v1]);
+        assert_eq!(dom.dominators(v6).unwrap().collect::<Vec<_>>(), vec![v6,v2,v1]);
+
+    }
+
+    #[test]
+    fn issue_5() {
+        let mut g = Graph::<usize, ()>::new();
+
+        let v0 = g.add_node(0);
+        let v1 = g.add_node(1);
+        let v2 = g.add_node(2);
+        let v3 = g.add_node(3);
+        let v4 = g.add_node(4);
+        let v5 = g.add_node(5);
+        let v6 = g.add_node(6);
+        let v7 = g.add_node(7);
+        let v8 = g.add_node(8);
+        let v9 = g.add_node(9);
+        let v10 = g.add_node(10);
+        let v11 = g.add_node(11);
+
+        g.add_edge( v0,  v2, ());
+        g.add_edge( v6,  v7, ());
+        g.add_edge( v4,  v3, ());
+        g.add_edge( v1,  v9, ());
+        g.add_edge( v5,  v7, ());
+        g.add_edge( v3,  v4, ());
+        g.add_edge( v10,  v11, ());
+        g.add_edge( v9,  v0, ());
+        g.add_edge( v7,  v6, ());
+        g.add_edge( v2,  v4, ());
+        g.add_edge( v11,  v11, ());
+        g.add_edge( v4,  v5, ());
+        g.add_edge( v8,  v10, ());
+        g.add_edge( v7,  v8, ());
+
+        let _doms = dominators::simple_fast(&g, v1);
+        // not sure what this issue was testing exactly
+        //assert_eq!(doms.count(), 12);
+    }
+
+    #[test]
+    fn immediate_dom_pet() {
+        let mut g = Graph::<usize, ()>::new();
+        let v1 = g.add_node(1);
+        let v2 = g.add_node(2);
+        let v3 = g.add_node(3);
+        let v4 = g.add_node(4);
+        let v5 = g.add_node(5);
+        let v6 = g.add_node(6);
+
+        g.add_edge(v6, v5, ());
+        g.add_edge(v6, v4, ());
+        g.add_edge(v5, v1, ());
+        g.add_edge(v4, v2, ());
+        g.add_edge(v4, v3, ());
+        g.add_edge(v3, v2, ());
+        g.add_edge(v2, v3, ());
+        g.add_edge(v1, v2, ());
+        g.add_edge(v2, v1, ());
+
+        let dom = dominators::simple_fast(&g, v6);
+
+        println!("Before 1");
+        assert_eq!(dom.immediate_dominator(v1).unwrap(), v6);
+        println!("Before 2");
+        assert_eq!(dom.immediate_dominator(v2).unwrap(), v6);
+        println!("Before 3");
+        assert_eq!(dom.immediate_dominator(v3).unwrap(), v6);
+        println!("Before 4");
+        assert_eq!(dom.immediate_dominator(v4).unwrap(), v6);
+        println!("Before 5");
+        assert_eq!(dom.immediate_dominator(v5).unwrap(), v6);
+        println!("Before 6");
+        // this is change/regression from old behavior but is technically correct now
+        assert_eq!(dom.immediate_dominator(v6), None);
+
+        let mut g2 = Graph::<usize, ()>::new();
+        let v7 = g2.add_node(7);
+        g2.add_edge(v7, v7, ());
+        let doms = dominators::simple_fast(&g2, v7);
+        let idom = doms.immediate_dominator(v7);
+
+        assert_eq!(None, idom);
+    }
+
+    #[test]
+    fn dominance_frontiers_pet () {
+        let mut g = Graph::<usize, ()>::new();
+        let a = g.add_node(0);
+        let b = g.add_node(1);
+        let c = g.add_node(2);
+        let d = g.add_node(3);
+        let e = g.add_node(4);
+        let f = g.add_node(5);
+
+        g.add_edge(a, b, ());
+        g.add_edge(b, c, ());
+        g.add_edge(b, d, ());
+        g.add_edge(c, e, ());
+        g.add_edge(d, e, ());
+        g.add_edge(e, f, ());
+        g.add_edge(a, f, ());
+
+        let dom = dominators::simple_fast(&g, a);
+
+        //assert_eq!(dom.len(), 6);
+        println!("Before 1");
+        assert_eq!(dom.immediate_dominator(a), None);
+        println!("Before 2");
+        assert_eq!(dom.immediate_dominator(b).unwrap(), a);
+        println!("Before 3");
+        assert_eq!(dom.immediate_dominator(c).unwrap(), b);
+        println!("Before 4");
+        assert_eq!(dom.immediate_dominator(d).unwrap(), b);
+        println!("Before 5");
+        assert_eq!(dom.immediate_dominator(e).unwrap(), b);
+        println!("Before 6");
+        assert_eq!(dom.immediate_dominator(f).unwrap(), a);
+
+
+        let fron = dom.dominance_frontiers(&g);
+
+        assert_eq!(fron.len(), 6);
+        assert_eq!(fron[&a], vec![]);
+        assert_eq!(fron[&b], vec![f]);
+        assert_eq!(fron[&c], vec![e]);
+        assert_eq!(fron[&d], vec![e]);
+        assert_eq!(fron[&e], vec![f]);
+        assert_eq!(fron[&f], vec![]);
     }
 }

--- a/qt/Cargo.toml
+++ b/qt/Cargo.toml
@@ -36,7 +36,7 @@ num = "0.1"
 
 [dev-dependencies]
 regex = "0.1"
-quickcheck = "0.3"
+quickcheck = "0.4"
 
 [target.i686-unknown-linux-gnu.dependencies]
 xdg = "^2.0"

--- a/qt/src/main.rs
+++ b/qt/src/main.rs
@@ -139,14 +139,14 @@ fn exists_path_val(filepath: String) -> result::Result<(), String> {
 fn read_recent_sessions() -> Result<Vec<(String, String, PathBuf, u32)>> {
     use std::fs;
     use std::time;
-    use panopticon_core::Project;
+    use panopticon_core::{Function, Project};
 
     let path = paths::session_directory()?;
     let mut ret = vec![];
 
     if let Ok(dir) = fs::read_dir(path) {
         for ent in dir.filter_map(|x| x.ok()) {
-            if let Ok(ref project) = Project::open(&ent.path()) {
+            if let Ok(ref project) = <Project<Function>>::open(&ent.path()) {
                 if let Ok(ref md) = ent.metadata() {
                     let mtime = md.modified()?.duration_since(time::UNIX_EPOCH)?.as_secs() as u32;
                     let fname = ent.path();

--- a/qt/src/singleton.rs
+++ b/qt/src/singleton.rs
@@ -65,7 +65,7 @@ pub struct Panopticon {
     pub unresolved_calls: MultiMap<Option<u64>, (Uuid, u64)>,
     pub resolved_calls: MultiMap<Uuid, (Uuid, u64)>, // callee -> caller
     pub region: Option<Region>,
-    pub project: Option<Project>,
+    pub project: Option<Project<Function>>,
 
     pub undo_stack: Vec<Action>,
     pub undo_stack_top: usize,
@@ -126,7 +126,7 @@ impl Panopticon {
 
     pub fn open_program(&mut self, path: String) -> Result<()> {
         use std::path::Path;
-        use panopticon_core::{CallTarget, Machine};
+        use panopticon_core::{Function, CallTarget, Machine};
         use panopticon_amd64 as amd64;
         use panopticon_avr as avr;
         use panopticon_analysis::pipeline;
@@ -135,7 +135,7 @@ impl Panopticon {
 
         debug!("open_program() path={}", path);
 
-        if let Ok(proj) = Project::open(&Path::new(&path)) {
+        if let Ok(proj) = <Project<Function>>::open(&Path::new(&path)) {
             if !proj.code.is_empty() {
                 {
                     let cg = &proj.code[0].call_graph;


### PR DESCRIPTION
@flanfly Only thing that remains of graph_algos is in `abstract_interp`

Seems you're working on data-flow esque stuff, so perhaps I'll leave that to you, especially if you add a new impl for neo (it's also apparently only used in QT currently)?

If that's alright, I won't mess with abstract_interp so we don't step on each others toes; if you're working on something else, let me know.

Also I'll rebase this branch off of bincode as though its master, in case this keeps going, so no need to delete (until it gets merged into master, that is) ;)

Anyway:

1. Totally removes graph_algos from core!
2. Also removes longstanding pointless imports field from project
3. re-adds `to_dot` impls using petgraphs version

Also, hilariously, adding this patch to disassembler (which I assumed was safe and would be a quick allocation-less gain in disassembler) causes the benchmarks to spiral out of control and use all memory on my system :sob: 

```diff
diff --git a/amd64/src/architecture.rs b/amd64/src/architecture.rs
index 2d056e6..19e7e65 100644
--- a/amd64/src/architecture.rs
+++ b/amd64/src/architecture.rs
@@ -55,14 +55,16 @@ impl Architecture for Amd64 {
     }
 
     fn decode(reg: &Region, start: u64, cfg: &Self::Configuration) -> Result<Match<Self>> {
+        const MAX: usize = 16;
         let data = reg.iter();
-        let mut buf: Vec<u8> = vec![];
+        let mut buf: [u8; MAX] = [0; MAX];
         let mut i = data.seek(start);
         let p = start;
-
+        let mut len = 0;
         while let Some(Some(b)) = i.next() {
-            buf.push(b);
-            if buf.len() == 15 {
+            buf[len] = b;
+            len += 1;
+            if len == MAX {
                 break;
             }
         }
```

Anyway, I think I want to work on the disassembler because:

1. I think there could be some easy perf gains (ostensibly like above, I suspect that's some weird compiler/benchmark bug?)
2. I don't really understand 