### PR TITLE
completely remove graph_algos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,7 +549,6 @@ dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "panopticon-avr 0.16.0",
- "panopticon-graph-algos 0.11.0",
  "petgraph 0.4.10 (git+https://github.com/m4b/petgraph?branch=dominance_frontiers)",
  "quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -171,7 +171,7 @@ fn print_reverse_deps<Function: Fun, W: Write + WriteColor>(mut fmt: W, program:
 fn disassemble<Function: Fun + DataFlow + Send>(binary: &str) -> Result<Program<Function>> {
     let (mut proj, machine) = loader::load(Path::new(&binary))?;
     let program = proj.code.pop().unwrap();
-    let reg = proj.region().clone();
+    let reg = proj.region();
     info!("disassembly thread started");
     Ok(match machine {
         Machine::Avr => analyze::<avr::Avr, Function>(program, reg.clone(), avr::Mcu::atmega103()),

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,7 +14,6 @@ uuid = { version = "0.5", features = ["v4", "serde"]}
 flate2 = "0.2.13"
 byteorder = "1"
 goblin = "0.0.11"
-panopticon-graph-algos = { path = "../graph-algos" }
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_cbor = "0.6"

--- a/core/src/function.rs
+++ b/core/src/function.rs
@@ -722,57 +722,13 @@ impl Function {
     pub fn statements<'b>(&'b self) -> Box<Iterator<Item=&'b Statement> + 'b> {
         Box::new(self.basic_blocks().map(|bb| bb.statements()).flat_map(|ss| ss))
     }
-}
-    ///// Returns the functions basic block graph in graphivz's DOT format. Useful for debugging.
-//    pub fn to_dot(&self) -> String {
-//        let mut ret = "digraph G {".to_string();
-//
-//        for v in self.cflow_graph.node_indices() {
-//            match self.cflow_graph.node_weight(v) {
-//                Some(&ControlFlowTarget::Resolved(ref bb)) => {
-//                    ret = format!(
-//                        "{}\n{} [label=<<table border=\"0\"><tr><td>{}:{}</td></tr>",
-//                        ret,
-//                        v.0,
-//                        bb.area.start,
-//                        bb.area.end
-//                    );
-//
-//                    for mne in bb.mnemonics.iter() {
-//                        ret = format!("{}<tr><td align=\"left\">{}</td></tr>", ret, mne.opcode);
-//                        for i in mne.instructions.iter() {
-//                            ret = format!(
-//                                "{}<tr><td align=\"left\">&nbsp;&nbsp;&nbsp;&nbsp;{}</td></tr>",
-//                                ret,
-//                                i
-//                            );
-//                        }
-//                    }
-//
-//                    ret = format!("{}</table>>,shape=record];", ret);
-//                }
-//                Some(&ControlFlowTarget::Unresolved(ref c)) => {
-//                    ret = format!("{}\n{} [label=\"{:?}\",shape=circle];", ret, v.0, c);
-//                }
-//                _ => {
-//                    ret = format!("{}\n{} [label=\"?\",shape=circle];", ret, v.0);
-//                }
-//            }
-//        }
-//
-////        for e in self.cflow_graph.edges() {
-////            ret = format!(
-////                "{}\n{} -> {} [label=\"{}\"];",
-////                ret,
-////                self.cflow_graph.source(e).0,
-////                self.cflow_graph.target(e).0,
-////                self.cflow_graph.edge_label(e).unwrap()
-////            );
-////        }
-//
-//        format!("{}\n}}", ret)
-//    }
 
+    /// Returns the functions basic block graph in graphivz's DOT format. Useful for debugging.
+    pub fn to_dot(&self) -> String {
+        use petgraph::dot::Dot;
+        format!("{:?}", Dot::new(&self.cflow_graph))
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -80,7 +80,6 @@ extern crate log;
 
 extern crate num;
 extern crate flate2;
-extern crate panopticon_graph_algos;
 extern crate uuid;
 extern crate byteorder;
 extern crate goblin;

--- a/core/src/project.rs
+++ b/core/src/project.rs
@@ -22,7 +22,6 @@
 
 
 use {CallGraphRef, Fun, Program, Region, Result, World};
-use panopticon_graph_algos::GraphTrait;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use flate2::Compression;
 use flate2::read::ZlibDecoder;
@@ -48,8 +47,6 @@ pub struct Project<F> {
     pub data: World,
     /// Comments
     pub comments: HashMap<(String, u64), String>,
-    /// Symbolic References (Imports)
-    pub imports: HashMap<u64, String>,
 }
 
 impl<'de, F: Fun + Deserialize<'de> + Serialize> Project<F> {
@@ -106,14 +103,13 @@ impl<F> Project<F> {
             code: Vec::new(),
             data: World::new(r),
             comments: HashMap::new(),
-            imports: HashMap::new(),
         }
     }
 
     /// Returns this project's root Region
     pub fn region(&self) -> &Region {
         // this cannot fail because World::new guarantees that data.root = r
-        self.data.dependencies.vertex_label(self.data.root).unwrap()
+        self.data.dependencies.node_weight(self.data.root).unwrap()
     }
 }
 


### PR DESCRIPTION
@flanfly Only thing that remains of graph_algos is in `abstract_interp`

Seems you're working on data-flow esque stuff, so perhaps I'll leave that to you, especially if you add a new impl for neo (it's also apparently only used in QT currently)?

If that's alright, I won't mess with abstract_interp so we don't step on each others toes; if you're working on something else, let me know.

Also I'll rebase this branch off of bincode as though its master, in case this keeps going, so no need to delete (until it gets merged into master, that is) ;)

Anyway:

1. Totally removes graph_algos from core!
2. Also removes longstanding pointless imports field from project
3. re-adds `to_dot` impls using petgraphs version

Also, hilariously, adding this patch to disassembler (which I assumed was safe and would be a quick allocation-less gain in disassembler) causes the benchmarks to spiral out of control and use all memory on my system :sob: 

```diff
diff --git a/amd64/src/architecture.rs b/amd64/src/architecture.rs
index 2d056e6..19e7e65 100644
--- a/amd64/src/architecture.rs
+++ b/amd64/src/architecture.rs
@@ -55,14 +55,16 @@ impl Architecture for Amd64 {
     }
 
     fn decode(reg: &Region, start: u64, cfg: &Self::Configuration) -> Result<Match<Self>> {
+        const MAX: usize = 16;
         let data = reg.iter();
-        let mut buf: Vec<u8> = vec![];
+        let mut buf: [u8; MAX] = [0; MAX];
         let mut i = data.seek(start);
         let p = start;
-
+        let mut len = 0;
         while let Some(Some(b)) = i.next() {
-            buf.push(b);
-            if buf.len() == 15 {
+            buf[len] = b;
+            len += 1;
+            if len == MAX {
                 break;
             }
         }
```

Anyway, I think I want to work on the disassembler because:

1. I think there could be some easy perf gains (ostensibly like above, I suspect that's some weird compiler/benchmark bug?)
2. I don't really understand 